### PR TITLE
fix(web): hydrate missing segments from IPFS on collection load

### DIFF
--- a/apps/web/server/index.ts
+++ b/apps/web/server/index.ts
@@ -10,6 +10,7 @@ import type {
 	StorageBackend,
 	VectorIndex,
 } from "@wtfoc/common";
+import { StorageNotFoundError } from "@wtfoc/common";
 import { createMcpServer } from "@wtfoc/mcp-server/server";
 import {
 	analyzeEdgeResolution,
@@ -178,6 +179,9 @@ function createHydratingStorage(
 			try {
 				return await local.download(id, signal);
 			} catch (err) {
+				// Only fall back to IPFS for missing segments, not IO/permission errors
+				if (!(err instanceof StorageNotFoundError)) throw err;
+
 				const ipfsCid = cidBySegmentId.get(id);
 				if (!ipfsCid) throw err; // no CID fallback available — rethrow
 
@@ -186,9 +190,16 @@ function createHydratingStorage(
 				if (!ipfsReader) ipfsReader = new CidReadableStorage();
 				const data = await ipfsReader.download(ipfsCid, signal);
 
-				// Persist locally so future loads don't need IPFS
+				// Persist locally so future loads don't need IPFS.
+				// LocalStorageBackend uses content SHA-256 as the ID, which must
+				// match the segment ID in the manifest (both are SHA-256 of the blob).
 				try {
-					await local.upload(data, undefined, signal);
+					const result = await local.upload(data, undefined, signal);
+					if (result.id !== id) {
+						console.error(
+							`⚠️  Hydrated segment hash mismatch: expected ${id.slice(0, 12)}…, got ${result.id.slice(0, 12)}… — content may have changed on IPFS`,
+						);
+					}
 				} catch (persistErr) {
 					console.error(`⚠️  Failed to persist segment locally: ${persistErr instanceof Error ? persistErr.message : persistErr}`);
 				}


### PR DESCRIPTION
## Summary
- When loading a name-based collection, missing segment blobs now fall back to IPFS instead of throwing `StorageNotFoundError`
- Creates a `HydratingStorage` wrapper that tries local disk first, then fetches from IPFS via `CidReadableStorage` if the segment has an `ipfsCid` in the manifest
- Downloaded segments are persisted locally so future loads don't need IPFS
- Transparent to `mountCollection` — no changes to the search/mount layer

Fixes #94

## Context
The `wtfoc-source-nomic-embed-text` collection on wtfoc.xyz had its manifest persisted (#166) but all 11 segment blobs were missing from disk — likely due to IPFS gateway timeout during the initial CID persistence step. Every query returned "Internal error".

This is also groundwork for #167 (async CID ingestion) and #168 (job orchestration) — once those exist, hydration can become a retryable background job.

## Test plan
- [x] `pnpm lint:fix` — clean
- [x] `pnpm test` — 641 tests pass
- [x] `pnpm build` — all packages + web app build
- [ ] Deploy to wtfoc.xyz and verify `wtfoc-source-nomic-embed-text` loads and serves queries
- [x] Verify hydration logs: `📥 Hydrating segment ...` appears for each missing segment
- [x] Verify subsequent loads use local cache (no hydration messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)