### PR TITLE
fix(config): exclude test files and fixtures from default ingestion

### DIFF
--- a/.specify/specs/120-exclude-test-fixtures/spec.md
+++ b/.specify/specs/120-exclude-test-fixtures/spec.md
@@ -20,13 +20,13 @@ When a user runs `wtfoc ingest repo` on a project containing test files, spec fi
 
 1. **Given** a repo with `*.test.ts`, `*.spec.ts`, `__tests__/`, `__fixtures__/` files, **When** user runs `wtfoc ingest repo .`, **Then** test files and fixtures are excluded from ingestion by default.
 2. **Given** a repo where test files reference fictional repos like `owner/repo`, **When** user runs ingestion followed by `unresolved-edges`, **Then** those fictional references do not appear.
-3. **Given** a user who wants to include test files, **When** they use `.wtfocignore` with negation `!*.test.ts`, **Then** test files are re-included.
+3. **Given** a user who wants to include test files matching `*.test.ts`, **When** they use `.wtfocignore` with negation `!*.test.ts`, **Then** those test files are re-included. Note: files inside ignored directories like `__tests__/` require un-ignoring the directory as well.
 
 ---
 
 ### Edge Cases
 
-- What happens if a non-test file is named `test.ts`? It would be excluded. Users can override via `.wtfocignore` negation.
+- What happens if a non-test file is literally named `test.ts` (for example at the repo root or under `src/`)? It would **not** be excluded by these defaults, since only `test/` directories and `*.test.*` patterns are ignored. Users who want it excluded can add `test.ts` to `.wtfocignore`.
 - What happens if test fixtures contain real, useful documentation? Users can override via `.wtfocignore` negation patterns.
 
 ## Requirements *(mandatory)*

--- a/packages/common/src/config-types.ts
+++ b/packages/common/src/config-types.ts
@@ -63,7 +63,7 @@ export const BUILTIN_IGNORE_PATTERNS: readonly string[] = [
 	"*.min.js",
 	"*.min.css",
 	"*.map",
-	// Test files and fixtures — prevent phantom edges from fictional test data
+	// Common test files and fixtures ignored by default
 	"*.test.*",
 	"*.spec.*",
 	"*.stories.*",

--- a/packages/config/src/ignore.test.ts
+++ b/packages/config/src/ignore.test.ts
@@ -48,6 +48,15 @@ describe("createIgnoreFilter", () => {
 		expect(filter("src/components/Button.tsx")).toBe(true);
 	});
 
+	it("allows negation to override built-in test file exclusions", () => {
+		// Re-include specific test file patterns
+		const filter = createIgnoreFilter(["!*.test.ts"]);
+		expect(filter("src/utils.test.ts")).toBe(true);
+		// Other test patterns still excluded
+		expect(filter("src/utils.spec.ts")).toBe(false);
+		expect(filter("__fixtures__/data.json")).toBe(false);
+	});
+
 	it("merges single pattern source additively with defaults", () => {
 		const filter = createIgnoreFilter(["*.log"]);
 		expect(filter(".git")).toBe(false);


### PR DESCRIPTION
## Summary

- Add test file patterns (`*.test.*`, `*.spec.*`, `*.stories.*`) to `BUILTIN_IGNORE_PATTERNS`
- Add test directory patterns (`__tests__/`, `__fixtures__/`, `__mocks__/`, `test/`, `tests/`, `fixtures/`, `spec/`) to defaults
- Prevents phantom edges from fictional test data (e.g., `owner/repo`, `test/repo`) polluting `unresolved-edges` and `suggest-sources` output

## Test plan

- [x] Test files (`*.test.ts`, `*.spec.ts`, `*.stories.tsx`) excluded by default
- [x] Test directories (`__tests__/`, `__fixtures__/`, `test/`, `tests/`) excluded by default  
- [x] Source files (`src/utils.ts`) still included
- [x] All 581 tests pass, build clean, lint clean
- [x] Users can override via `.wtfocignore` negation patterns

**Depends on**: PR #156 (.wtfocignore support)

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)