### PR TITLE
feat(cli): add wtfoc extract-edges command for incremental LLM extraction

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,6 +2,7 @@
 
 import { Command } from "commander";
 import { registerCollectionsCommand } from "./commands/collections.js";
+import { registerExtractEdgesCommand } from "./commands/extract-edges.js";
 import { registerIngestCommand } from "./commands/ingest.js";
 import { registerInitCommand } from "./commands/init.js";
 import { registerPromoteCommand } from "./commands/promote.js";
@@ -27,6 +28,7 @@ program
 
 registerInitCommand(program);
 registerIngestCommand(program);
+registerExtractEdgesCommand(program);
 registerTraceCommand(program);
 registerQueryCommand(program);
 registerStatusCommand(program);

--- a/packages/cli/src/commands/extract-edges.ts
+++ b/packages/cli/src/commands/extract-edges.ts
@@ -1,0 +1,338 @@
+import type { Chunk, Segment } from "@wtfoc/common";
+import {
+	computeContextHash,
+	type ExtractionStatusData,
+	getContextsToProcess,
+	LlmEdgeExtractor,
+	mergeOverlayEdges,
+	readExtractionStatus,
+	readOverlayEdges,
+	writeExtractionStatus,
+	writeOverlayEdges,
+} from "@wtfoc/ingest";
+import { LocalManifestStore } from "@wtfoc/store";
+import type { Command } from "commander";
+import { type ExtractorCliOpts, resolveExtractorConfig } from "../extractor-config.js";
+import { getFormat, getStore, withExtractorOptions } from "../helpers.js";
+
+function getManifestDir(store: { manifests: unknown }): string {
+	if (store.manifests instanceof LocalManifestStore) {
+		return store.manifests.dir;
+	}
+	const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? ".";
+	return `${homeDir}/.wtfoc/projects`;
+}
+
+/**
+ * Map a segment chunk to the Chunk interface for extractors.
+ * Segment chunks have extra fields (embedding, terms, storageId) that extractors don't need.
+ */
+function segmentChunkToChunk(chunk: Segment["chunks"][number]): Chunk {
+	return {
+		id: chunk.id,
+		content: chunk.content,
+		sourceType: chunk.sourceType,
+		source: chunk.source,
+		sourceUrl: chunk.sourceUrl,
+		timestamp: chunk.timestamp,
+		chunkIndex: "chunkIndex" in chunk ? (chunk as { chunkIndex: number }).chunkIndex : 0,
+		totalChunks: "totalChunks" in chunk ? (chunk as { totalChunks: number }).totalChunks : 1,
+		metadata: chunk.metadata,
+	};
+}
+
+/**
+ * Load segments from storage without building a vector index.
+ * Avoids the memory overhead of storing all embeddings in InMemoryVectorIndex.
+ */
+async function loadSegments(
+	manifest: { segments: Array<{ id: string }> },
+	storage: { download: (id: string, signal?: AbortSignal) => Promise<Uint8Array> },
+	signal?: AbortSignal,
+): Promise<Segment[]> {
+	const segments: Segment[] = [];
+	for (const segRef of manifest.segments) {
+		signal?.throwIfAborted();
+		const data = await storage.download(segRef.id, signal);
+		const text = new TextDecoder().decode(data);
+		segments.push(JSON.parse(text) as Segment);
+	}
+	return segments;
+}
+
+/**
+ * Prune stale overlay edges and status entries.
+ * Returns true if anything was pruned.
+ */
+async function pruneStaleData(
+	overlayEdges: import("@wtfoc/common").Edge[],
+	statusData: ExtractionStatusData,
+	allChunks: Chunk[],
+	contexts: Array<{ contextId: string }>,
+	overlayPath: string,
+	statusPath: string,
+	collectionId: string,
+	existingOverlayCreatedAt: string | undefined,
+	format: string,
+): Promise<import("@wtfoc/common").Edge[]> {
+	const validChunkIds = new Set(allChunks.map((c) => c.id));
+	const prunedEdges = overlayEdges.filter((e) => validChunkIds.has(e.sourceId));
+	const edgesPruned = overlayEdges.length - prunedEdges.length;
+
+	const validContextIds = new Set(contexts.map((c) => c.contextId));
+	let contextsPruned = 0;
+	for (const key of Object.keys(statusData.contexts)) {
+		if (!validContextIds.has(key)) {
+			delete statusData.contexts[key];
+			contextsPruned++;
+		}
+	}
+
+	if (edgesPruned > 0 || contextsPruned > 0) {
+		await writeOverlayEdges(overlayPath, {
+			collectionId,
+			edges: prunedEdges,
+			createdAt: existingOverlayCreatedAt ?? new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		});
+		await writeExtractionStatus(statusPath, statusData);
+		if (format !== "quiet") {
+			if (edgesPruned > 0) console.error(`🧹 Pruned ${edgesPruned} stale overlay edges`);
+			if (contextsPruned > 0) console.error(`🧹 Pruned ${contextsPruned} stale status entries`);
+		}
+	}
+
+	return prunedEdges;
+}
+
+export function registerExtractEdgesCommand(program: Command): void {
+	withExtractorOptions(
+		program
+			.command("extract-edges")
+			.description("Run LLM edge extraction on an existing collection (incremental)")
+			.requiredOption("-c, --collection <name>", "Collection name"),
+	).action(async (opts: { collection: string } & ExtractorCliOpts) => {
+		const store = getStore(program);
+		const format = getFormat(program.opts());
+
+		// Set up abort handling early so even loading can be cancelled
+		const abortController = new AbortController();
+		const { signal } = abortController;
+		process.on("SIGINT", () => abortController.abort(new Error("Interrupted")));
+		process.on("SIGTERM", () => abortController.abort(new Error("Terminated")));
+
+		// Resolve extractor config (fail fast)
+		const config = resolveExtractorConfig({ ...opts, extractorEnabled: true });
+		if (!config.enabled) {
+			// Unreachable with extractorEnabled: true, but satisfies type narrowing
+			process.exit(2);
+		}
+
+		// Load collection
+		const head = await store.manifests.getHead(opts.collection);
+		if (!head) {
+			console.error(`Collection "${opts.collection}" not found.`);
+			process.exit(1);
+		}
+
+		if (format !== "quiet") {
+			console.error(`⏳ Loading collection "${opts.collection}"...`);
+		}
+
+		// Load segments directly — no vector index needed, saves memory
+		const segments = await loadSegments(head.manifest, store.storage, signal);
+
+		// Map to Chunk interface
+		const allChunks: Chunk[] = segments.flatMap((seg) => seg.chunks.map(segmentChunkToChunk));
+
+		if (format !== "quiet") {
+			console.error(`📦 ${allChunks.length} chunks in ${segments.length} segments`);
+		}
+
+		// Build extraction contexts grouped by source
+		const contextMap = new Map<string, Chunk[]>();
+		for (const chunk of allChunks) {
+			signal.throwIfAborted();
+			const key = chunk.source || chunk.id;
+			const group = contextMap.get(key);
+			if (group) {
+				group.push(chunk);
+			} else {
+				contextMap.set(key, [chunk]);
+			}
+		}
+
+		const contexts: Array<{
+			contextId: string;
+			contextHash: string;
+			chunkIds: string[];
+			chunks: Chunk[];
+		}> = [];
+		for (const [contextId, chunks] of contextMap) {
+			signal.throwIfAborted();
+			const contextHash = await computeContextHash(chunks);
+			contexts.push({
+				contextId,
+				contextHash,
+				chunkIds: chunks.map((c) => c.id),
+				chunks,
+			});
+		}
+
+		// Build O(1) lookup for context chunks
+		const chunksByContextId = new Map<string, Chunk[]>();
+		for (const ctx of contexts) {
+			chunksByContextId.set(ctx.contextId, ctx.chunks);
+		}
+
+		// Derive paths from store's manifest directory
+		const manifestDir = getManifestDir(store);
+		const statusPath = `${manifestDir}/${opts.collection}.extraction-status.json`;
+		const overlayPath = `${manifestDir}/${opts.collection}.edges-overlay.json`;
+
+		const existingStatus = await readExtractionStatus(statusPath);
+		const existingOverlay = await readOverlayEdges(overlayPath);
+		const existingOverlayCreatedAt = existingOverlay?.createdAt;
+
+		// Always prune stale data, even if nothing new to extract
+		const statusData: ExtractionStatusData = existingStatus
+			? {
+					...existingStatus,
+					extractorModel: config.model,
+					contexts: { ...existingStatus.contexts },
+				}
+			: { extractorModel: config.model, contexts: {} };
+
+		let overlayEdges = await pruneStaleData(
+			existingOverlay?.edges ?? [],
+			statusData,
+			allChunks,
+			contexts,
+			overlayPath,
+			statusPath,
+			head.manifest.collectionId,
+			existingOverlayCreatedAt,
+			format,
+		);
+
+		const toProcess = getContextsToProcess(existingStatus, contexts, config.model);
+
+		if (toProcess.length === 0) {
+			if (format !== "quiet") {
+				console.error("✅ All contexts already processed. Nothing to do.");
+			}
+			return;
+		}
+
+		if (format !== "quiet") {
+			console.error(
+				`🔍 ${toProcess.length}/${contexts.length} contexts to process (${toProcess.reduce((sum, c) => sum + c.chunkIds.length, 0)} chunks)`,
+			);
+		}
+
+		const extractor = new LlmEdgeExtractor({
+			baseUrl: config.baseUrl,
+			model: config.model,
+			apiKey: config.apiKey,
+			jsonMode: config.jsonMode,
+			timeoutMs: config.timeoutMs,
+			maxConcurrency: config.maxConcurrency,
+			maxInputTokens: config.maxInputTokens,
+		});
+
+		let totalNewEdges = 0;
+		let processed = 0;
+
+		for (const ctx of toProcess) {
+			// Clean abort: stop processing, don't mark remaining as failed
+			if (signal.aborted) {
+				if (format !== "quiet") {
+					console.error(`\n⚠️  Cancelled. ${processed} contexts processed before abort.`);
+				}
+				break;
+			}
+
+			const chunksForContext = chunksByContextId.get(ctx.contextId);
+			if (!chunksForContext || chunksForContext.length === 0) continue;
+
+			processed++;
+			if (format !== "quiet") {
+				console.error(
+					`  [${processed}/${toProcess.length}] Extracting: ${ctx.contextId} (${chunksForContext.length} chunks)...`,
+				);
+			}
+
+			try {
+				const edges = await extractor.extract(chunksForContext, signal);
+
+				overlayEdges = mergeOverlayEdges(overlayEdges, edges);
+				totalNewEdges += edges.length;
+
+				statusData.contexts[ctx.contextId] = {
+					contextId: ctx.contextId,
+					contextHash: ctx.contextHash,
+					chunkIds: ctx.chunkIds,
+					status: "completed",
+					edgeCount: edges.length,
+					timestamp: new Date().toISOString(),
+				};
+			} catch (err) {
+				// On abort, break cleanly without marking as failed
+				if (signal.aborted) {
+					if (format !== "quiet") {
+						console.error(`\n⚠️  Cancelled during extraction of ${ctx.contextId}.`);
+					}
+					break;
+				}
+
+				statusData.contexts[ctx.contextId] = {
+					contextId: ctx.contextId,
+					contextHash: ctx.contextHash,
+					chunkIds: ctx.chunkIds,
+					status: "failed",
+					error: err instanceof Error ? err.message : String(err),
+					timestamp: new Date().toISOString(),
+				};
+			}
+
+			// Write both after each context for crash safety
+			await writeExtractionStatus(statusPath, statusData);
+			await writeOverlayEdges(overlayPath, {
+				collectionId: head.manifest.collectionId,
+				edges: overlayEdges,
+				createdAt: existingOverlayCreatedAt ?? new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			});
+		}
+
+		// Summary
+		const failed = Object.values(statusData.contexts).filter((c) => c.status === "failed").length;
+		const completed = Object.values(statusData.contexts).filter(
+			(c) => c.status === "completed",
+		).length;
+
+		if (format !== "quiet") {
+			console.error(`\n✅ Done. ${totalNewEdges} new edges extracted.`);
+			console.error(
+				`   Contexts: ${completed} completed, ${failed} failed, ${contexts.length} total`,
+			);
+			console.error(`   Overlay: ${overlayEdges.length} total edges in ${overlayPath}`);
+		}
+
+		if (format === "json") {
+			console.log(
+				JSON.stringify({
+					collection: opts.collection,
+					newEdges: totalNewEdges,
+					totalOverlayEdges: overlayEdges.length,
+					contextsProcessed: processed,
+					contextsFailed: failed,
+					contextsTotal: contexts.length,
+				}),
+			);
+		}
+
+		// Exit with non-zero if cancelled
+		if (signal.aborted) process.exit(130);
+	});
+}

--- a/packages/ingest/src/edges/extraction-status.ts
+++ b/packages/ingest/src/edges/extraction-status.ts
@@ -1,5 +1,5 @@
-import { readFile, rename, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 
 export interface ContextStatus {
 	contextId: string;
@@ -42,6 +42,7 @@ export async function writeExtractionStatus(
 	statusPath: string,
 	data: ExtractionStatusData,
 ): Promise<void> {
+	await mkdir(dirname(statusPath), { recursive: true });
 	const tmpPath = `${statusPath}.tmp.${Date.now()}`;
 	await writeFile(tmpPath, JSON.stringify(data, null, 2));
 	await rename(tmpPath, statusPath);

--- a/packages/ingest/src/edges/overlay-store.ts
+++ b/packages/ingest/src/edges/overlay-store.ts
@@ -1,5 +1,5 @@
-import { readFile, rename, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import type { Edge } from "@wtfoc/common";
 import { edgeKey } from "./merge.js";
 
@@ -37,6 +37,7 @@ export async function readOverlayEdges(filePath: string): Promise<OverlayEdgeDat
  * Write overlay edges to disk atomically (temp + rename).
  */
 export async function writeOverlayEdges(filePath: string, data: OverlayEdgeData): Promise<void> {
+	await mkdir(dirname(filePath), { recursive: true });
 	const tmpPath = `${filePath}.tmp.${Date.now()}`;
 	await writeFile(tmpPath, JSON.stringify(data, null, 2));
 	await rename(tmpPath, filePath);

--- a/packages/store/src/manifest/local.ts
+++ b/packages/store/src/manifest/local.ts
@@ -13,7 +13,11 @@ import { validateManifestSchema } from "../schema.js";
  * headId = SHA-256 of the serialized manifest JSON.
  */
 export class LocalManifestStore implements ManifestStore {
-	constructor(private readonly manifestDir: string) {}
+	readonly dir: string;
+
+	constructor(manifestDir: string) {
+		this.dir = manifestDir;
+	}
 
 	async getHead(projectName: string): Promise<StoredHead | null> {
 		let data: string;
@@ -40,7 +44,7 @@ export class LocalManifestStore implements ManifestStore {
 			throw new ManifestConflictError(prevHeadId, currentHeadId);
 		}
 
-		await mkdir(this.manifestDir, { recursive: true });
+		await mkdir(this.dir, { recursive: true });
 		const serialized = JSON.stringify(manifest, null, "\t");
 		await writeFile(this.filePath(projectName), serialized, "utf-8");
 
@@ -50,7 +54,7 @@ export class LocalManifestStore implements ManifestStore {
 
 	async listProjects(): Promise<string[]> {
 		try {
-			const files = await readdir(this.manifestDir);
+			const files = await readdir(this.dir);
 			return files.filter((f) => f.endsWith(".json")).map((f) => f.replace(/\.json$/, ""));
 		} catch {
 			return [];
@@ -58,7 +62,7 @@ export class LocalManifestStore implements ManifestStore {
 	}
 
 	private filePath(projectName: string): string {
-		const base = resolve(this.manifestDir);
+		const base = resolve(this.dir);
 		const resolved = resolve(base, `${projectName}.json`);
 		const rel = relative(base, resolved);
 		if (rel.startsWith("..") || isAbsolute(rel)) {


### PR DESCRIPTION
## Summary

New `wtfoc extract-edges` CLI command that runs LLM edge extraction on an existing collection incrementally. Safe to re-run after failures — picks up where it left off.

## Robustness (Cursor review feedback addressed proactively)

- **Crash safety**: Both status AND overlay written after each context extraction (worst case: lose 1 context's work, re-extracted on next run)
- **Path consistency**: Manifest dir derived from store's `LocalManifestStore.dir`, not hardcoded `~/.wtfoc/projects`
- **Stale pruning**: Overlay edges pruned when source chunks are removed from collection. Status entries pruned when contexts disappear.
- **Clean cancellation**: SIGINT/SIGTERM → AbortSignal passed to LlmEdgeExtractor
- **Incremental**: Per-context hash tracking. Changed content → re-extract. Changed model → re-extract all.

## Usage

```bash
wtfoc extract-edges -c my-collection \
  --extractor-url lmstudio \
  --extractor-model "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF/qwen2.5-coder-32b-instruct-q8_0.gguf"
```

## Known limitations (tracked in issues)

- Context grouping by `chunk.source` — may be too coarse or too fine depending on adapter (#141)
- Segment chunks may lack `chunkIndex`/`totalChunks` (defaults to 0/1)
- No schema validation on status/overlay JSON (corrupt files logged as warning, treated as fresh)

## Test plan

- [x] Build passes (TS compilation)
- [x] 498 tests pass
- [x] Lint clean
- [x] Tested end-to-end with LM Studio (Qwen2.5-Coder-32B-Instruct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)