### PR TITLE
docs: add spec for store schema validation refactor

### DIFF
--- a/.specify/specs/010-store-schema-validation-architecture-refactor/plan.md
+++ b/.specify/specs/010-store-schema-validation-architecture-refactor/plan.md
@@ -1,0 +1,102 @@
+# Implementation Plan: Store Schema Validation Architecture Refactor
+
+**Branch**: `010-store-schema-validation-architecture-refactor` | **Date**: 2026-03-24 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `.specify/specs/010-store-schema-validation-architecture-refactor/spec.md`
+
+## Summary
+
+Decompose `packages/store/src/schema.ts` into focused internal modules for manifest validation, segment validation, and shared schema helpers while keeping the public `schema.ts` API and current validation behavior unchanged. The existing test suite remains the primary regression contract.
+
+## Technical Context
+
+**Language/Version**: TypeScript strict mode, ESM only, Node >=24
+**Primary Dependencies**: `@wtfoc/common`, `valibot`
+**Storage**: N/A - validation-only refactor inside `@wtfoc/store`
+**Testing**: Vitest via `pnpm --filter @wtfoc/store test`
+**Target Platform**: Node.js library package
+**Project Type**: pnpm monorepo package refactor
+**Performance Goals**: No meaningful regression in validation runtime
+**Constraints**: No public API change, no schema version change, no new common-package seam, preserve typed error behavior
+**Scale/Scope**: `packages/store/src/schema.ts` and related store schema tests only
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Credible Exit at Every Seam | PASS | No new seams added; this is internal store structure only |
+| II. Standalone Packages | PASS | `@wtfoc/store` remains standalone and owns its validators |
+| III. Backend-Neutral Identity | PASS | No storage identity behavior changes |
+| IV. Immutable Data, Mutable Index | PASS | Manifest and segment compatibility preserved |
+| V. Edges Are First-Class | N/A | No edge behavior changes |
+| VI. Test-First | PASS | Existing schema tests are the regression contract |
+| VII. Bundle Uploads | N/A | No bundling changes |
+| VIII. Hackathon-First, Future-Aware | PASS | Cleaner internal structure lowers future schema risk |
+
+**No violations. Gate passed.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+.specify/specs/010-store-schema-validation-architecture-refactor/
+├── spec.md
+├── research.md
+├── plan.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+packages/store/src/
+├── schema.ts
+├── schema.test.ts
+└── schema/
+    ├── manifest.ts
+    ├── segment.ts
+    └── shared.ts
+```
+
+**Structure Decision**: Keep `packages/store/src/schema.ts` as the stable public facade and move internal validator ownership into domain-focused sibling modules under `packages/store/src/schema/`.
+
+## Phase 0: Research (COMPLETED)
+
+See [research.md](research.md).
+
+Resolved decisions:
+
+1. Keep the public schema entry point stable
+2. Split by validator domain plus shared helpers
+3. Preserve current error shaping as the behavioral contract
+4. Keep semantic rules adjacent to each validator domain
+5. Use existing tests as the primary safety net
+
+## Phase 1: Design & Contracts
+
+No new public contracts or persisted data models are introduced.
+
+Design constraints for implementation:
+
+- `schema.ts` must remain the import surface for callers
+- manifest logic owns manifest-only semantic rules
+- segment logic owns segment-only semantic rules
+- shared helpers own only generic reusable concerns
+- tests should continue asserting externally visible behavior rather than internal module structure
+
+## Post-Design Constitution Re-check
+
+All gates still pass:
+
+- No interface widening in `@wtfoc/common`
+- No manifest or segment schema version change
+- No behavior-first implementation drift
+- Package boundaries remain intact
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | N/A | The refactor fits inside existing package and seam boundaries |

--- a/.specify/specs/010-store-schema-validation-architecture-refactor/research.md
+++ b/.specify/specs/010-store-schema-validation-architecture-refactor/research.md
@@ -1,0 +1,39 @@
+# Research: Store Schema Validation Architecture Refactor
+
+## Decision 1: Keep the public schema entry point stable
+
+- **Decision**: Preserve `packages/store/src/schema.ts` as the public entry point and make it a thin compatibility/export layer.
+- **Rationale**: Existing tests and downstream imports already depend on this module path. The refactor is intended to be structural only.
+- **Alternatives considered**:
+  - Move callers to new public modules: rejected because it creates a public API migration for an internal cleanup.
+  - Keep the monolith and only reorder functions: rejected because it does not meaningfully reduce coupling.
+
+## Decision 2: Split by domain, not by helper type alone
+
+- **Decision**: Extract manifest-focused validation and segment-focused validation into separate internal modules, with a small shared helper module.
+- **Rationale**: Manifest and segment validation are the two dominant reasons the file changes. Shared helper extraction alone would still leave a large mixed-responsibility file.
+- **Alternatives considered**:
+  - Split purely into `guards.ts`, `schemas.ts`, and `validators.ts`: rejected because manifest and segment logic would still stay entangled.
+  - Introduce validator classes/interfaces: rejected because there is only one implementation and no new seam is needed.
+
+## Decision 3: Preserve current error shaping as the contract
+
+- **Decision**: Treat current `SCHEMA_INVALID` and `SchemaUnknownError` behavior as part of the contract for this refactor.
+- **Rationale**: Validation errors are consumed programmatically by code using stable `code` fields, and tests already lock in important message/context details.
+- **Alternatives considered**:
+  - Normalize all errors through raw valibot output: rejected because it would change current user-facing and test-visible behavior.
+  - Change message wording while keeping codes stable: rejected because the purpose of this refactor is structural, not behavioral.
+
+## Decision 4: Keep semantic validation adjacent to each domain
+
+- **Decision**: Keep manifest-specific semantic rules in the manifest module and segment-specific semantic rules in the segment module, while centralizing only generic helpers.
+- **Rationale**: Rules like batch-to-segment cross-reference checks and embedding dimension checks belong with their owning validator domain.
+- **Alternatives considered**:
+  - Central semantic-validation module: rejected because it would reintroduce a mixed-responsibility hub.
+
+## Decision 5: Use existing tests as the main safety net
+
+- **Decision**: Preserve and run the current schema tests, adding only small targeted tests if extraction produces a useful new behavior boundary.
+- **Rationale**: The existing suite already encodes the required acceptance/rejection behavior; duplicating it at many layers would overfit the implementation.
+- **Alternatives considered**:
+  - Rewrite tests around internal helpers: rejected because the repo prefers behavior tests over implementation-detail tests.

--- a/.specify/specs/010-store-schema-validation-architecture-refactor/spec.md
+++ b/.specify/specs/010-store-schema-validation-architecture-refactor/spec.md
@@ -1,0 +1,133 @@
+# Feature Specification: Store Schema Validation Architecture Refactor
+
+**Feature Branch**: `010-store-schema-validation-architecture-refactor`
+**Created**: 2026-03-24
+**Status**: Draft
+**Input**: User description: "Look at the largest files in the wtfoc repo and identify which ones could use a re-architecture or split. We already have issue 81 for the large cli.ts, but there are some others that could probably be cleaned up and utilize more SOLID patterns."
+
+## Clarifications
+
+### Session 2026-03-24
+
+- Q: Should this refactor change manifest or segment schema shape, validation semantics, or error messages? → A: No. This is a structure-only refactor. Public validation behavior remains the contract.
+- Q: Should manifest and segment validation stay reachable from the current `packages/store/src/schema.ts` entry point? → A: Yes. Keep the current public module surface stable and let it delegate to smaller internal modules.
+- Q: Should new seams/interfaces be introduced for validators? → A: No. This is an internal decomposition inside `@wtfoc/store`, not a new public seam in `@wtfoc/common`.
+
+## Overview
+
+`packages/store/src/schema.ts` is currently the largest non-CLI source file in the repository and combines multiple responsibilities:
+
+- primitive guard helpers
+- schema-version gating
+- manifest sub-schema definitions
+- manifest semantic validation
+- segment sub-schema definitions
+- segment semantic validation
+- hand-authored error shaping
+
+This refactor decomposes the file into smaller internal modules while preserving the current public behavior, exported API, schema-version rules, and validation errors. The goal is to make schema evolution safer and testing more targeted without changing persisted data contracts.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Manifest validation remains behaviorally stable after decomposition (Priority: P1)
+
+As a maintainer, I can refactor manifest validation internals into focused modules without changing what valid and invalid manifests do today.
+
+**Why this priority**: Manifest validation is part of the persistence boundary. Regressions here would risk collection readability and schema compatibility.
+
+**Independent Test**: Run the existing manifest validation test suite and add targeted tests that validate the extracted manifest module boundaries where useful.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid manifest input, **When** `validateManifestSchema()` is called after the refactor, **Then** it returns the same typed manifest shape as before.
+2. **Given** an invalid manifest input, **When** `validateManifestSchema()` rejects it after the refactor, **Then** it still throws the same typed error code and materially equivalent message/field context as before.
+3. **Given** a mixed-history manifest with optional batch records, **When** it is validated after the refactor, **Then** compatibility behavior remains unchanged.
+
+---
+
+### User Story 2 - Segment validation remains behaviorally stable after decomposition (Priority: P1)
+
+As a maintainer, I can refactor segment validation internals independently from manifest validation without changing segment acceptance or rejection behavior.
+
+**Why this priority**: Segment validation is the immutable artifact boundary. Any change here risks breaking stored segment readability.
+
+**Independent Test**: Run the existing segment validation test suite and add focused tests around extracted segment validation helpers if needed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid segment input, **When** `validateSegmentSchema()` is called after the refactor, **Then** it returns the same typed segment shape as before.
+2. **Given** a segment with invalid chunk or edge fields, **When** validation runs after the refactor, **Then** the same error code and equivalent field targeting are preserved.
+3. **Given** an unsupported `schemaVersion`, **When** either manifest or segment validation runs, **Then** `SchemaUnknownError` behavior remains unchanged.
+
+---
+
+### User Story 3 - Maintainers can evolve one validator area without touching the whole file (Priority: P2)
+
+As a maintainer, I can change manifest-only or segment-only validation logic in a focused module with less risk of unrelated regressions.
+
+**Why this priority**: This is the actual maintainability payoff from the refactor, but it is lower priority than preserving current behavior.
+
+**Independent Test**: Review the resulting source structure and verify the old monolithic file is reduced to a thin compatibility/export layer plus focused internal modules.
+
+**Acceptance Scenarios**:
+
+1. **Given** a future manifest-only change, **When** a maintainer edits the validator internals, **Then** the change can be made in manifest-focused modules without editing segment validation code.
+2. **Given** a future segment-only change, **When** a maintainer edits the validator internals, **Then** the change can be made in segment-focused modules without editing manifest validation code.
+
+---
+
+### Edge Cases
+
+- Inputs that are not objects at the root level
+- `schemaVersion` missing, non-integer, below 1, or above max supported
+- Optional manifest fields (`batches`, `timeRange`, `repoIds`, `sourceUrl`, `timestamp`) present with invalid types
+- Batch records referencing missing segments or duplicating segment IDs
+- Segment embeddings with mismatched dimensions
+- Existing callers importing from `packages/store/src/schema.ts`
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The refactor MUST preserve the exported API of `packages/store/src/schema.ts`, including `MAX_SUPPORTED_SCHEMA_VERSION`, `validateManifestSchema`, and `validateSegmentSchema`.
+- **FR-002**: The refactor MUST preserve current manifest and segment validation behavior for valid inputs.
+- **FR-003**: The refactor MUST preserve current typed error behavior for invalid inputs, including `SchemaUnknownError` usage and `SCHEMA_INVALID` error codes.
+- **FR-004**: The refactor MUST separate manifest-focused validation logic from segment-focused validation logic into distinct internal modules.
+- **FR-005**: The refactor MUST centralize shared schema helpers used by both validators rather than duplicating primitive guards or schema error construction logic.
+- **FR-006**: The refactor MUST NOT change manifest schema versions, segment schema versions, or persisted field names.
+- **FR-007**: The refactor MUST NOT introduce new public interfaces or seams in `@wtfoc/common`.
+- **FR-008**: The refactor MUST keep mixed-history manifest compatibility intact, including optional batch records and legacy summary fields already accepted today.
+- **FR-009**: The refactor MUST keep behavioral tests as the primary regression guard and add targeted tests only where module extraction creates a new meaningful behavior boundary.
+
+### Key Entities
+
+- **Schema Compatibility Layer**: The stable public `packages/store/src/schema.ts` module that preserves the current API and delegates to internal validator modules.
+- **Manifest Validator Module**: Internal logic responsible for manifest-specific structural and semantic validation.
+- **Segment Validator Module**: Internal logic responsible for segment-specific structural and semantic validation.
+- **Shared Schema Helpers**: Internal utilities for object narrowing, primitive guards, schema-version gating, and consistent schema error creation.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `packages/store/src/schema.ts` is reduced from a monolithic validator implementation to a thin compatibility/export layer with manifest, segment, and shared helper logic extracted into focused modules.
+- **SC-002**: Existing store schema tests continue to pass without changing the asserted external behavior.
+- **SC-003**: The refactor adds no schema version bumps, no public API changes, and no new seams in `@wtfoc/common`.
+- **SC-004**: A maintainer can identify the owning module for manifest validation, segment validation, and shared schema helpers in under one minute by browsing the source tree.
+
+## Out of Scope
+
+- Changes to manifest or segment field shapes
+- Changes to schema version numbers
+- New validation semantics or relaxed/stricter acceptance rules
+- New public validator interfaces
+- Refactors outside `@wtfoc/store`
+
+## References
+
+- Issue #85: Refactor store schema validation architecture
+- Issue #87: [spec] 010: Store schema validation architecture refactor
+- SPEC.md rule 5: immutable data, mutable index
+- SPEC.md rule 7: format compatibility
+- `packages/store/src/schema.ts`
+- `packages/store/src/schema.test.ts`

--- a/.specify/specs/010-store-schema-validation-architecture-refactor/tasks.md
+++ b/.specify/specs/010-store-schema-validation-architecture-refactor/tasks.md
@@ -1,0 +1,103 @@
+# Tasks: Store Schema Validation Architecture Refactor
+
+**Input**: Design documents from `.specify/specs/010-store-schema-validation-architecture-refactor/`
+**Prerequisites**: plan.md, spec.md, research.md
+
+**Tests**: Run `pnpm --filter @wtfoc/store test` plus targeted build/lint verification for `@wtfoc/store`.
+
+**Organization**: Tasks grouped by user story so behavior preservation and structural cleanup can be verified incrementally.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. US1, US2)
+
+## Phase 1: Setup
+
+**Purpose**: Create the target module layout without changing validation behavior.
+
+- [ ] T001 Create `packages/store/src/schema/` internal module structure and reduce `packages/store/src/schema.ts` to a compatibility/export layer
+
+**Checkpoint**: Public import surface is unchanged and the module structure is ready for extraction.
+
+---
+
+## Phase 2: User Story 1 — Manifest validation remains stable (Priority: P1)
+
+**Goal**: Move manifest-focused logic into a dedicated module without changing manifest validation behavior.
+
+**Independent Test**: Existing manifest tests continue to pass.
+
+- [ ] T002 [US1] Extract manifest-specific schemas, validators, and semantic checks into `packages/store/src/schema/manifest.ts`
+- [ ] T003 [US1] Extract shared manifest-related helper usage into `packages/store/src/schema/shared.ts` where generic reuse is justified
+- [ ] T004 [US1] Run and update `packages/store/src/schema.test.ts` only as needed to preserve the current external contract
+
+**Checkpoint**: Manifest validation is isolated and behaviorally unchanged.
+
+---
+
+## Phase 3: User Story 2 — Segment validation remains stable (Priority: P1)
+
+**Goal**: Move segment-focused logic into a dedicated module without changing segment validation behavior.
+
+**Independent Test**: Existing segment tests continue to pass.
+
+- [ ] T005 [US2] Extract segment-specific schemas, chunk validation, edge validation, and semantic checks into `packages/store/src/schema/segment.ts`
+- [ ] T006 [US2] Reuse shared schema helpers from `packages/store/src/schema/shared.ts` without duplicating primitive guards
+- [ ] T007 [US2] Add or adjust targeted tests only if extraction reveals an uncovered segment behavior edge
+
+**Checkpoint**: Segment validation is isolated and behaviorally unchanged.
+
+---
+
+## Phase 4: User Story 3 — Future changes can stay localized (Priority: P2)
+
+**Goal**: Leave the schema validator in a maintainable structure with clear ownership boundaries.
+
+**Independent Test**: Source tree clearly separates manifest, segment, and shared responsibilities.
+
+- [ ] T008 [US3] Remove dead helper duplication and ensure each module owns only its domain logic
+- [ ] T009 [US3] Verify `packages/store/src/schema.ts` remains a thin facade with no domain-heavy logic
+
+**Checkpoint**: The new structure is navigable and ownership is obvious.
+
+---
+
+## Phase 5: Verification and Polish
+
+- [ ] T010 Run `pnpm lint:fix`
+- [ ] T011 Run `pnpm --filter @wtfoc/store test`
+- [ ] T012 Run `pnpm --filter @wtfoc/store build`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **US1 (Phase 2)**: Depends on Phase 1
+- **US2 (Phase 3)**: Depends on Phase 1, can proceed after the shared helper shape is established
+- **US3 (Phase 4)**: Depends on Phases 2 and 3
+- **Verification (Phase 5)**: Depends on all previous phases
+
+### Parallel Opportunities
+
+- T004 and T007 are partially parallel after the extraction work lands
+- Verification tasks are sequential at the end
+
+## Implementation Strategy
+
+### MVP First
+
+1. Create the new module structure
+2. Extract manifest validation
+3. Extract segment validation
+4. Confirm all existing schema tests still pass
+
+### Incremental Delivery
+
+1. Public facade stays stable
+2. Manifest logic becomes isolated
+3. Segment logic becomes isolated
+4. Final pass removes leftover coupling and verifies package quality gates


### PR DESCRIPTION
## Summary
- add a spec for decomposing `packages/store/src/schema.ts`
- capture the design constraints for a behavior-preserving refactor
- add research, plan, and tasks docs for the implementation phase

## Context
This starts the first queued architecture cleanup identified from the largest non-CLI files in the repo.

Refs #85
Refs #87
