### PR TITLE
feat(runtime): wire /mcp endpoint tools into shared collection cache

### DIFF
--- a/apps/web/server/index.ts
+++ b/apps/web/server/index.ts
@@ -470,10 +470,7 @@ async function main() {
 			// but share the collection cache so MCP queries don't re-read from disk.
 			const mcpServer = createMcpServer(store, embedder, embedderModel, {
 				readOnly: true,
-				collectionLoader: async (name) => {
-					const col = await getCollection(name);
-					return col;
-				},
+				collectionLoader: getCollection,
 			});
 			const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
 

--- a/packages/mcp-server/src/helpers.ts
+++ b/packages/mcp-server/src/helpers.ts
@@ -11,12 +11,40 @@ import type { createStore } from "@wtfoc/store";
 
 export type LoadedCollection = MountedCollection;
 
+/**
+ * Resolve a collection by name, returning the mounted vector index and segments.
+ * When provided, MCP tools use this instead of loading from disk each request.
+ */
+export type CollectionLoader = (name: string) => Promise<{
+	vectorIndex: import("@wtfoc/common").VectorIndex;
+	segments: import("@wtfoc/common").Segment[];
+} | null>;
+
 export async function loadCollection(
 	store: ReturnType<typeof createStore>,
 	manifest: CollectionHead,
 ): Promise<LoadedCollection> {
 	const vectorIndex = new InMemoryVectorIndex();
 	return mountCollection(manifest, store.storage, vectorIndex);
+}
+
+/**
+ * Resolve a collection using the injected loader (cache-aware) or fall back
+ * to loading from disk. Shared by query and trace tool handlers.
+ */
+export async function resolveCollection(
+	store: ReturnType<typeof createStore>,
+	collection: string,
+	collectionLoader?: CollectionLoader,
+): Promise<LoadedCollection> {
+	if (collectionLoader) {
+		const loaded = await collectionLoader(collection);
+		if (!loaded) throw new Error(`Collection "${collection}" not found`);
+		return loaded as LoadedCollection;
+	}
+	const head = await store.manifests.getHead(collection);
+	if (!head) throw new Error(`Collection "${collection}" not found`);
+	return loadCollection(store, head.manifest);
 }
 
 /**

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -2,18 +2,12 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Embedder } from "@wtfoc/common";
 import type { createStore } from "@wtfoc/store";
 import { z } from "zod";
+import type { CollectionLoader } from "./helpers.js";
 import { handleQuery } from "./tools/query.js";
 import { handleStatus } from "./tools/status.js";
 import { handleTrace } from "./tools/trace.js";
 
-/**
- * Resolve a collection by name, returning the mounted vector index and segments.
- * When provided, MCP tools use this instead of loading from disk each request.
- */
-export type CollectionLoader = (name: string) => Promise<{
-	vectorIndex: import("@wtfoc/common").VectorIndex;
-	segments: import("@wtfoc/common").Segment[];
-} | null>;
+export type { CollectionLoader } from "./helpers.js";
 
 export interface CreateMcpServerOptions {
 	/** If true, omit write tools like ingest. Defaults to false. */

--- a/packages/mcp-server/src/tools/query.ts
+++ b/packages/mcp-server/src/tools/query.ts
@@ -1,23 +1,8 @@
 import type { Embedder } from "@wtfoc/common";
 import { query } from "@wtfoc/search";
 import type { createStore } from "@wtfoc/store";
-import { loadCollection } from "../helpers.js";
-import type { CollectionLoader } from "../server.js";
-
-async function resolveCollection(
-	store: ReturnType<typeof createStore>,
-	collection: string,
-	collectionLoader?: CollectionLoader,
-) {
-	if (collectionLoader) {
-		const loaded = await collectionLoader(collection);
-		if (!loaded) throw new Error(`Collection "${collection}" not found`);
-		return loaded;
-	}
-	const head = await store.manifests.getHead(collection);
-	if (!head) throw new Error(`Collection "${collection}" not found`);
-	return loadCollection(store, head.manifest);
-}
+import type { CollectionLoader } from "../helpers.js";
+import { resolveCollection } from "../helpers.js";
 
 export async function handleQuery(
 	store: ReturnType<typeof createStore>,

--- a/packages/mcp-server/src/tools/trace.ts
+++ b/packages/mcp-server/src/tools/trace.ts
@@ -1,23 +1,8 @@
 import type { Embedder } from "@wtfoc/common";
 import { type TraceMode, trace } from "@wtfoc/search";
 import type { createStore } from "@wtfoc/store";
-import { loadCollection } from "../helpers.js";
-import type { CollectionLoader } from "../server.js";
-
-async function resolveCollection(
-	store: ReturnType<typeof createStore>,
-	collection: string,
-	collectionLoader?: CollectionLoader,
-) {
-	if (collectionLoader) {
-		const loaded = await collectionLoader(collection);
-		if (!loaded) throw new Error(`Collection "${collection}" not found`);
-		return loaded;
-	}
-	const head = await store.manifests.getHead(collection);
-	if (!head) throw new Error(`Collection "${collection}" not found`);
-	return loadCollection(store, head.manifest);
-}
+import type { CollectionLoader } from "../helpers.js";
+import { resolveCollection } from "../helpers.js";
 
 export async function handleTrace(
 	store: ReturnType<typeof createStore>,


### PR DESCRIPTION
## Summary

Closes #114

- MCP query/trace tools now reuse the web server's `collectionCache` instead of re-reading all segment blobs from disk on every request
- Added optional `collectionLoader` callback to `CreateMcpServerOptions` — when the web server passes its cached `getCollection()`, MCP queries get the same freshness-checking, dedup, and warm-cache benefits as REST API calls
- Stdio MCP server behavior is unchanged (no cache, loads from disk as before)

### What changed

| File | Change |
|------|--------|
| `packages/mcp-server/src/server.ts` | New `CollectionLoader` type + `collectionLoader` option |
| `packages/mcp-server/src/tools/query.ts` | Uses loader when available, falls back to `loadCollection()` |
| `packages/mcp-server/src/tools/trace.ts` | Same pattern as query |
| `apps/web/server/index.ts` | Injects `getCollection` as the loader when creating MCP servers |

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm test` — 614 tests pass
- [x] `pnpm lint:fix` — clean
- [ ] Manual: query via `/mcp` endpoint, verify collection loads once (check server logs for absence of repeated "Loading collection" messages)
- [ ] Manual: verify `/api/collections/:name/query` and `/mcp` query return same results for identical queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)