### PR TITLE
fix(cli): use helper functions for extraction file paths

### DIFF
--- a/packages/cli/src/commands/extract-edges.ts
+++ b/packages/cli/src/commands/extract-edges.ts
@@ -5,8 +5,10 @@ import {
 	getContextsToProcess,
 	LlmEdgeExtractor,
 	mergeOverlayEdges,
+	overlayFilePath,
 	readExtractionStatus,
 	readOverlayEdges,
+	statusFilePath,
 	writeExtractionStatus,
 	writeOverlayEdges,
 } from "@wtfoc/ingest";
@@ -184,8 +186,8 @@ export function registerExtractEdgesCommand(program: Command): void {
 
 		// Derive paths from store's manifest directory
 		const manifestDir = getManifestDir(store);
-		const statusPath = `${manifestDir}/${opts.collection}.extraction-status.json`;
-		const overlayPath = `${manifestDir}/${opts.collection}.edges-overlay.json`;
+		const statusPath = statusFilePath(manifestDir, opts.collection);
+		const overlayPath = overlayFilePath(manifestDir, opts.collection);
 
 		const existingStatus = await readExtractionStatus(statusPath);
 		const existingOverlay = await readOverlayEdges(overlayPath);


### PR DESCRIPTION
## Summary
- Replace string interpolation with `statusFilePath()` and `overlayFilePath()` helpers in `extract-edges.ts`
- Ensures path construction stays consistent with the rest of the codebase that already uses these helpers

Fixes #148

## Test plan
- [x] `pnpm lint:fix` passes
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)