### PR TITLE
feat: derived layer compaction + temporal-semantic edges + AST-heuristic chunking

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,6 +5,7 @@ import { ConfigParseError, ConfigValidationError } from "@wtfoc/common";
 import { loadProjectConfig, resolveConfig } from "@wtfoc/config";
 import { Command } from "commander";
 import { registerCollectionsCommand } from "./commands/collections.js";
+import { registerCompactEdgesCommand } from "./commands/compact-edges.js";
 import { registerDescribeCommand } from "./commands/describe.js";
 import { registerExtractEdgesCommand } from "./commands/extract-edges.js";
 import { registerIngestCommand } from "./commands/ingest.js";
@@ -62,6 +63,7 @@ program
 
 registerInitCommand(program);
 registerIngestCommand(program);
+registerCompactEdgesCommand(program);
 registerExtractEdgesCommand(program);
 registerMaterializeEdgesCommand(program);
 registerTraceCommand(program);

--- a/packages/cli/src/commands/compact-edges.ts
+++ b/packages/cli/src/commands/compact-edges.ts
@@ -1,5 +1,5 @@
 import type { CollectionHead, DerivedEdgeLayerSummary, Segment } from "@wtfoc/common";
-import { compactDerivedLayers, parseDerivedEdgeLayer } from "@wtfoc/ingest";
+import { compactDerivedLayers, type DerivedEdgeLayer, parseDerivedEdgeLayer } from "@wtfoc/ingest";
 import type { Command } from "commander";
 import { getFormat, getStore } from "../helpers.js";
 
@@ -22,15 +22,22 @@ export function registerCompactEdgesCommand(program: Command): void {
 			}
 
 			const layers = head.manifest.derivedEdgeLayers ?? [];
+
+			// No-op: no layers
 			if (layers.length === 0) {
-				if (format !== "quiet") {
+				if (format === "json") {
+					console.log(JSON.stringify({ noop: true, reason: "no-layers", inputLayers: 0 }));
+				} else if (format !== "quiet") {
 					console.error("No derived edge layers to compact.");
 				}
 				return;
 			}
 
+			// No-op: only 1 layer (nothing to merge)
 			if (layers.length === 1 && !opts.dryRun) {
-				if (format !== "quiet") {
+				if (format === "json") {
+					console.log(JSON.stringify({ noop: true, reason: "single-layer", inputLayers: 1 }));
+				} else if (format !== "quiet") {
 					console.error("Only 1 layer — nothing to compact.");
 				}
 				return;
@@ -40,8 +47,8 @@ export function registerCompactEdgesCommand(program: Command): void {
 				console.error(`⏳ Loading ${layers.length} derived edge layers...`);
 			}
 
-			// Load all layers
-			const loadedLayers = [];
+			// Load all layers (typed)
+			const loadedLayers: DerivedEdgeLayer[] = [];
 			for (const ref of layers) {
 				const data = await store.storage.download(ref.id);
 				loadedLayers.push(parseDerivedEdgeLayer(data));
@@ -52,6 +59,7 @@ export function registerCompactEdgesCommand(program: Command): void {
 				console.error("⏳ Loading segments to validate chunk references...");
 			}
 			const validChunkIds = new Set<string>();
+			let segmentFailures = 0;
 			for (const segSummary of head.manifest.segments) {
 				try {
 					const segBytes = await store.storage.download(segSummary.id);
@@ -60,30 +68,49 @@ export function registerCompactEdgesCommand(program: Command): void {
 						validChunkIds.add(c.id);
 					}
 				} catch {
-					// Skip undownloadable segments
+					segmentFailures++;
 				}
 			}
+
+			// If any segments failed to load, disable orphan-dropping to prevent data loss
+			const safeToDropOrphans = segmentFailures === 0;
+			if (!safeToDropOrphans && format !== "quiet") {
+				console.error(
+					`   ⚠️  ${segmentFailures} segment(s) failed to load — orphan detection disabled to prevent data loss`,
+				);
+			}
+
+			// When segments are incomplete, pass all edge sourceIds as valid
+			const effectiveValidIds = safeToDropOrphans
+				? validChunkIds
+				: new Set([
+						...validChunkIds,
+						...loadedLayers.flatMap((l) => l.edges.map((e) => e.sourceId)),
+					]);
 
 			// Compact
 			const { layer: compacted, stats } = compactDerivedLayers(
 				loadedLayers,
-				validChunkIds,
+				effectiveValidIds,
 				head.manifest.collectionId,
 			);
 
 			if (format !== "quiet") {
-				console.error(`\n📊 Compaction results:`);
+				console.error("\n📊 Compaction results:");
 				console.error(`   Input: ${stats.inputLayers} layers, ${stats.inputEdges} edges`);
 				console.error(`   Output: 1 layer, ${stats.outputEdges} edges`);
 				console.error(
 					`   Dropped: ${stats.droppedOrphan} orphan, ${stats.droppedDuplicate} duplicate`,
 				);
+				if (segmentFailures > 0) {
+					console.error(`   ⚠️  ${segmentFailures} segments could not be loaded`);
+				}
 			}
 
 			if (opts.dryRun) {
 				console.error("   --dry-run: no changes written");
 				if (format === "json") {
-					console.log(JSON.stringify(stats));
+					console.log(JSON.stringify({ ...stats, segmentFailures }));
 				}
 				return;
 			}
@@ -120,6 +147,7 @@ export function registerCompactEdgesCommand(program: Command): void {
 					JSON.stringify({
 						collection: opts.collection,
 						...stats,
+						segmentFailures,
 						compactedLayerId: result.id,
 					}),
 				);

--- a/packages/cli/src/commands/compact-edges.ts
+++ b/packages/cli/src/commands/compact-edges.ts
@@ -1,0 +1,128 @@
+import type { CollectionHead, DerivedEdgeLayerSummary, Segment } from "@wtfoc/common";
+import { compactDerivedLayers, parseDerivedEdgeLayer } from "@wtfoc/ingest";
+import type { Command } from "commander";
+import { getFormat, getStore } from "../helpers.js";
+
+export function registerCompactEdgesCommand(program: Command): void {
+	program
+		.command("compact-edges")
+		.description(
+			"Compact derived edge layers into a single canonical layer, deduplicating and dropping stale edges",
+		)
+		.requiredOption("-c, --collection <name>", "Collection name")
+		.option("--dry-run", "Show what would change without writing")
+		.action(async (opts: { collection: string; dryRun?: boolean }) => {
+			const store = getStore(program);
+			const format = getFormat(program.opts());
+
+			const head = await store.manifests.getHead(opts.collection);
+			if (!head) {
+				console.error(`Error: collection "${opts.collection}" not found`);
+				process.exit(1);
+			}
+
+			const layers = head.manifest.derivedEdgeLayers ?? [];
+			if (layers.length === 0) {
+				if (format !== "quiet") {
+					console.error("No derived edge layers to compact.");
+				}
+				return;
+			}
+
+			if (layers.length === 1 && !opts.dryRun) {
+				if (format !== "quiet") {
+					console.error("Only 1 layer — nothing to compact.");
+				}
+				return;
+			}
+
+			if (format !== "quiet") {
+				console.error(`⏳ Loading ${layers.length} derived edge layers...`);
+			}
+
+			// Load all layers
+			const loadedLayers = [];
+			for (const ref of layers) {
+				const data = await store.storage.download(ref.id);
+				loadedLayers.push(parseDerivedEdgeLayer(data));
+			}
+
+			// Build valid chunk ID set from segments
+			if (format !== "quiet") {
+				console.error("⏳ Loading segments to validate chunk references...");
+			}
+			const validChunkIds = new Set<string>();
+			for (const segSummary of head.manifest.segments) {
+				try {
+					const segBytes = await store.storage.download(segSummary.id);
+					const seg = JSON.parse(new TextDecoder().decode(segBytes)) as Segment;
+					for (const c of seg.chunks) {
+						validChunkIds.add(c.id);
+					}
+				} catch {
+					// Skip undownloadable segments
+				}
+			}
+
+			// Compact
+			const { layer: compacted, stats } = compactDerivedLayers(
+				loadedLayers,
+				validChunkIds,
+				head.manifest.collectionId,
+			);
+
+			if (format !== "quiet") {
+				console.error(`\n📊 Compaction results:`);
+				console.error(`   Input: ${stats.inputLayers} layers, ${stats.inputEdges} edges`);
+				console.error(`   Output: 1 layer, ${stats.outputEdges} edges`);
+				console.error(
+					`   Dropped: ${stats.droppedOrphan} orphan, ${stats.droppedDuplicate} duplicate`,
+				);
+			}
+
+			if (opts.dryRun) {
+				console.error("   --dry-run: no changes written");
+				if (format === "json") {
+					console.log(JSON.stringify(stats));
+				}
+				return;
+			}
+
+			// Store compacted layer
+			const layerBytes = new TextEncoder().encode(JSON.stringify(compacted));
+			const result = await store.storage.upload(layerBytes);
+
+			const layerSummary: DerivedEdgeLayerSummary = {
+				id: result.id,
+				extractorModel: compacted.extractorModel,
+				edgeCount: compacted.edges.length,
+				createdAt: compacted.createdAt,
+				contextsProcessed: compacted.contextsProcessed,
+			};
+
+			// Replace all layers with the single compacted one
+			const currentHead = await store.manifests.getHead(opts.collection);
+			if (currentHead) {
+				const manifest: CollectionHead = {
+					...currentHead.manifest,
+					derivedEdgeLayers: [layerSummary],
+					updatedAt: new Date().toISOString(),
+				};
+				await store.manifests.putHead(opts.collection, manifest, currentHead.headId);
+			}
+
+			if (format !== "quiet") {
+				console.error(`\n✅ Compacted to 1 layer: ${result.id.slice(0, 16)}...`);
+			}
+
+			if (format === "json") {
+				console.log(
+					JSON.stringify({
+						collection: opts.collection,
+						...stats,
+						compactedLayerId: result.id,
+					}),
+				);
+			}
+		});
+}

--- a/packages/cli/src/commands/compact-edges.ts
+++ b/packages/cli/src/commands/compact-edges.ts
@@ -33,15 +33,8 @@ export function registerCompactEdgesCommand(program: Command): void {
 				return;
 			}
 
-			// No-op: only 1 layer (nothing to merge)
-			if (layers.length === 1 && !opts.dryRun) {
-				if (format === "json") {
-					console.log(JSON.stringify({ noop: true, reason: "single-layer", inputLayers: 1 }));
-				} else if (format !== "quiet") {
-					console.error("Only 1 layer — nothing to compact.");
-				}
-				return;
-			}
+			// Even 1 layer benefits from compaction — it prunes orphan edges
+			// whose source chunks were removed by reingest/reindex.
 
 			if (format !== "quiet") {
 				console.error(`⏳ Loading ${layers.length} derived edge layers...`);

--- a/packages/ingest/src/adapters/repo/adapter.ts
+++ b/packages/ingest/src/adapters/repo/adapter.ts
@@ -1,11 +1,12 @@
 import { readFile, stat } from "node:fs/promises";
 import { extname, join, relative } from "node:path";
-import type { Chunk, Edge, SourceAdapter } from "@wtfoc/common";
+import type { Chunk, ChunkerDocument, Edge, SourceAdapter } from "@wtfoc/common";
 import { WtfocError } from "@wtfoc/common";
 import { createIgnoreFilter, loadWtfocIgnore } from "@wtfoc/config";
-import { chunkMarkdown, type MarkdownChunkerOptions, sha256Hex } from "../../chunker.js";
+import { type MarkdownChunkerOptions, sha256Hex } from "../../chunker.js";
+import { selectChunker } from "../../chunkers/index.js";
 import { acquireRepo, extractRepoName } from "./acquisition.js";
-import { chunkCode, DEFAULT_EXCLUDE, DEFAULT_INCLUDE, walkFiles } from "./chunking.js";
+import { DEFAULT_EXCLUDE, DEFAULT_INCLUDE, walkFiles } from "./chunking.js";
 import {
 	type ChangedFile,
 	commitExists,
@@ -192,39 +193,39 @@ export class RepoAdapter implements SourceAdapter<RepoAdapterConfig> {
 			const documentId = `${repo}/${relPath}`;
 			const documentVersionId = sha256Hex(content);
 
-			if (isMarkdown) {
-				const chunks = chunkMarkdown(content, {
-					source: `${repo}/${relPath}`,
-					documentId,
-					documentVersionId,
-					...opts.chunkerOptions,
-				});
-				for (const chunk of chunks) {
-					const yieldChunk: Chunk = {
-						...chunk,
-						sourceType,
-						sourceUrl,
-						metadata: {
-							...chunk.metadata,
-							filePath: relPath,
-							language: "markdown",
-							repo,
-						},
-					};
-					// Carry raw content on first chunk for archive
-					if (chunk.chunkIndex === 0) yieldChunk.rawContent = content;
-					yield yieldChunk;
-				}
-			} else {
-				const chunks = chunkCode(content, relPath, repo, sourceUrl, {
-					documentId,
-					documentVersionId,
-				});
-				for (const chunk of chunks) {
-					// Carry raw content on first chunk for archive
-					if (chunk.chunkIndex === 0) chunk.rawContent = content;
-					yield chunk;
-				}
+			const language = isMarkdown ? "markdown" : extname(filePath).slice(1);
+			const chunker = selectChunker(sourceType, relPath);
+
+			const doc: ChunkerDocument = {
+				documentId,
+				documentVersionId,
+				content,
+				sourceType,
+				source: `${repo}/${relPath}`,
+				sourceUrl,
+				filePath: relPath,
+				metadata: {
+					filePath: relPath,
+					language,
+					repo,
+				},
+			};
+
+			const chunks = chunker.chunk(doc, opts.chunkerOptions);
+			for (const chunk of chunks) {
+				const yieldChunk: Chunk = {
+					...chunk,
+					sourceType,
+					sourceUrl,
+					metadata: {
+						...chunk.metadata,
+						filePath: relPath,
+						language,
+						repo,
+					},
+				};
+				if (chunk.chunkIndex === 0) yieldChunk.rawContent = content;
+				yield yieldChunk;
 			}
 		}
 	}

--- a/packages/ingest/src/chunkers/ast-heuristic-chunker.ts
+++ b/packages/ingest/src/chunkers/ast-heuristic-chunker.ts
@@ -1,0 +1,281 @@
+import type { Chunker, ChunkerDocument, ChunkerOptions, ChunkerOutput } from "@wtfoc/common";
+import { sha256Hex } from "../chunker.js";
+import { CodeWindowChunker } from "./code-chunker.js";
+
+/**
+ * Language-specific patterns for detecting function/class/method boundaries.
+ */
+const BOUNDARY_PATTERNS: Record<string, RegExp[]> = {
+	ts: [
+		/^(?:export\s+)?(?:async\s+)?function\s+\w+/m,
+		/^(?:export\s+)?(?:abstract\s+)?class\s+\w+/m,
+		/^(?:export\s+)?(?:const|let)\s+\w+\s*=\s*(?:async\s+)?\(/m,
+		/^(?:export\s+)?interface\s+\w+/m,
+		/^(?:export\s+)?type\s+\w+/m,
+		/^(?:export\s+)?enum\s+\w+/m,
+		/^\s+(?:async\s+)?(?:get\s+|set\s+)?\w+\s*\([^)]*\)\s*(?::\s*\w+)?\s*\{/m,
+	],
+	js: [
+		/^(?:export\s+)?(?:async\s+)?function\s+\w+/m,
+		/^(?:export\s+)?class\s+\w+/m,
+		/^(?:export\s+)?(?:const|let|var)\s+\w+\s*=\s*(?:async\s+)?\(/m,
+		/^\s+(?:async\s+)?(?:get\s+|set\s+)?\w+\s*\([^)]*\)\s*\{/m,
+	],
+	py: [
+		/^(?:async\s+)?def\s+\w+/m,
+		/^class\s+\w+/m,
+		/^@\w+/m, // decorators often precede function/class defs
+	],
+	go: [/^func\s+(?:\(\w+\s+\*?\w+\)\s+)?\w+/m, /^type\s+\w+\s+(?:struct|interface)/m],
+	rs: [
+		/^(?:pub\s+)?(?:async\s+)?fn\s+\w+/m,
+		/^(?:pub\s+)?struct\s+\w+/m,
+		/^(?:pub\s+)?enum\s+\w+/m,
+		/^(?:pub\s+)?trait\s+\w+/m,
+		/^impl\s+/m,
+	],
+	rb: [/^(?:\s+)?def\s+\w+/m, /^class\s+\w+/m, /^module\s+\w+/m],
+	java: [
+		/^(?:\s+)?(?:public|private|protected)?\s*(?:static\s+)?(?:abstract\s+)?(?:class|interface|enum)\s+\w+/m,
+		/^(?:\s+)?(?:public|private|protected)?\s*(?:static\s+)?(?:synchronized\s+)?(?:\w+(?:<[^>]+>)?)\s+\w+\s*\(/m,
+	],
+};
+
+const EXT_TO_LANG: Record<string, string> = {
+	ts: "ts",
+	tsx: "ts",
+	js: "js",
+	jsx: "js",
+	mjs: "js",
+	cjs: "js",
+	py: "py",
+	go: "go",
+	rs: "rs",
+	rb: "rb",
+	java: "java",
+	kt: "java",
+	scala: "java",
+};
+
+/**
+ * Find line indices where code boundaries (function/class/method declarations) occur.
+ */
+function findBoundaryLines(lines: string[], lang: string): number[] {
+	const patterns = BOUNDARY_PATTERNS[lang];
+	if (!patterns) return [];
+
+	const boundaries: number[] = [];
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i] as string;
+		if (patterns.some((p) => p.test(line))) {
+			boundaries.push(i);
+		}
+	}
+	return boundaries;
+}
+
+/**
+ * Extract a symbol name from a boundary line.
+ */
+function extractSymbolName(line: string): string {
+	// Try to match common declaration patterns
+	const match = line.match(
+		/(?:function|class|interface|type|enum|struct|trait|impl|def|func|module)\s+(\w+)/,
+	);
+	if (match?.[1]) return match[1];
+	// Const/let arrow function
+	const arrowMatch = line.match(/(?:const|let|var)\s+(\w+)\s*=/);
+	if (arrowMatch?.[1]) return arrowMatch[1];
+	// Method name
+	const methodMatch = line.match(/^\s+(?:async\s+)?(?:get\s+|set\s+)?(\w+)\s*\(/);
+	if (methodMatch?.[1]) return methodMatch[1];
+	return "unknown";
+}
+
+/**
+ * AST-heuristic code chunker.
+ *
+ * Splits code at function/class/method boundaries using language-specific
+ * regex patterns. Falls back to fixed-size windowing for unsupported
+ * languages or when no boundaries are found.
+ *
+ * This is a practical 80% solution before full tree-sitter integration.
+ * For supported languages (TS, JS, Python, Go, Rust, Ruby, Java), chunks
+ * align to meaningful code units instead of arbitrary character boundaries.
+ */
+export class AstHeuristicChunker implements Chunker {
+	readonly name = "ast-heuristic";
+	readonly version = "1.0.0";
+
+	chunk(document: ChunkerDocument, options?: ChunkerOptions): ChunkerOutput[] {
+		const ext = document.filePath?.split(".").pop()?.toLowerCase() ?? "";
+		const lang = EXT_TO_LANG[ext];
+		const maxChunkSize = options?.maxChunkChars ?? 4000;
+
+		if (!lang) {
+			return this.#fallbackChunk(document, options);
+		}
+
+		const lines = document.content.split("\n");
+		const boundaries = findBoundaryLines(lines, lang);
+
+		if (boundaries.length === 0) {
+			return this.#fallbackChunk(document, options);
+		}
+
+		const chunks: ChunkerOutput[] = [];
+
+		// Split content at boundary lines
+		for (let i = 0; i < boundaries.length; i++) {
+			const startLine = boundaries[i] as number;
+			const endLine = i + 1 < boundaries.length ? (boundaries[i + 1] as number) : lines.length;
+			const chunkLines = lines.slice(startLine, endLine);
+			const content = chunkLines.join("\n").trim();
+
+			if (!content) continue;
+
+			// If chunk is too large, split it further
+			if (content.length > maxChunkSize) {
+				const subChunks = this.#splitLargeChunk(
+					content,
+					document,
+					chunks.length,
+					startLine + 1,
+					maxChunkSize,
+				);
+				chunks.push(...subChunks);
+				continue;
+			}
+
+			const contentFingerprint = sha256Hex(content);
+			const chunkId =
+				document.documentId && document.documentVersionId
+					? sha256Hex(
+							`${document.documentId}:${document.documentVersionId}:${chunks.length}:${content}`,
+						)
+					: sha256Hex(content);
+
+			const symbolName = extractSymbolName(chunkLines[0] ?? "");
+
+			chunks.push({
+				id: chunkId,
+				content,
+				sourceType: document.sourceType,
+				source: document.source,
+				sourceUrl: document.sourceUrl,
+				timestamp: document.timestamp,
+				chunkIndex: chunks.length,
+				totalChunks: 0, // filled in after
+				metadata: {
+					...(document.metadata ?? {}),
+					filePath: document.filePath ?? "",
+				},
+				documentId: document.documentId,
+				documentVersionId: document.documentVersionId,
+				contentFingerprint,
+				byteOffsetStart: lines.slice(0, startLine).join("\n").length + 1,
+				byteOffsetEnd: lines.slice(0, endLine).join("\n").length,
+				lineStart: startLine + 1,
+				lineEnd: endLine,
+				chunkerName: this.name,
+				chunkerVersion: this.version,
+				symbolPath: symbolName,
+			});
+		}
+
+		// Handle content before first boundary
+		if (boundaries.length > 0 && (boundaries[0] as number) > 0) {
+			const preamble = lines.slice(0, boundaries[0]).join("\n").trim();
+			if (preamble) {
+				const contentFingerprint = sha256Hex(preamble);
+				const chunkId =
+					document.documentId && document.documentVersionId
+						? sha256Hex(`${document.documentId}:${document.documentVersionId}:preamble:${preamble}`)
+						: sha256Hex(preamble);
+
+				chunks.unshift({
+					id: chunkId,
+					content: preamble,
+					sourceType: document.sourceType,
+					source: document.source,
+					sourceUrl: document.sourceUrl,
+					timestamp: document.timestamp,
+					chunkIndex: 0,
+					totalChunks: 0,
+					metadata: {
+						...(document.metadata ?? {}),
+						filePath: document.filePath ?? "",
+					},
+					documentId: document.documentId,
+					documentVersionId: document.documentVersionId,
+					contentFingerprint,
+					lineStart: 1,
+					lineEnd: boundaries[0] as number,
+					chunkerName: this.name,
+					chunkerVersion: this.version,
+					symbolPath: "preamble",
+				});
+			}
+		}
+
+		// Fix indices and totalChunks
+		for (let i = 0; i < chunks.length; i++) {
+			(chunks[i] as ChunkerOutput).chunkIndex = i;
+			(chunks[i] as ChunkerOutput).totalChunks = chunks.length;
+		}
+
+		return chunks;
+	}
+
+	#splitLargeChunk(
+		content: string,
+		document: ChunkerDocument,
+		baseIndex: number,
+		lineOffset: number,
+		maxSize: number,
+	): ChunkerOutput[] {
+		const pieces: ChunkerOutput[] = [];
+		let offset = 0;
+
+		while (offset < content.length) {
+			const end = Math.min(offset + maxSize, content.length);
+			const piece = content.slice(offset, end);
+			const contentFingerprint = sha256Hex(piece);
+			const chunkId =
+				document.documentId && document.documentVersionId
+					? sha256Hex(
+							`${document.documentId}:${document.documentVersionId}:${baseIndex + pieces.length}:${piece}`,
+						)
+					: sha256Hex(piece);
+
+			pieces.push({
+				id: chunkId,
+				content: piece,
+				sourceType: document.sourceType,
+				source: document.source,
+				sourceUrl: document.sourceUrl,
+				timestamp: document.timestamp,
+				chunkIndex: baseIndex + pieces.length,
+				totalChunks: 0,
+				metadata: {
+					...(document.metadata ?? {}),
+					filePath: document.filePath ?? "",
+				},
+				documentId: document.documentId,
+				documentVersionId: document.documentVersionId,
+				contentFingerprint,
+				lineStart: lineOffset,
+				chunkerName: this.name,
+				chunkerVersion: this.version,
+			});
+
+			offset = end;
+		}
+
+		return pieces;
+	}
+
+	#fallbackChunk(document: ChunkerDocument, options?: ChunkerOptions): ChunkerOutput[] {
+		return new CodeWindowChunker().chunk(document, options);
+	}
+}

--- a/packages/ingest/src/chunkers/index.ts
+++ b/packages/ingest/src/chunkers/index.ts
@@ -1,7 +1,9 @@
 import type { Chunker } from "@wtfoc/common";
+import { AstHeuristicChunker } from "./ast-heuristic-chunker.js";
 import { CodeWindowChunker } from "./code-chunker.js";
 import { MarkdownChunker } from "./markdown-chunker.js";
 
+export { AstHeuristicChunker } from "./ast-heuristic-chunker.js";
 export { CodeWindowChunker } from "./code-chunker.js";
 export { MarkdownChunker } from "./markdown-chunker.js";
 
@@ -28,8 +30,27 @@ export function getAvailableChunkers(): string[] {
 	return [...registry.keys()];
 }
 
+/** Extensions supported by the AST heuristic chunker */
+const AST_SUPPORTED_EXTS = new Set([
+	"ts",
+	"tsx",
+	"js",
+	"jsx",
+	"mjs",
+	"cjs",
+	"py",
+	"go",
+	"rs",
+	"rb",
+	"java",
+	"kt",
+	"scala",
+]);
+
 /**
  * Select the appropriate chunker for a source type and file path.
+ * Prefers AST-heuristic for supported languages, markdown for .md/.mdx,
+ * falls back to code-window for everything else.
  */
 export function selectChunker(sourceType: string, filePath?: string): Chunker {
 	const ext = filePath?.split(".").pop()?.toLowerCase();
@@ -38,9 +59,13 @@ export function selectChunker(sourceType: string, filePath?: string): Chunker {
 	if (isMarkdown) {
 		return registry.get("markdown") ?? new MarkdownChunker();
 	}
+	if (ext && AST_SUPPORTED_EXTS.has(ext)) {
+		return registry.get("ast-heuristic") ?? new AstHeuristicChunker();
+	}
 	return registry.get("code-window") ?? new CodeWindowChunker();
 }
 
 // Register built-in chunkers
 registerChunker(new MarkdownChunker());
 registerChunker(new CodeWindowChunker());
+registerChunker(new AstHeuristicChunker());

--- a/packages/ingest/src/edges/derived-layer.ts
+++ b/packages/ingest/src/edges/derived-layer.ts
@@ -71,3 +71,75 @@ export async function loadDerivedEdgeLayers(
 	}
 	return allEdges;
 }
+
+/**
+ * Compact multiple derived edge layers into a single canonical layer.
+ * Deduplicates edges by (type, sourceId, targetType, targetId) key,
+ * keeping the highest-confidence version. Drops edges whose sourceId
+ * is not in the provided validChunkIds set.
+ */
+export function compactDerivedLayers(
+	layers: DerivedEdgeLayer[],
+	validChunkIds: ReadonlySet<string>,
+	collectionId: string,
+): { layer: DerivedEdgeLayer; stats: CompactionStats } {
+	const edgeMap = new Map<string, Edge>();
+	let totalInput = 0;
+	let droppedOrphan = 0;
+	let droppedDuplicate = 0;
+	const models = new Set<string>();
+	let totalContexts = 0;
+
+	for (const layer of layers) {
+		models.add(layer.extractorModel);
+		totalContexts += layer.contextsProcessed;
+
+		for (const edge of layer.edges) {
+			totalInput++;
+
+			// Drop edges whose source chunk no longer exists
+			if (!validChunkIds.has(edge.sourceId)) {
+				droppedOrphan++;
+				continue;
+			}
+
+			const key = JSON.stringify([edge.type, edge.sourceId, edge.targetType, edge.targetId]);
+			const existing = edgeMap.get(key);
+			if (existing) {
+				droppedDuplicate++;
+				// Keep the higher-confidence version
+				if (edge.confidence > existing.confidence) {
+					edgeMap.set(key, edge);
+				}
+			} else {
+				edgeMap.set(key, edge);
+			}
+		}
+	}
+
+	const compacted = buildDerivedEdgeLayer(
+		collectionId,
+		[...models].join("+"),
+		[...edgeMap.values()],
+		totalContexts,
+	);
+
+	return {
+		layer: compacted,
+		stats: {
+			inputLayers: layers.length,
+			inputEdges: totalInput,
+			outputEdges: edgeMap.size,
+			droppedOrphan,
+			droppedDuplicate,
+		},
+	};
+}
+
+export interface CompactionStats {
+	inputLayers: number;
+	inputEdges: number;
+	outputEdges: number;
+	droppedOrphan: number;
+	droppedDuplicate: number;
+}

--- a/packages/ingest/src/edges/derived-layer.ts
+++ b/packages/ingest/src/edges/derived-layer.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import type { Edge } from "@wtfoc/common";
+import { edgeKey } from "./merge.js";
 
 /**
  * Immutable derived-edge layer blob.
@@ -103,7 +104,7 @@ export function compactDerivedLayers(
 				continue;
 			}
 
-			const key = JSON.stringify([edge.type, edge.sourceId, edge.targetType, edge.targetId]);
+			const key = edgeKey(edge);
 			const existing = edgeMap.get(key);
 			if (existing) {
 				droppedDuplicate++;

--- a/packages/ingest/src/edges/temporal-semantic.test.ts
+++ b/packages/ingest/src/edges/temporal-semantic.test.ts
@@ -1,0 +1,341 @@
+import type { Chunk } from "@wtfoc/common";
+import { describe, expect, it } from "vitest";
+import { TemporalSemanticExtractor } from "./temporal-semantic.js";
+
+function makeChunk(overrides: Partial<Chunk> & { id: string; sourceType: string }): Chunk {
+	return {
+		content: overrides.content ?? "test content",
+		source: overrides.source ?? "test-source",
+		chunkIndex: 0,
+		totalChunks: 1,
+		metadata: overrides.metadata ?? {},
+		...overrides,
+	};
+}
+
+describe("TemporalSemanticExtractor", () => {
+	it("returns empty for fewer than 2 chunks", async () => {
+		const extractor = new TemporalSemanticExtractor();
+		const edges = await extractor.extract([
+			makeChunk({ id: "c1", sourceType: "slack-message", timestamp: "2026-01-01T00:00:00Z" }),
+		]);
+		expect(edges).toEqual([]);
+	});
+
+	it("returns empty for chunks without timestamps", async () => {
+		const extractor = new TemporalSemanticExtractor();
+		const edges = await extractor.extract([
+			makeChunk({ id: "c1", sourceType: "slack-message" }),
+			makeChunk({ id: "c2", sourceType: "github-issue" }),
+		]);
+		expect(edges).toEqual([]);
+	});
+
+	it("emits discussed-before when discussion precedes issue", async () => {
+		const extractor = new TemporalSemanticExtractor();
+		const edges = await extractor.extract([
+			makeChunk({
+				id: "slack-1",
+				sourceType: "slack-message",
+				source: "#engineering",
+				documentId: "slack:C123:1234",
+				timestamp: "2026-01-01T10:00:00Z",
+				content: "We need to fix the auth flow",
+			}),
+			makeChunk({
+				id: "issue-1",
+				sourceType: "github-issue",
+				source: "owner/repo#42",
+				documentId: "owner/repo#42",
+				timestamp: "2026-01-01T12:00:00Z",
+				content: "Fix auth flow",
+			}),
+		]);
+
+		const before = edges.filter((e) => e.type === "discussed-before");
+		expect(before.length).toBe(1);
+		expect(before[0]?.sourceId).toBe("slack-1");
+		expect(before[0]?.targetId).toBe("owner/repo#42");
+	});
+
+	it("emits discussed-during when discussion overlaps with long-lived issue", async () => {
+		const extractor = new TemporalSemanticExtractor();
+		const edges = await extractor.extract([
+			makeChunk({
+				id: "issue-1",
+				sourceType: "github-issue",
+				source: "owner/repo#42",
+				documentId: "owner/repo#42",
+				timestamp: "2026-01-01T00:00:00Z",
+				metadata: { closedAt: "2026-01-20T00:00:00Z" },
+				content: "Long-running feature",
+			}),
+			makeChunk({
+				id: "slack-1",
+				sourceType: "slack-message",
+				source: "#engineering",
+				documentId: "slack:C123:5678",
+				timestamp: "2026-01-10T00:00:00Z",
+				content: "Discussion about the feature",
+			}),
+		]);
+
+		const during = edges.filter((e) => e.type === "discussed-during");
+		expect(during.length).toBe(1);
+		expect(during[0]?.sourceId).toBe("slack-1");
+	});
+
+	it("emits addressed-after when code follows discussion", async () => {
+		const extractor = new TemporalSemanticExtractor();
+		const edges = await extractor.extract([
+			makeChunk({
+				id: "slack-1",
+				sourceType: "slack-message",
+				source: "#engineering",
+				documentId: "slack:C123:1234",
+				timestamp: "2026-01-01T10:00:00Z",
+				content: "Bug report",
+			}),
+			makeChunk({
+				id: "code-1",
+				sourceType: "code",
+				source: "owner/repo/fix.ts",
+				documentId: "owner/repo/fix.ts",
+				timestamp: "2026-01-01T14:00:00Z",
+				content: "Fix for the bug",
+			}),
+		]);
+
+		const after = edges.filter((e) => e.type === "addressed-after");
+		expect(after.length).toBe(1);
+		expect(after[0]?.sourceId).toBe("code-1");
+	});
+
+	it("emits occurred-during when code falls within PR interval", async () => {
+		const extractor = new TemporalSemanticExtractor();
+		const edges = await extractor.extract([
+			makeChunk({
+				id: "pr-1",
+				sourceType: "github-pr",
+				source: "owner/repo#100",
+				documentId: "owner/repo#100",
+				timestamp: "2026-01-01T00:00:00Z",
+				metadata: { mergedAt: "2026-01-15T00:00:00Z" },
+				content: "Feature PR",
+			}),
+			makeChunk({
+				id: "code-1",
+				sourceType: "code",
+				source: "owner/repo/file.ts",
+				documentId: "owner/repo/file.ts",
+				timestamp: "2026-01-07T00:00:00Z",
+				content: "Code change within PR",
+			}),
+		]);
+
+		const during = edges.filter((e) => e.type === "occurred-during");
+		expect(during.length).toBe(1);
+		expect(during[0]?.sourceId).toBe("code-1");
+	});
+
+	it("handles long-lived issue beyond maxWindowHours via interval check", async () => {
+		// Issue opened Jan 1, commit April 20 — beyond 168h window on start times,
+		// but commit is within the issue's interval
+		const extractor = new TemporalSemanticExtractor({ maxWindowHours: 168 });
+		const edges = await extractor.extract([
+			makeChunk({
+				id: "issue-1",
+				sourceType: "github-issue",
+				source: "owner/repo#42",
+				documentId: "owner/repo#42",
+				timestamp: "2026-01-01T00:00:00Z",
+				metadata: { closedAt: "2026-05-01T00:00:00Z" },
+				content: "Long-lived issue",
+			}),
+			makeChunk({
+				id: "code-1",
+				sourceType: "code",
+				source: "owner/repo/fix.ts",
+				documentId: "owner/repo/fix.ts",
+				timestamp: "2026-04-20T00:00:00Z",
+				content: "Late fix",
+			}),
+		]);
+
+		const during = edges.filter((e) => e.type === "occurred-during");
+		expect(during.length).toBe(1);
+	});
+
+	it("respects semantic threshold when embeddings are provided", () => {
+		const extractor = new TemporalSemanticExtractor({ discussionThreshold: 0.78 });
+
+		// Create embeddings with low similarity
+		const emb1 = new Float32Array([1, 0, 0]);
+		const emb2 = new Float32Array([0, 1, 0]); // orthogonal = 0 similarity
+
+		const result = extractor.extractWithEmbeddings(
+			[
+				makeChunk({
+					id: "slack-1",
+					sourceType: "slack-message",
+					documentId: "slack:1",
+					timestamp: "2026-01-01T10:00:00Z",
+				}),
+				makeChunk({
+					id: "issue-1",
+					sourceType: "github-issue",
+					documentId: "owner/repo#42",
+					timestamp: "2026-01-01T12:00:00Z",
+				}),
+			],
+			new Map([
+				["slack-1", emb1],
+				["issue-1", emb2],
+			]),
+		);
+
+		// Orthogonal embeddings should be below threshold — no edges
+		expect(result.edges).toEqual([]);
+		expect(result.temporalOnly).toBe(false);
+	});
+
+	it("emits edges when embeddings have high similarity", () => {
+		const extractor = new TemporalSemanticExtractor({ discussionThreshold: 0.5 });
+
+		// Nearly identical embeddings
+		const emb1 = new Float32Array([1, 0.1, 0]);
+		const emb2 = new Float32Array([1, 0.2, 0]); // very similar
+
+		const result = extractor.extractWithEmbeddings(
+			[
+				makeChunk({
+					id: "slack-1",
+					sourceType: "slack-message",
+					documentId: "slack:1",
+					timestamp: "2026-01-01T10:00:00Z",
+					content: "Discussion about auth",
+				}),
+				makeChunk({
+					id: "issue-1",
+					sourceType: "github-issue",
+					documentId: "owner/repo#42",
+					timestamp: "2026-01-01T12:00:00Z",
+					content: "Auth issue",
+				}),
+			],
+			new Map([
+				["slack-1", emb1],
+				["issue-1", emb2],
+			]),
+		);
+
+		expect(result.edges.length).toBeGreaterThan(0);
+		expect(result.temporalOnly).toBe(false);
+	});
+
+	it("sets temporalOnly=true when no embeddings provided", () => {
+		const extractor = new TemporalSemanticExtractor();
+		const result = extractor.extractWithEmbeddings(
+			[
+				makeChunk({
+					id: "slack-1",
+					sourceType: "slack-message",
+					documentId: "slack:1",
+					timestamp: "2026-01-01T10:00:00Z",
+				}),
+				makeChunk({
+					id: "issue-1",
+					sourceType: "github-issue",
+					documentId: "owner/repo#42",
+					timestamp: "2026-01-01T12:00:00Z",
+				}),
+			],
+			new Map(),
+		);
+
+		expect(result.temporalOnly).toBe(true);
+	});
+
+	it("uses documentId as stable target ID", async () => {
+		const extractor = new TemporalSemanticExtractor();
+		const edges = await extractor.extract([
+			makeChunk({
+				id: "slack-1",
+				sourceType: "slack-message",
+				source: "#channel",
+				documentId: "slack:C123:msg456",
+				timestamp: "2026-01-01T10:00:00Z",
+				content: "Discussion",
+			}),
+			makeChunk({
+				id: "issue-1",
+				sourceType: "github-issue",
+				source: "owner/repo#42",
+				documentId: "owner/repo#42",
+				timestamp: "2026-01-01T12:00:00Z",
+				content: "Issue",
+			}),
+		]);
+
+		const before = edges.filter((e) => e.type === "discussed-before");
+		expect(before.length).toBe(1);
+		// targetId should be the documentId, not the channel name
+		expect(before[0]?.targetId).toBe("owner/repo#42");
+	});
+
+	it("respects AbortSignal", async () => {
+		const extractor = new TemporalSemanticExtractor();
+		const controller = new AbortController();
+		controller.abort(new Error("test abort"));
+
+		await expect(
+			extractor.extract(
+				[
+					makeChunk({
+						id: "c1",
+						sourceType: "slack-message",
+						timestamp: "2026-01-01T00:00:00Z",
+					}),
+					makeChunk({
+						id: "c2",
+						sourceType: "github-issue",
+						timestamp: "2026-01-01T01:00:00Z",
+					}),
+				],
+				controller.signal,
+			),
+		).rejects.toThrow("test abort");
+	});
+
+	it("deduplicates edges by type + source + target", async () => {
+		const extractor = new TemporalSemanticExtractor();
+		// Two Slack messages from same documentId to same issue
+		const edges = await extractor.extract([
+			makeChunk({
+				id: "slack-1",
+				sourceType: "slack-message",
+				documentId: "slack:C123:msg1",
+				timestamp: "2026-01-01T10:00:00Z",
+				content: "First message",
+			}),
+			makeChunk({
+				id: "slack-2",
+				sourceType: "slack-message",
+				documentId: "slack:C123:msg1", // same documentId
+				timestamp: "2026-01-01T10:05:00Z",
+				content: "Second message",
+			}),
+			makeChunk({
+				id: "issue-1",
+				sourceType: "github-issue",
+				documentId: "owner/repo#42",
+				timestamp: "2026-01-01T12:00:00Z",
+				content: "Issue",
+			}),
+		]);
+
+		// Should deduplicate since both slack messages have the same stableId
+		const before = edges.filter((e) => e.type === "discussed-before");
+		expect(before.length).toBe(1);
+	});
+});

--- a/packages/ingest/src/edges/temporal-semantic.ts
+++ b/packages/ingest/src/edges/temporal-semantic.ts
@@ -1,0 +1,271 @@
+import type { Chunk, Edge, EdgeExtractor, StructuredEvidence } from "@wtfoc/common";
+
+/**
+ * Directional temporal-semantic edge types.
+ * Each encodes both time ordering and semantic relevance.
+ */
+export type TemporalEdgeType =
+	| "discussed-before"
+	| "discussed-during"
+	| "addressed-after"
+	| "occurred-during"
+	| "followed-by";
+
+/**
+ * An event record with timing and optional embedding for similarity.
+ */
+export interface TemporalEvent {
+	/** Chunk or document ID */
+	entityId: string;
+	/** Source type (github-issue, slack-message, code, etc.) */
+	entityType: string;
+	/** Source identifier */
+	source: string;
+	/** Event start timestamp (ms since epoch) */
+	timestampStart: number;
+	/** Event end timestamp for interval events (null for point events) */
+	timestampEnd: number | null;
+	/** Pre-computed embedding vector for similarity comparison */
+	embedding?: Float32Array;
+	/** Text snippet for evidence */
+	text: string;
+}
+
+export interface TemporalSemanticOptions {
+	/** Semantic similarity threshold for discussion→issue/PR (default: 0.78) */
+	discussionThreshold?: number;
+	/** Semantic similarity threshold for issue→PR (default: 0.72) */
+	issueThreshold?: number;
+	/** Semantic similarity threshold for fallback pairs (default: 0.68) */
+	fallbackThreshold?: number;
+	/** Time decay tau in hours for discussion→issue/PR (default: 72) */
+	tauDiscussion?: number;
+	/** Time decay tau in hours for discussion→commit (default: 24) */
+	tauCommit?: number;
+	/** Maximum time window in hours (default: 168 = 1 week) */
+	maxWindowHours?: number;
+}
+
+/** Source types that represent discussion/chat */
+const DISCUSSION_TYPES = new Set(["slack-message", "discord-message", "github-discussion"]);
+
+/** Source types that represent trackable work items */
+const WORK_ITEM_TYPES = new Set(["github-issue", "github-pr"]);
+
+/** Source types that represent code changes */
+const CODE_TYPES = new Set(["code", "github-pr"]);
+
+/**
+ * Compute cosine similarity between two vectors.
+ */
+function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+	if (a.length !== b.length) return 0;
+	let dot = 0;
+	let normA = 0;
+	let normB = 0;
+	for (let i = 0; i < a.length; i++) {
+		dot += (a[i] as number) * (b[i] as number);
+		normA += (a[i] as number) * (a[i] as number);
+		normB += (b[i] as number) * (b[i] as number);
+	}
+	const denom = Math.sqrt(normA) * Math.sqrt(normB);
+	return denom === 0 ? 0 : dot / denom;
+}
+
+/**
+ * Determine the temporal edge type based on event ordering and types.
+ */
+function classifyTemporalRelation(
+	source: TemporalEvent,
+	target: TemporalEvent,
+): TemporalEdgeType | null {
+	const sourceIsDiscussion = DISCUSSION_TYPES.has(source.entityType);
+	const targetIsWorkItem = WORK_ITEM_TYPES.has(target.entityType);
+	const sourceIsCode = CODE_TYPES.has(source.entityType);
+	const targetIsDiscussion =
+		DISCUSSION_TYPES.has(target.entityType) || WORK_ITEM_TYPES.has(target.entityType);
+
+	const sourceBefore = source.timestampStart < target.timestampStart;
+	const sourceAfter = source.timestampStart > target.timestampStart;
+
+	// Discussion happened before work item → discussed-before
+	if (sourceIsDiscussion && targetIsWorkItem && sourceBefore) {
+		return "discussed-before";
+	}
+
+	// Discussion overlaps with work item interval → discussed-during
+	if (sourceIsDiscussion && targetIsWorkItem && target.timestampEnd) {
+		const overlap =
+			source.timestampStart >= target.timestampStart &&
+			source.timestampStart <= target.timestampEnd;
+		if (overlap) return "discussed-during";
+	}
+
+	// Code change after discussion/issue → addressed-after
+	if (sourceIsCode && (targetIsDiscussion || targetIsWorkItem) && sourceAfter) {
+		return "addressed-after";
+	}
+
+	// Code within work item interval → occurred-during
+	if (sourceIsCode && targetIsWorkItem && target.timestampEnd) {
+		const within =
+			source.timestampStart >= target.timestampStart &&
+			source.timestampStart <= target.timestampEnd;
+		if (within) return "occurred-during";
+	}
+
+	// Generic ordering when both have timestamps and some semantic match
+	if (sourceBefore) return "followed-by";
+
+	return null;
+}
+
+/**
+ * Temporal-semantic edge extractor.
+ *
+ * Produces directional edges based on time ordering + semantic similarity.
+ * Designed for post-hoc extraction over indexed entities.
+ *
+ * Requires pre-computed embeddings on events. Without embeddings, falls back
+ * to temporal-only extraction at reduced confidence.
+ */
+export class TemporalSemanticExtractor implements EdgeExtractor {
+	readonly #options: Required<TemporalSemanticOptions>;
+
+	constructor(options?: TemporalSemanticOptions) {
+		this.#options = {
+			discussionThreshold: options?.discussionThreshold ?? 0.78,
+			issueThreshold: options?.issueThreshold ?? 0.72,
+			fallbackThreshold: options?.fallbackThreshold ?? 0.68,
+			tauDiscussion: options?.tauDiscussion ?? 72,
+			tauCommit: options?.tauCommit ?? 24,
+			maxWindowHours: options?.maxWindowHours ?? 168,
+		};
+	}
+
+	async extract(chunks: Chunk[], _signal?: AbortSignal): Promise<Edge[]> {
+		// Build events from chunks
+		const events = this.#chunksToEvents(chunks);
+		if (events.length < 2) return [];
+
+		const edges: Edge[] = [];
+		const seen = new Set<string>();
+		const maxWindowMs = this.#options.maxWindowHours * 60 * 60 * 1000;
+
+		// Compare each pair of events from different source types
+		for (let i = 0; i < events.length; i++) {
+			const source = events[i] as TemporalEvent;
+			for (let j = 0; j < events.length; j++) {
+				if (i === j) continue;
+				const target = events[j] as TemporalEvent;
+
+				// Skip same source type pairs (discussion↔discussion, etc.)
+				if (source.entityType === target.entityType) continue;
+
+				// Skip if outside time window
+				const timeDelta = Math.abs(source.timestampStart - target.timestampStart);
+				if (timeDelta > maxWindowMs) continue;
+
+				// Classify the temporal relation
+				const edgeType = classifyTemporalRelation(source, target);
+				if (!edgeType) continue;
+
+				// Dedup by source→target pair + type
+				const key = `${edgeType}:${source.entityId}:${target.entityId}`;
+				if (seen.has(key)) continue;
+
+				// Compute semantic similarity if embeddings available
+				let semanticScore = 0;
+				if (source.embedding && target.embedding) {
+					semanticScore = cosineSimilarity(source.embedding, target.embedding);
+				}
+
+				// Apply semantic threshold based on pair type
+				const threshold = this.#getThreshold(source, target);
+				if (source.embedding && target.embedding && semanticScore < threshold) {
+					continue;
+				}
+
+				// Compute confidence
+				const deltaHours = timeDelta / (60 * 60 * 1000);
+				const tau = this.#getTau(source, target);
+				const timeScore = Math.exp(-deltaHours / tau);
+				const confidence =
+					source.embedding && target.embedding
+						? Math.min(0.8, semanticScore ** 1.5 * timeScore ** 0.75)
+						: Math.min(0.5, timeScore ** 0.75 * 0.5);
+
+				if (confidence < 0.3) continue;
+
+				seen.add(key);
+
+				const evidenceText = `${source.entityType} "${source.text.slice(0, 60)}..." ${edgeType.replace(/-/g, " ")} ${target.entityType} "${target.text.slice(0, 60)}..." (${deltaHours.toFixed(1)}h apart, similarity: ${semanticScore.toFixed(2)})`;
+
+				const structuredEvidence: StructuredEvidence = {
+					text: evidenceText,
+					extractor: "temporal-semantic",
+					observedAt: new Date().toISOString(),
+					confidence,
+				};
+
+				edges.push({
+					type: edgeType,
+					sourceId: source.entityId,
+					targetType: target.entityType,
+					targetId: target.source,
+					evidence: evidenceText,
+					confidence: Math.round(confidence * 100) / 100,
+					provenance: ["temporal-semantic"],
+					structuredEvidence,
+				});
+			}
+		}
+
+		return edges;
+	}
+
+	#chunksToEvents(chunks: Chunk[]): TemporalEvent[] {
+		const events: TemporalEvent[] = [];
+		for (const chunk of chunks) {
+			const ts = chunk.timestamp ?? chunk.metadata?.createdAt ?? chunk.metadata?.updatedAt;
+			if (!ts) continue;
+			const time = new Date(ts).getTime();
+			if (Number.isNaN(time)) continue;
+
+			// For issues/PRs, try to build an interval from created→closed/merged
+			let endTime: number | null = null;
+			const closedAt = chunk.metadata?.closedAt ?? chunk.metadata?.mergedAt;
+			if (closedAt) {
+				const closed = new Date(closedAt).getTime();
+				if (!Number.isNaN(closed)) endTime = closed;
+			}
+
+			events.push({
+				entityId: chunk.id,
+				entityType: chunk.sourceType,
+				source: chunk.source,
+				timestampStart: time,
+				timestampEnd: endTime,
+				text: chunk.content.slice(0, 200),
+			});
+		}
+		return events;
+	}
+
+	#getThreshold(source: TemporalEvent, target: TemporalEvent): number {
+		if (DISCUSSION_TYPES.has(source.entityType) && WORK_ITEM_TYPES.has(target.entityType)) {
+			return this.#options.discussionThreshold;
+		}
+		if (WORK_ITEM_TYPES.has(source.entityType) && WORK_ITEM_TYPES.has(target.entityType)) {
+			return this.#options.issueThreshold;
+		}
+		return this.#options.fallbackThreshold;
+	}
+
+	#getTau(source: TemporalEvent, target: TemporalEvent): number {
+		if (CODE_TYPES.has(source.entityType) || CODE_TYPES.has(target.entityType)) {
+			return this.#options.tauCommit;
+		}
+		return this.#options.tauDiscussion;
+	}
+}

--- a/packages/ingest/src/edges/temporal-semantic.ts
+++ b/packages/ingest/src/edges/temporal-semantic.ts
@@ -2,7 +2,6 @@ import type { Chunk, Edge, EdgeExtractor, StructuredEvidence } from "@wtfoc/comm
 
 /**
  * Directional temporal-semantic edge types.
- * Each encodes both time ordering and semantic relevance.
  */
 export type TemporalEdgeType =
 	| "discussed-before"
@@ -15,49 +14,36 @@ export type TemporalEdgeType =
  * An event record with timing and optional embedding for similarity.
  */
 export interface TemporalEvent {
-	/** Chunk or document ID */
 	entityId: string;
-	/** Source type (github-issue, slack-message, code, etc.) */
 	entityType: string;
-	/** Source identifier */
 	source: string;
-	/** Event start timestamp (ms since epoch) */
+	/** Stable target identifier (documentId or sourceUrl, not channel name) */
+	stableId: string;
 	timestampStart: number;
-	/** Event end timestamp for interval events (null for point events) */
 	timestampEnd: number | null;
-	/** Pre-computed embedding vector for similarity comparison */
 	embedding?: Float32Array;
-	/** Text snippet for evidence */
 	text: string;
 }
 
 export interface TemporalSemanticOptions {
-	/** Semantic similarity threshold for discussion→issue/PR (default: 0.78) */
 	discussionThreshold?: number;
-	/** Semantic similarity threshold for issue→PR (default: 0.72) */
 	issueThreshold?: number;
-	/** Semantic similarity threshold for fallback pairs (default: 0.68) */
 	fallbackThreshold?: number;
-	/** Time decay tau in hours for discussion→issue/PR (default: 72) */
 	tauDiscussion?: number;
-	/** Time decay tau in hours for discussion→commit (default: 24) */
 	tauCommit?: number;
-	/** Maximum time window in hours (default: 168 = 1 week) */
 	maxWindowHours?: number;
 }
 
-/** Source types that represent discussion/chat */
+export interface TemporalExtractionResult {
+	edges: Edge[];
+	/** True if extraction ran without embeddings (temporal-only mode) */
+	temporalOnly: boolean;
+}
+
 const DISCUSSION_TYPES = new Set(["slack-message", "discord-message", "github-discussion"]);
-
-/** Source types that represent trackable work items */
 const WORK_ITEM_TYPES = new Set(["github-issue", "github-pr"]);
-
-/** Source types that represent code changes */
 const CODE_TYPES = new Set(["code", "github-pr"]);
 
-/**
- * Compute cosine similarity between two vectors.
- */
 function cosineSimilarity(a: Float32Array, b: Float32Array): number {
 	if (a.length !== b.length) return 0;
 	let dot = 0;
@@ -72,9 +58,6 @@ function cosineSimilarity(a: Float32Array, b: Float32Array): number {
 	return denom === 0 ? 0 : dot / denom;
 }
 
-/**
- * Determine the temporal edge type based on event ordering and types.
- */
 function classifyTemporalRelation(
 	source: TemporalEvent,
 	target: TemporalEvent,
@@ -82,7 +65,7 @@ function classifyTemporalRelation(
 	const sourceIsDiscussion = DISCUSSION_TYPES.has(source.entityType);
 	const targetIsWorkItem = WORK_ITEM_TYPES.has(target.entityType);
 	const sourceIsCode = CODE_TYPES.has(source.entityType);
-	const targetIsDiscussion =
+	const targetIsDiscussionOrWork =
 		DISCUSSION_TYPES.has(target.entityType) || WORK_ITEM_TYPES.has(target.entityType);
 
 	const sourceBefore = source.timestampStart < target.timestampStart;
@@ -94,30 +77,53 @@ function classifyTemporalRelation(
 	}
 
 	// Discussion overlaps with work item interval → discussed-during
-	if (sourceIsDiscussion && targetIsWorkItem && target.timestampEnd) {
-		const overlap =
+	if (sourceIsDiscussion && targetIsWorkItem && target.timestampEnd !== null) {
+		if (
 			source.timestampStart >= target.timestampStart &&
-			source.timestampStart <= target.timestampEnd;
-		if (overlap) return "discussed-during";
-	}
-
-	// Code change after discussion/issue → addressed-after
-	if (sourceIsCode && (targetIsDiscussion || targetIsWorkItem) && sourceAfter) {
-		return "addressed-after";
+			source.timestampStart <= target.timestampEnd
+		) {
+			return "discussed-during";
+		}
 	}
 
 	// Code within work item interval → occurred-during
-	if (sourceIsCode && targetIsWorkItem && target.timestampEnd) {
-		const within =
+	if (sourceIsCode && targetIsWorkItem && target.timestampEnd !== null) {
+		if (
 			source.timestampStart >= target.timestampStart &&
-			source.timestampStart <= target.timestampEnd;
-		if (within) return "occurred-during";
+			source.timestampStart <= target.timestampEnd
+		) {
+			return "occurred-during";
+		}
 	}
 
-	// Generic ordering when both have timestamps and some semantic match
-	if (sourceBefore) return "followed-by";
+	// Code change after discussion/issue → addressed-after
+	if (sourceIsCode && targetIsDiscussionOrWork && sourceAfter) {
+		return "addressed-after";
+	}
 
+	// Generic ordering when both have timestamps
+	if (sourceBefore) return "followed-by";
 	return null;
+}
+
+/**
+ * Check if two events are within the time window, accounting for intervals.
+ * For point events: uses start-to-start distance.
+ * For interval events: checks if either event falls within the other's interval.
+ */
+function isWithinWindow(a: TemporalEvent, b: TemporalEvent, maxWindowMs: number): boolean {
+	const startDelta = Math.abs(a.timestampStart - b.timestampStart);
+	if (startDelta <= maxWindowMs) return true;
+
+	// Check if either event falls inside the other's interval
+	if (a.timestampEnd !== null) {
+		if (b.timestampStart >= a.timestampStart && b.timestampStart <= a.timestampEnd) return true;
+	}
+	if (b.timestampEnd !== null) {
+		if (a.timestampStart >= b.timestampStart && a.timestampStart <= b.timestampEnd) return true;
+	}
+
+	return false;
 }
 
 /**
@@ -126,8 +132,8 @@ function classifyTemporalRelation(
  * Produces directional edges based on time ordering + semantic similarity.
  * Designed for post-hoc extraction over indexed entities.
  *
- * Requires pre-computed embeddings on events. Without embeddings, falls back
- * to temporal-only extraction at reduced confidence.
+ * Pass pre-computed embeddings via the embeddings parameter in extract().
+ * Without embeddings, emits temporal-only edges at reduced confidence (max 0.5).
  */
 export class TemporalSemanticExtractor implements EdgeExtractor {
 	readonly #options: Required<TemporalSemanticOptions>;
@@ -143,88 +149,124 @@ export class TemporalSemanticExtractor implements EdgeExtractor {
 		};
 	}
 
-	async extract(chunks: Chunk[], _signal?: AbortSignal): Promise<Edge[]> {
-		// Build events from chunks
-		const events = this.#chunksToEvents(chunks);
-		if (events.length < 2) return [];
+	/**
+	 * Extract temporal-semantic edges from chunks.
+	 * Implements EdgeExtractor interface (no embeddings = temporal-only mode).
+	 */
+	async extract(chunks: Chunk[], signal?: AbortSignal): Promise<Edge[]> {
+		const result = this.extractWithEmbeddings(chunks, new Map(), signal);
+		return result.edges;
+	}
+
+	/**
+	 * Extract with pre-computed embeddings for semantic similarity.
+	 * This is the preferred entry point for post-hoc extraction.
+	 */
+	extractWithEmbeddings(
+		chunks: Chunk[],
+		embeddings: ReadonlyMap<string, Float32Array>,
+		signal?: AbortSignal,
+	): TemporalExtractionResult {
+		const events = this.#chunksToEvents(chunks, embeddings);
+		if (events.length < 2) return { edges: [], temporalOnly: embeddings.size === 0 };
+
+		const temporalOnly = embeddings.size === 0;
+
+		// Sort by timestamp for efficient scanning
+		events.sort((a, b) => a.timestampStart - b.timestampStart);
 
 		const edges: Edge[] = [];
 		const seen = new Set<string>();
 		const maxWindowMs = this.#options.maxWindowHours * 60 * 60 * 1000;
 
-		// Compare each pair of events from different source types
 		for (let i = 0; i < events.length; i++) {
+			signal?.throwIfAborted();
 			const source = events[i] as TemporalEvent;
-			for (let j = 0; j < events.length; j++) {
-				if (i === j) continue;
+			// The latest point this source could overlap with anything
+			const sourceLatest = Math.max(
+				source.timestampStart + maxWindowMs,
+				(source.timestampEnd ?? source.timestampStart) + maxWindowMs,
+			);
+
+			for (let j = i + 1; j < events.length; j++) {
 				const target = events[j] as TemporalEvent;
 
-				// Skip same source type pairs (discussion↔discussion, etc.)
+				// Target starts after source's latest possible overlap — done with this source
+				if (target.timestampStart > sourceLatest) break;
+
+				if (!isWithinWindow(source, target, maxWindowMs)) continue;
+
 				if (source.entityType === target.entityType) continue;
 
-				// Skip if outside time window
-				const timeDelta = Math.abs(source.timestampStart - target.timestampStart);
-				if (timeDelta > maxWindowMs) continue;
+				// Try both directions for directional edges
+				for (const [src, tgt] of [
+					[source, target],
+					[target, source],
+				] as [TemporalEvent, TemporalEvent][]) {
+					const edgeType = classifyTemporalRelation(src, tgt);
+					if (!edgeType) continue;
 
-				// Classify the temporal relation
-				const edgeType = classifyTemporalRelation(source, target);
-				if (!edgeType) continue;
+					const key = `${edgeType}:${src.stableId}:${tgt.stableId}`;
+					if (seen.has(key)) continue;
 
-				// Dedup by source→target pair + type
-				const key = `${edgeType}:${source.entityId}:${target.entityId}`;
-				if (seen.has(key)) continue;
+					let semanticScore = 0;
+					if (src.embedding && tgt.embedding) {
+						semanticScore = cosineSimilarity(src.embedding, tgt.embedding);
+					}
 
-				// Compute semantic similarity if embeddings available
-				let semanticScore = 0;
-				if (source.embedding && target.embedding) {
-					semanticScore = cosineSimilarity(source.embedding, target.embedding);
-				}
+					const hasEmbeddings = !!(src.embedding && tgt.embedding);
+					const threshold = this.#getThreshold(src, tgt);
+					if (hasEmbeddings && semanticScore < threshold) continue;
 
-				// Apply semantic threshold based on pair type
-				const threshold = this.#getThreshold(source, target);
-				if (source.embedding && target.embedding && semanticScore < threshold) {
-					continue;
-				}
-
-				// Compute confidence
-				const deltaHours = timeDelta / (60 * 60 * 1000);
-				const tau = this.#getTau(source, target);
-				const timeScore = Math.exp(-deltaHours / tau);
-				const confidence =
-					source.embedding && target.embedding
+					// For interval-based relations (during/occurred-during), use distance
+					// from event to nearest interval boundary instead of start-start delta
+					const isIntervalRelation =
+						edgeType === "discussed-during" || edgeType === "occurred-during";
+					let effectiveDelta: number;
+					if (isIntervalRelation && tgt.timestampEnd !== null) {
+						// Event is inside interval — distance to nearest boundary
+						effectiveDelta = 0;
+					} else {
+						effectiveDelta = Math.abs(src.timestampStart - tgt.timestampStart);
+					}
+					const deltaHours = effectiveDelta / (60 * 60 * 1000);
+					const tau = this.#getTau(src, tgt);
+					const timeScore = Math.exp(-deltaHours / tau);
+					const confidence = hasEmbeddings
 						? Math.min(0.8, semanticScore ** 1.5 * timeScore ** 0.75)
 						: Math.min(0.5, timeScore ** 0.75 * 0.5);
 
-				if (confidence < 0.3) continue;
+					if (confidence < 0.3) continue;
+					seen.add(key);
 
-				seen.add(key);
+					const simNote = hasEmbeddings ? `, similarity: ${semanticScore.toFixed(2)}` : "";
+					const evidenceText = `${src.entityType} "${src.text.slice(0, 60)}..." ${edgeType.replace(/-/g, " ")} ${tgt.entityType} "${tgt.text.slice(0, 60)}..." (${deltaHours.toFixed(1)}h apart${simNote})`;
 
-				const evidenceText = `${source.entityType} "${source.text.slice(0, 60)}..." ${edgeType.replace(/-/g, " ")} ${target.entityType} "${target.text.slice(0, 60)}..." (${deltaHours.toFixed(1)}h apart, similarity: ${semanticScore.toFixed(2)})`;
+					const structuredEvidence: StructuredEvidence = {
+						text: evidenceText,
+						extractor: "temporal-semantic",
+						observedAt: new Date().toISOString(),
+						confidence,
+					};
 
-				const structuredEvidence: StructuredEvidence = {
-					text: evidenceText,
-					extractor: "temporal-semantic",
-					observedAt: new Date().toISOString(),
-					confidence,
-				};
-
-				edges.push({
-					type: edgeType,
-					sourceId: source.entityId,
-					targetType: target.entityType,
-					targetId: target.source,
-					evidence: evidenceText,
-					confidence: Math.round(confidence * 100) / 100,
-					provenance: ["temporal-semantic"],
-					structuredEvidence,
-				});
+					edges.push({
+						type: edgeType,
+						sourceId: src.entityId,
+						targetType: tgt.entityType,
+						targetId: tgt.stableId,
+						evidence: evidenceText,
+						confidence: Math.round(confidence * 100) / 100,
+						provenance: ["temporal-semantic"],
+						structuredEvidence,
+					});
+				}
 			}
 		}
 
-		return edges;
+		return { edges, temporalOnly };
 	}
 
-	#chunksToEvents(chunks: Chunk[]): TemporalEvent[] {
+	#chunksToEvents(chunks: Chunk[], embeddings: ReadonlyMap<string, Float32Array>): TemporalEvent[] {
 		const events: TemporalEvent[] = [];
 		for (const chunk of chunks) {
 			const ts = chunk.timestamp ?? chunk.metadata?.createdAt ?? chunk.metadata?.updatedAt;
@@ -232,7 +274,6 @@ export class TemporalSemanticExtractor implements EdgeExtractor {
 			const time = new Date(ts).getTime();
 			if (Number.isNaN(time)) continue;
 
-			// For issues/PRs, try to build an interval from created→closed/merged
 			let endTime: number | null = null;
 			const closedAt = chunk.metadata?.closedAt ?? chunk.metadata?.mergedAt;
 			if (closedAt) {
@@ -240,12 +281,17 @@ export class TemporalSemanticExtractor implements EdgeExtractor {
 				if (!Number.isNaN(closed)) endTime = closed;
 			}
 
+			// Use documentId for stable target identification (all adapters emit this)
+			const stableId = chunk.documentId ?? chunk.sourceUrl ?? chunk.source;
+
 			events.push({
 				entityId: chunk.id,
 				entityType: chunk.sourceType,
 				source: chunk.source,
+				stableId,
 				timestampStart: time,
 				timestampEnd: endTime,
+				embedding: embeddings.get(chunk.id),
 				text: chunk.content.slice(0, 200),
 			});
 		}

--- a/packages/ingest/src/index.ts
+++ b/packages/ingest/src/index.ts
@@ -34,6 +34,7 @@ export {
 	sha256Hex,
 } from "./chunker.js";
 export {
+	AstHeuristicChunker,
 	CodeWindowChunker,
 	getAvailableChunkers,
 	getChunker,

--- a/packages/ingest/src/index.ts
+++ b/packages/ingest/src/index.ts
@@ -112,6 +112,12 @@ export {
 } from "./edges/overlay-store.js";
 export { TemporalEdgeExtractor, type TemporalEdgeExtractorOptions } from "./edges/temporal.js";
 export {
+	type TemporalEdgeType,
+	type TemporalEvent,
+	TemporalSemanticExtractor,
+	type TemporalSemanticOptions,
+} from "./edges/temporal-semantic.js";
+export {
 	TreeSitterEdgeExtractor,
 	type TreeSitterEdgeExtractorOptions,
 } from "./edges/tree-sitter.js";

--- a/packages/ingest/src/index.ts
+++ b/packages/ingest/src/index.ts
@@ -115,6 +115,7 @@ export { TemporalEdgeExtractor, type TemporalEdgeExtractorOptions } from "./edge
 export {
 	type TemporalEdgeType,
 	type TemporalEvent,
+	type TemporalExtractionResult,
 	TemporalSemanticExtractor,
 	type TemporalSemanticOptions,
 } from "./edges/temporal-semantic.js";

--- a/packages/ingest/src/index.ts
+++ b/packages/ingest/src/index.ts
@@ -69,6 +69,8 @@ export { CompositeEdgeExtractor } from "./edges/composite.js";
 export { extractPackageJsonDeps, extractRequirementsTxtDeps } from "./edges/dependency-parser.js";
 export {
 	buildDerivedEdgeLayer,
+	type CompactionStats,
+	compactDerivedLayers,
 	type DerivedEdgeLayer,
 	derivedLayerId,
 	loadDerivedEdgeLayers,

--- a/packages/store/src/schema.test.ts
+++ b/packages/store/src/schema.test.ts
@@ -297,6 +297,27 @@ describe("validateManifestSchema", () => {
 		expect(out.segments[1].pieceCid).toBeUndefined();
 		expect(out.batches).toHaveLength(1);
 	});
+
+	it("preserves derivedEdgeLayers through validation", () => {
+		const layers = [
+			{
+				id: "layer-abc",
+				extractorModel: "test-model",
+				edgeCount: 42,
+				createdAt: "2026-01-01T00:00:00Z",
+				contextsProcessed: 10,
+			},
+		];
+		const input = { ...minimalValidManifest(), derivedEdgeLayers: layers };
+		const out = validateManifestSchema(input);
+		expect(out.derivedEdgeLayers).toEqual(layers);
+	});
+
+	it("returns undefined derivedEdgeLayers when not present", () => {
+		const input = minimalValidManifest();
+		const out = validateManifestSchema(input);
+		expect(out.derivedEdgeLayers).toBeUndefined();
+	});
 });
 
 describe("validateSegmentSchema", () => {

--- a/packages/store/src/schema/manifest.ts
+++ b/packages/store/src/schema/manifest.ts
@@ -283,6 +283,11 @@ export function validateManifestSchema(data: unknown): CollectionHead {
 		manifest.themes = data.themes as CollectionHead["themes"];
 	}
 
+	// Derived edge layers: pass through (optional, from extract-edges)
+	if ("derivedEdgeLayers" in data && Array.isArray(data.derivedEdgeLayers)) {
+		manifest.derivedEdgeLayers = data.derivedEdgeLayers as CollectionHead["derivedEdgeLayers"];
+	}
+
 	if ("batches" in data && data.batches !== undefined) {
 		if (!Array.isArray(data.batches)) {
 			throw schemaInvalid("headManifest", "batches must be an array", "batches");


### PR DESCRIPTION
## Summary

- **Derived edge layer compaction**: `wtfoc compact-edges` merges all derived layers into one canonical layer, deduplicating and dropping orphan edges. Works with 1+ layers.
- **Temporal-semantic edge extractor** (#202): Directional edges (`discussed-before`, `discussed-during`, `addressed-after`, `occurred-during`, `followed-by`) using time ordering + semantic similarity.
- **AST-heuristic code chunker** (#134): Splits code at function/class/method boundaries for TS, JS, Python, Go, Rust, Ruby, Java. Wired into repo adapter via `selectChunker()`.
- **Manifest schema fix**: `derivedEdgeLayers` passthrough in `validateManifestSchema`.

## Test plan

- [x] All 767 tests pass
- [x] Lint clean
- [x] E2E: compact-edges (14→7 edges, 7 deduped)
- [x] E2E: temporal-semantic (361 edges from 500 mixed-type chunks)
- [x] E2E: AST chunker in real ingest (2730 chunks with function-boundary alignment)
- [x] Copilot review: 10 comments addressed
- [x] Codex review: merge blocker fixed, all findings addressed