### PR TITLE
fix(e2e): use placeholder-based selector for search input test

### DIFF
--- a/tests/e2e/tests/ui/query-results.spec.ts
+++ b/tests/e2e/tests/ui/query-results.spec.ts
@@ -41,8 +41,8 @@ test.describe("query results", () => {
 	test("search input is visible when collection is selected", async ({ page }) => {
 		await page.goto("/?collection=ui-test");
 
-		// Search container should be present
-		const searchRow = page.locator(".search-row input");
-		await expect(searchRow).toBeVisible({ timeout: 10_000 });
+		// SearchBar is always rendered in Layout — use placeholder for stable selection
+		const searchInput = page.getByPlaceholder("Trace a question");
+		await expect(searchInput).toBeVisible({ timeout: 10_000 });
 	});
 });


### PR DESCRIPTION
## Summary

Fix flaky e2e UI test that fails on main and all PRs. The `.search-row input` CSS selector times out during page hydration.

## Fix

Changed from fragile CSS class selector to Playwright's `getByPlaceholder("Trace a question")` which matches the SearchBar's actual placeholder text and is resilient to layout timing.

## Test plan

- [x] Fixes the failing test: `tests/ui/query-results.spec.ts:41 › search input is visible when collection is selected`
- [x] No other test changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)