### PR TITLE
fix(cli): suppress progress output when --json flag is passed

### DIFF
--- a/.specweave/increments/0001-json-flag-progress-suppression/metadata.json
+++ b/.specweave/increments/0001-json-flag-progress-suppression/metadata.json
@@ -1,0 +1,14 @@
+{
+  "id": "0001-json-flag-progress-suppression",
+  "status": "planned",
+  "type": "bug",
+  "priority": "P1",
+  "created": "2026-04-12T19:48:50.931Z",
+  "lastActivity": "2026-04-12T19:48:50.931Z",
+  "testMode": "TDD",
+  "coverageTarget": 80,
+  "feature_id": null,
+  "epic_id": null,
+  "externalLinks": {},
+  "project": "wtfoc3"
+}

--- a/.specweave/increments/0001-json-flag-progress-suppression/plan.md
+++ b/.specweave/increments/0001-json-flag-progress-suppression/plan.md
@@ -1,0 +1,70 @@
+# Implementation Plan: Fix --json flag outputting progress text
+
+<!--
+====================================================================
+  TEMPLATE FILE - MUST BE COMPLETED VIA ARCHITECT SKILL
+====================================================================
+
+This is a TEMPLATE created by increment skill.
+DO NOT manually fill in the placeholders below.
+
+To complete this plan, run:
+  Tell Claude: "Design architecture for increment [ID]"
+
+This will activate the Architect skill which will:
+- Create system architecture diagrams
+- Define data models and API contracts
+- Document architecture decisions (ADRs)
+- Identify technical challenges
+
+====================================================================
+-->
+
+## Overview
+
+[Technical summary of implementation approach]
+
+## Architecture
+
+### Components
+- [Component 1]: [Purpose]
+- [Component 2]: [Purpose]
+
+### Data Model
+- [Entity 1]: [Fields, relationships]
+- [Entity 2]: [Fields, relationships]
+
+### API Contracts
+- `POST /api/resource`: [Purpose, request/response]
+- `GET /api/resource/:id`: [Purpose, request/response]
+
+## Technology Stack
+
+- **Language/Framework**: [Choice]
+- **Libraries**: [List]
+- **Tools**: [List]
+
+**Architecture Decisions**:
+- [Decision 1]: [Why this choice? Alternatives considered?]
+- [Decision 2]: [Rationale]
+
+## Implementation Phases
+
+### Phase 1: Foundation
+- [Setup, infrastructure, base components]
+
+### Phase 2: Core Functionality
+- [Primary features from P1 user stories]
+
+### Phase 3: Enhancement
+- [P2 features and optimizations]
+
+## Testing Strategy
+
+[High-level testing approach - details in tasks.md]
+
+## Technical Challenges
+
+### Challenge 1: [Description]
+**Solution**: [Approach]
+**Risk**: [Mitigation]

--- a/.specweave/increments/0001-json-flag-progress-suppression/spec.md
+++ b/.specweave/increments/0001-json-flag-progress-suppression/spec.md
@@ -1,0 +1,80 @@
+---
+increment: 0001-json-flag-progress-suppression
+title: "Fix --json flag outputting progress text"
+type: bug
+priority: P1
+status: planned
+created: 2026-04-12
+structure: user-stories
+test_mode: TDD
+coverage_target: 80
+---
+
+# Feature: Fix --json flag outputting progress text
+
+## Overview
+
+Suppress spinner/progress output when --json is passed
+
+<!--
+====================================================================
+  TEMPLATE FILE - MUST BE COMPLETED VIA PM/ARCHITECT SKILLS
+====================================================================
+
+This is a TEMPLATE created by increment skill.
+DO NOT manually fill in the placeholders below.
+
+To complete this specification, run:
+  Tell Claude: "Complete the spec for increment 0001-json-flag-progress-suppression"
+
+This will activate the PM skill which will:
+- Define proper user stories with acceptance criteria
+- Conduct market research and competitive analysis
+- Create user personas
+- Define success metrics
+
+====================================================================
+-->
+
+## User Stories
+
+### US-001: [Story Title] (P1)
+**Project**: wtfoc
+
+**As a** [user type]
+**I want** [goal]
+**So that** [benefit]
+
+**Acceptance Criteria**:
+- [ ] **AC-US1-01**: [Specific, testable criterion]
+- [ ] **AC-US1-02**: [Another criterion]
+
+---
+
+### US-002: [Story Title] (P2)
+**Project**: wtfoc
+
+**As a** [user type]
+**I want** [goal]
+**So that** [benefit]
+
+**Acceptance Criteria**:
+- [ ] **AC-US2-01**: [Specific, testable criterion]
+- [ ] **AC-US2-02**: [Another criterion]
+
+## Functional Requirements
+
+### FR-001: [Requirement]
+[Detailed description]
+
+## Success Criteria
+
+[Measurable outcomes - metrics, KPIs]
+
+## Out of Scope
+
+[What this explicitly does NOT include]
+
+## Dependencies
+
+[Other features or systems this depends on]

--- a/.specweave/increments/0001-json-flag-progress-suppression/tasks.md
+++ b/.specweave/increments/0001-json-flag-progress-suppression/tasks.md
@@ -1,0 +1,64 @@
+# Tasks: Fix --json flag outputting progress text
+
+<!--
+====================================================================
+  TEMPLATE FILE - MUST BE COMPLETED VIA TASK BUILDER SKILL
+====================================================================
+
+This is a TEMPLATE created by increment skill.
+DO NOT manually fill in the tasks below.
+
+To complete this task list, run:
+  Tell Claude: "Create tasks for increment [ID]"
+
+This will activate the test-aware planner which will:
+- Generate detailed implementation tasks
+- Add embedded test plans (BDD format)
+- Set task dependencies
+- Assign model hints
+
+====================================================================
+-->
+
+## Task Notation
+
+- `[T###]`: Task ID
+- `[P]`: Parallelizable
+- `[ ]`: Not started
+- `[x]`: Completed
+- Model hints: haiku (simple), opus (default)
+
+## Phase 1: Setup
+
+- [ ] [T001] [P] haiku - Initialize project structure
+- [ ] [T002] haiku - Setup testing framework
+
+## Phase 2: Core Implementation
+
+### US-001: [User Story Title] (P1)
+
+#### T-003: Implement [component]
+
+**Description**: [What needs to be done]
+
+**References**: AC-US1-01, AC-US1-02
+
+**Implementation Details**:
+- [Step 1]
+- [Step 2]
+
+**Test Plan**:
+- **File**: `tests/unit/component.test.ts`
+- **Tests**:
+  - **TC-001**: [Test name]
+    - Given [precondition]
+    - When [action]
+    - Then [expected result]
+
+**Dependencies**: None
+**Status**: [ ] Not Started
+
+## Phase 3: Testing
+
+- [ ] [T050] Run integration tests
+- [ ] [T051] Verify all acceptance criteria

--- a/packages/cli/src/commands/collections.ts
+++ b/packages/cli/src/commands/collections.ts
@@ -15,7 +15,7 @@ export function registerCollectionsCommand(program: Command): void {
 			if (names.length === 0) {
 				if (format === "json") {
 					console.log(JSON.stringify([]));
-				} else if (format !== "quiet") {
+				} else if (format === "human") {
 					console.log("No collections found.");
 				}
 				return;

--- a/packages/cli/src/commands/describe.ts
+++ b/packages/cli/src/commands/describe.ts
@@ -47,7 +47,7 @@ export function registerDescribeCommand(program: Command): void {
 							description: updatedManifest.description ?? null,
 						}),
 					);
-				} else if (format !== "quiet") {
+				} else if (format === "human") {
 					if (opts.clear) {
 						console.log(`Cleared description for "${opts.collection}"`);
 					} else {

--- a/packages/cli/src/commands/extract-edges.ts
+++ b/packages/cli/src/commands/extract-edges.ts
@@ -90,7 +90,7 @@ async function pruneStaleData(
 			updatedAt: new Date().toISOString(),
 		});
 		await writeExtractionStatus(statusPath, statusData);
-		if (format !== "quiet") {
+		if (format === "human") {
 			if (edgesPruned > 0) console.error(`🧹 Pruned ${edgesPruned} stale overlay edges`);
 			if (contextsPruned > 0) console.error(`🧹 Pruned ${contextsPruned} stale status entries`);
 		}
@@ -135,7 +135,7 @@ export function registerExtractEdgesCommand(program: Command): void {
 		}
 		const head = headResult;
 
-		if (format !== "quiet") {
+		if (format === "human") {
 			console.error(`⏳ Loading collection "${opts.collection}"...`);
 		}
 
@@ -145,7 +145,7 @@ export function registerExtractEdgesCommand(program: Command): void {
 		// Map to Chunk interface
 		const allChunks: Chunk[] = segments.flatMap((seg) => seg.chunks.map(segmentChunkToChunk));
 
-		if (format !== "quiet") {
+		if (format === "human") {
 			console.error(`📦 ${allChunks.length} chunks in ${segments.length} segments`);
 		}
 
@@ -218,13 +218,13 @@ export function registerExtractEdgesCommand(program: Command): void {
 		const toProcess = getContextsToProcess(existingStatus, contexts, config.model);
 
 		if (toProcess.length === 0) {
-			if (format !== "quiet") {
+			if (format === "human") {
 				console.error("✅ All contexts already processed. Nothing to do.");
 			}
 			return;
 		}
 
-		if (format !== "quiet") {
+		if (format === "human") {
 			console.error(
 				`🔍 ${toProcess.length}/${contexts.length} contexts to process (${toProcess.reduce((sum, c) => sum + c.chunkIds.length, 0)} chunks)`,
 			);
@@ -244,7 +244,7 @@ export function registerExtractEdgesCommand(program: Command): void {
 		let processed = 0;
 		const contextConcurrency = Math.max(1, Number.parseInt(opts.contextConcurrency, 10) || 4);
 
-		if (format !== "quiet" && contextConcurrency > 1) {
+		if (format === "human" && contextConcurrency > 1) {
 			console.error(`   Context concurrency: ${contextConcurrency}`);
 		}
 
@@ -271,7 +271,7 @@ export function registerExtractEdgesCommand(program: Command): void {
 			if (!chunksForContext || chunksForContext.length === 0) return;
 
 			const idx = ++processed;
-			if (format !== "quiet") {
+			if (format === "human") {
 				console.error(
 					`  [${idx}/${toProcess.length}] Extracting: ${ctx.contextId} (${chunksForContext.length} chunks)...`,
 				);
@@ -336,7 +336,7 @@ export function registerExtractEdgesCommand(program: Command): void {
 		// Wait for remaining
 		await Promise.all(active);
 
-		if (signal.aborted && format !== "quiet") {
+		if (signal.aborted && format === "human") {
 			console.error(`\n⚠️  Cancelled. ${processed} contexts processed before abort.`);
 		}
 
@@ -376,12 +376,12 @@ export function registerExtractEdgesCommand(program: Command): void {
 				await store.manifests.putHead(opts.collection, manifest, currentHead.headId);
 			}
 
-			if (format !== "quiet") {
+			if (format === "human") {
 				console.error(`   📦 Stored derived edge layer: ${layerStorageResult.id.slice(0, 16)}...`);
 			}
 		}
 
-		if (format !== "quiet") {
+		if (format === "human") {
 			console.error(`\n✅ Done. ${totalNewEdges} new edges extracted.`);
 			console.error(
 				`   Contexts: ${completed} completed, ${failed} failed, ${contexts.length} total`,

--- a/packages/cli/src/commands/ingest.ts
+++ b/packages/cli/src/commands/ingest.ts
@@ -132,7 +132,7 @@ export function registerIngestCommand(program: Command): void {
 			const extractorConfig = resolveExtractorConfig(opts);
 
 			// Initialize embedder
-			if (format !== "quiet") console.error("⏳ Loading embedder...");
+			if (format === "human") console.error("⏳ Loading embedder...");
 			const { embedder, modelName } = createEmbedder(opts, getProjectConfig()?.embedder);
 
 			// Detect model mismatch
@@ -204,13 +204,13 @@ export function registerIngestCommand(program: Command): void {
 				const storedSince = getCursorSince(cursorData, sourceKey);
 				if (storedSince) {
 					rawConfig.since = storedSince;
-					if (format !== "quiet") {
+					if (format === "human") {
 						console.error(`   Resuming from cursor: ${storedSince}`);
 					}
 				}
 			}
 
-			if (format !== "quiet") console.error(`⏳ Ingesting ${sourceType}: ${sourceArg}...`);
+			if (format === "human") console.error(`⏳ Ingesting ${sourceType}: ${sourceArg}...`);
 
 			const config = adapter.parseConfig(rawConfig);
 			// Pass raw ignore pattern sources to repo adapter for unified filter construction
@@ -257,7 +257,7 @@ export function registerIngestCommand(program: Command): void {
 						knownFingerprints.add(fp);
 					}
 				}
-				if (knownChunkIds.size > 0 && format !== "quiet") {
+				if (knownChunkIds.size > 0 && format === "human") {
 					console.error(
 						`   ${knownChunkIds.size} existing chunks from catalog (fast dedup, ${knownFingerprints.size} fingerprints)`,
 					);
@@ -278,7 +278,7 @@ export function registerIngestCommand(program: Command): void {
 						// Segment may not be downloadable (e.g. FOC-only), skip
 					}
 				}
-				if (knownChunkIds.size > 0 && format !== "quiet") {
+				if (knownChunkIds.size > 0 && format === "human") {
 					console.error(`   ${knownChunkIds.size} existing chunks from segments (legacy dedup)`);
 				}
 			}
@@ -317,13 +317,13 @@ export function registerIngestCommand(program: Command): void {
 				return true;
 			}
 
-			if (filterDocIds && format !== "quiet") {
+			if (filterDocIds && format === "human") {
 				console.error(`   Filtering to ${filterDocIds.size} document ID(s)`);
 			}
-			if (filterPaths && format !== "quiet") {
+			if (filterPaths && format === "human") {
 				console.error(`   Filtering to ${filterPaths.length} source path(s)`);
 			}
-			if (filterChangedSince && format !== "quiet") {
+			if (filterChangedSince && format === "human") {
 				console.error(`   Filtering to documents changed since ${opts.changedSince}`);
 			}
 
@@ -380,7 +380,7 @@ export function registerIngestCommand(program: Command): void {
 				]);
 
 				// Embed this batch
-				if (format !== "quiet")
+				if (format === "human")
 					console.error(`⏳ Embedding batch ${batchNumber} (${batchChunks.length} chunks)...`);
 				const embeddings = await embedder.embedBatch(batchChunks.map((c) => c.content));
 
@@ -413,21 +413,21 @@ export function registerIngestCommand(program: Command): void {
 				let batchForManifest: import("@wtfoc/common").BatchRecord | undefined;
 
 				if (storageType === "foc") {
-					if (format !== "quiet") console.error("⏳ Bundling into CAR...");
+					if (format === "human") console.error("⏳ Bundling into CAR...");
 					const bundleResult = await bundleAndUpload(
 						[{ id: segId, data: segmentBytes }],
 						store.storage,
 					);
 					resultId = bundleResult.segmentCids.get(segId) ?? segId;
 					batchForManifest = bundleResult.batch;
-					if (format !== "quiet")
+					if (format === "human")
 						console.error(
 							`   Segment bundled: ${resultId.slice(0, 16)}... (PieceCID: ${bundleResult.batch.pieceCid.slice(0, 16)}...)`,
 						);
 				} else {
 					const segmentResult = await store.storage.upload(segmentBytes);
 					resultId = segmentResult.id;
-					if (format !== "quiet") console.error(`   Segment stored: ${resultId.slice(0, 16)}...`);
+					if (format === "human") console.error(`   Segment stored: ${resultId.slice(0, 16)}...`);
 				}
 
 				// Re-read head for each batch to avoid manifest conflicts
@@ -532,7 +532,7 @@ export function registerIngestCommand(program: Command): void {
 					}
 					batch.push(chunk);
 					if (batch.length >= maxBatch) {
-						if (format !== "quiet")
+						if (format === "human")
 							console.error(`   ${totalChunksIngested + batch.length} chunks so far...`);
 						await flushBatch(batch);
 						batch = [];
@@ -608,7 +608,7 @@ export function registerIngestCommand(program: Command): void {
 						const oldDocId = `${repo}/${oldPath}`;
 						renameDocument(catalog, oldDocId);
 					}
-					if (format !== "quiet" && renames.length > 0) {
+					if (format === "human" && renames.length > 0) {
 						console.error(`   📋 ${renames.length} renamed file(s) archived in catalog`);
 					}
 				}
@@ -617,7 +617,7 @@ export function registerIngestCommand(program: Command): void {
 				if (totalArchived > 0) {
 					await writeArchiveIndex(arcPath, archiveIndex);
 				}
-				if (format !== "quiet" && (totalDocsSuperseded > 0 || totalArchived > 0)) {
+				if (format === "human" && (totalDocsSuperseded > 0 || totalArchived > 0)) {
 					const parts: string[] = [];
 					if (catalogPendingChunks.size > 0)
 						parts.push(`${catalogPendingChunks.size} documents tracked`);
@@ -628,11 +628,11 @@ export function registerIngestCommand(program: Command): void {
 			}
 
 			if (totalChunksIngested === 0 && totalChunksSkipped === 0) {
-				if (format !== "quiet") console.error("⚠️  No chunks produced — skipping upload");
+				if (format === "human") console.error("⚠️  No chunks produced — skipping upload");
 				return;
 			}
 
-			if (format !== "quiet") {
+			if (format === "human") {
 				const parts = [`${totalChunksIngested} chunks`];
 				if (batchNumber > 1) parts[0] += ` (${batchNumber} batches)`;
 				if (rechunkedCount > 0) parts.push(`${rechunkedCount} from oversized splits`);
@@ -647,7 +647,7 @@ export function registerIngestCommand(program: Command): void {
 			// Persist cursor after successful ingest (FR-001, FR-004: only on success)
 			// IMPORTANT: Don't advance cursor when filter flags are active — partial runs
 			// should not skip unprocessed changes on the next full ingest
-			if (isPartialRun && format !== "quiet") {
+			if (isPartialRun && format === "human") {
 				console.error("   ⚠️  Partial run (filter flags active) — cursor not advanced");
 			}
 
@@ -678,7 +678,7 @@ export function registerIngestCommand(program: Command): void {
 					chunksIngested: totalChunksIngested,
 				};
 				await writeCursors(cursorPath, updatedCursors);
-				if (format !== "quiet") {
+				if (format === "human") {
 					console.error(`   Saved cursor for next run: ${nextCursorValue}`);
 				}
 			}

--- a/packages/cli/src/commands/materialize-edges.ts
+++ b/packages/cli/src/commands/materialize-edges.ts
@@ -36,7 +36,7 @@ export function registerMaterializeEdgesCommand(program: Command): void {
 			const overlay = await readOverlayEdges(overlayPath);
 
 			if (!overlay || overlay.edges.length === 0) {
-				if (format !== "quiet") {
+				if (format === "human") {
 					console.error(
 						`No overlay edges found for "${opts.collection}". Run extract-edges first.`,
 					);
@@ -44,7 +44,7 @@ export function registerMaterializeEdgesCommand(program: Command): void {
 				return;
 			}
 
-			if (format !== "quiet") {
+			if (format === "human") {
 				console.error(
 					`🔗 Materializing ${overlay.edges.length} overlay edges into ${head.manifest.segments.length} segments`,
 				);
@@ -151,7 +151,7 @@ export function registerMaterializeEdgesCommand(program: Command): void {
 					chunkCount: segSummary.chunkCount,
 				});
 
-				if (format !== "quiet") {
+				if (format === "human") {
 					console.error(
 						`   ✅ Segment ${segSummary.id.slice(0, 16)}... → ${result.id.slice(0, 16)}... (+${relevantOverlay.length} edges)`,
 					);
@@ -160,7 +160,7 @@ export function registerMaterializeEdgesCommand(program: Command): void {
 
 			// Handle orphan overlay edges (sourceId doesn't match any segment chunk)
 			const orphanEdges = overlay.edges.filter((e) => !placedEdgeKeys.has(edgeKey(e)));
-			if (orphanEdges.length > 0 && format !== "quiet") {
+			if (orphanEdges.length > 0 && format === "human") {
 				console.error(
 					`   ⚠️  ${orphanEdges.length} overlay edges couldn't be placed (sourceId not in any segment)`,
 				);
@@ -194,7 +194,7 @@ export function registerMaterializeEdgesCommand(program: Command): void {
 						orphanEdges: orphanEdges.length,
 					}),
 				);
-			} else if (format !== "quiet") {
+			} else if (format === "human") {
 				console.error(`\n✅ Materialized ${totalEdgesMerged} overlay edges into segments`);
 				console.error(`   ${newSegmentRefs.length} segments rebuilt with merged edges`);
 				if (orphanEdges.length > 0) {

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -64,7 +64,7 @@ export function registerPromoteCommand(program: Command): void {
 				// All segments already on Filecoin — just upload/re-upload the manifest
 				const privateKey = process.env.WTFOC_PRIVATE_KEY;
 				if (!privateKey) {
-					if (format !== "quiet") {
+					if (format === "human") {
 						console.error(`✅ Collection "${collectionName}" is already fully promoted to FOC.`);
 						console.error(
 							"   Set WTFOC_PRIVATE_KEY to re-upload the manifest and get a shareable CID.",
@@ -73,7 +73,7 @@ export function registerPromoteCommand(program: Command): void {
 					return;
 				}
 
-				if (format !== "quiet") {
+				if (format === "human") {
 					console.error(`✅ Segments already on Filecoin. Uploading manifest...`);
 				}
 
@@ -94,7 +94,7 @@ export function registerPromoteCommand(program: Command): void {
 							chunks: head.manifest.totalChunks,
 						}),
 					);
-				} else if (format !== "quiet") {
+				} else if (format === "human") {
 					console.error(`   Manifest CID: ${manifestCid}`);
 					if (existingBatches.length > 0) {
 						const lastBatch = existingBatches[existingBatches.length - 1];
@@ -110,7 +110,7 @@ export function registerPromoteCommand(program: Command): void {
 				process.exit(0);
 			}
 
-			if (format !== "quiet") {
+			if (format === "human") {
 				console.error(`📦 Promoting "${collectionName}" to FOC`);
 				console.error(
 					`   ${segmentsToPromote.length} segments to upload (${head.manifest.totalChunks} chunks)`,
@@ -142,14 +142,14 @@ export function registerPromoteCommand(program: Command): void {
 			const bundleSegments: { id: string; data: Uint8Array }[] = [];
 
 			for (const seg of segmentsToPromote) {
-				if (format !== "quiet") {
+				if (format === "human") {
 					console.error(`   ⏳ Reading segment ${seg.id.slice(0, 16)}...`);
 				}
 				const data = await localStore.storage.download(seg.id);
 				bundleSegments.push({ id: seg.id, data });
 			}
 
-			if (format !== "quiet") {
+			if (format === "human") {
 				console.error("   ⏳ Bundling segments + manifest into CAR and uploading to FOC...");
 			}
 
@@ -204,7 +204,7 @@ export function registerPromoteCommand(program: Command): void {
 			await localStore.manifests.putHead(collectionName, finalManifest, head.headId);
 
 			// Post-upload IPNI validation
-			if (format !== "quiet") {
+			if (format === "human") {
 				console.error("   ⏳ Validating IPNI indexing...");
 			}
 
@@ -230,7 +230,7 @@ export function registerPromoteCommand(program: Command): void {
 						},
 					}),
 				);
-			} else if (format !== "quiet") {
+			} else if (format === "human") {
 				console.error(`\n✅ Promoted "${collectionName}" to FOC`);
 				if (manifestCid) {
 					console.error(`   Manifest CID: ${manifestCid}`);

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -12,12 +12,12 @@ export function registerPullCommand(program: Command): void {
 			const store = getStore(program);
 			const format = getFormat(program.opts());
 
-			if (format !== "quiet") console.error(`⏳ Fetching manifest from CID ${cid}...`);
+			if (format === "human") console.error(`⏳ Fetching manifest from CID ${cid}...`);
 
 			const { manifest, storage: remoteStorage } = await resolveCollectionByCid(cid);
 			const name = opts.name ?? manifest.name;
 
-			if (format !== "quiet") {
+			if (format === "human") {
 				console.error(`📦 Collection: "${manifest.name}"`);
 				console.error(
 					`   ${manifest.totalChunks} chunks, ${manifest.segments.length} segments, ${manifest.embeddingModel} (${manifest.embeddingDimensions}d)`,
@@ -54,7 +54,7 @@ export function registerPullCommand(program: Command): void {
 				}
 				downloaded++;
 
-				if (format !== "quiet" && downloaded % 50 === 0) {
+				if (format === "human" && downloaded % 50 === 0) {
 					console.error(`   ${downloaded}/${manifest.segments.length} segments downloaded...`);
 				}
 			}
@@ -62,7 +62,7 @@ export function registerPullCommand(program: Command): void {
 			// Save manifest locally
 			await store.manifests.putHead(name, manifest, null);
 
-			if (format !== "quiet") {
+			if (format === "human") {
 				console.error(
 					`\n✅ Pulled "${name}" — ${manifest.totalChunks} chunks in ${downloaded} segments`,
 				);

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -35,7 +35,7 @@ export function registerQueryCommand(program: Command): void {
 			process.exit(1);
 		}
 
-		if (format !== "quiet") console.error("⏳ Loading embedder + index...");
+		if (format === "human") console.error("⏳ Loading embedder + index...");
 		const { embedder } = createEmbedder(opts, getProjectConfig()?.embedder);
 
 		// Load document catalog to exclude archived/superseded chunks from search

--- a/packages/cli/src/commands/reindex.ts
+++ b/packages/cli/src/commands/reindex.ts
@@ -69,10 +69,10 @@ export function registerReindexCommand(program: Command): void {
 			}
 
 			// Probe embed to detect dimensions (OpenAI-compatible embedders auto-detect on first call)
-			if (format !== "quiet") console.error("⏳ Detecting embedding dimensions...");
+			if (format === "human") console.error("⏳ Detecting embedding dimensions...");
 			await embedder.embed("dimension probe");
 
-			if (format !== "quiet") {
+			if (format === "human") {
 				console.error(
 					`🔄 Re-indexing "${opts.collection}"${targetName !== opts.collection ? ` → "${targetName}"` : ""}`,
 				);
@@ -112,7 +112,7 @@ export function registerReindexCommand(program: Command): void {
 				}
 			}
 
-			if (format !== "quiet") {
+			if (format === "human") {
 				console.error(`   Loaded ${allChunks.length} chunks and ${allEdges.length} edges`);
 			}
 
@@ -155,7 +155,7 @@ export function registerReindexCommand(program: Command): void {
 				const rechunked = rechunkOversized(oversized, maxChars);
 				chunksToEmbed.push(...rechunked);
 
-				if (format !== "quiet") {
+				if (format === "human") {
 					if (preservedChunks.length > 0) {
 						console.error(
 							`   Preserved ${preservedChunks.length} chunks, re-chunked ${oversized.length} oversized → ${rechunked.length} new chunks`,
@@ -182,7 +182,7 @@ export function registerReindexCommand(program: Command): void {
 				const batchNum = Math.floor(i / batchSize) + 1;
 				const totalBatches = Math.ceil(chunksToEmbed.length / batchSize);
 
-				if (format !== "quiet" && chunksToEmbed.length > 0) {
+				if (format === "human" && chunksToEmbed.length > 0) {
 					console.error(
 						`⏳ Embedding batch ${batchNum}/${totalBatches} (${batchChunks.length} chunks)...`,
 					);
@@ -222,7 +222,7 @@ export function registerReindexCommand(program: Command): void {
 				let batchRecord: import("@wtfoc/common").BatchRecord | undefined;
 
 				if (storageType === "foc") {
-					if (format !== "quiet") console.error("⏳ Bundling into CAR...");
+					if (format === "human") console.error("⏳ Bundling into CAR...");
 					const bundleResult = await bundleAndUpload(
 						[{ id: segId, data: segmentBytes }],
 						store.storage,
@@ -234,7 +234,7 @@ export function registerReindexCommand(program: Command): void {
 					resultId = segmentResult.id;
 				}
 
-				if (format !== "quiet") {
+				if (format === "human") {
 					console.error(`   Segment stored: ${resultId.slice(0, 16)}...`);
 				}
 
@@ -287,7 +287,7 @@ export function registerReindexCommand(program: Command): void {
 						chunks: chunksProcessed,
 					}),
 				);
-			} else if (format !== "quiet") {
+			} else if (format === "human") {
 				console.error(
 					`\n✅ Re-indexed "${opts.collection}"${targetName !== opts.collection ? ` → "${targetName}"` : ""}`,
 				);

--- a/packages/cli/src/commands/reingest.ts
+++ b/packages/cli/src/commands/reingest.ts
@@ -83,10 +83,10 @@ export function registerReingestCommand(program: Command): void {
 			const ignoreFilter = createIgnoreFilter(projectCfg?.ignore, opts.ignore);
 
 			// Probe embedder dimensions
-			if (format !== "quiet") console.error("⏳ Detecting embedding dimensions...");
+			if (format === "human") console.error("⏳ Detecting embedding dimensions...");
 			await embedder.embed("dimension probe");
 
-			if (format !== "quiet") {
+			if (format === "human") {
 				console.error(
 					`🔄 Reingesting "${opts.collection}"${targetName !== opts.collection ? ` → "${targetName}"` : ""}`,
 				);
@@ -126,7 +126,7 @@ export function registerReingestCommand(program: Command): void {
 				}
 			}
 
-			if (format !== "quiet") {
+			if (format === "human") {
 				console.error(
 					`   Loaded ${allChunks.length} chunks (${filteredCount} filtered by ignore patterns)`,
 				);
@@ -149,7 +149,7 @@ export function registerReingestCommand(program: Command): void {
 				const rechunked = rechunkOversized(oversized, maxChars);
 				chunksToProcess = [...withinLimit, ...rechunked];
 
-				if (format !== "quiet" && oversized.length > 0) {
+				if (format === "human" && oversized.length > 0) {
 					console.error(
 						`   Rechunked ${oversized.length} oversized → ${rechunked.length} new chunks`,
 					);
@@ -192,7 +192,7 @@ export function registerReingestCommand(program: Command): void {
 				]);
 
 				// Embed
-				if (format !== "quiet") {
+				if (format === "human") {
 					console.error(
 						`⏳ Batch ${batchNum}/${totalBatches}: embedding ${batchChunks.length} chunks...`,
 					);
@@ -255,7 +255,7 @@ export function registerReingestCommand(program: Command): void {
 
 				await store.manifests.putHead(targetName, manifest, prevHeadId);
 
-				if (format !== "quiet") {
+				if (format === "human") {
 					console.error(`   Segment stored: ${result.id.slice(0, 16)}...`);
 				}
 			}
@@ -270,7 +270,7 @@ export function registerReingestCommand(program: Command): void {
 						chunksFiltered: filteredCount,
 					}),
 				);
-			} else if (format !== "quiet") {
+			} else if (format === "human") {
 				console.error(
 					`\n✅ Reingested "${opts.collection}"${targetName !== opts.collection ? ` → "${targetName}"` : ""}`,
 				);

--- a/packages/cli/src/commands/suggest-sources.ts
+++ b/packages/cli/src/commands/suggest-sources.ts
@@ -18,7 +18,7 @@ export function registerSuggestSourcesCommand(program: Command): void {
 				process.exit(1);
 			}
 
-			if (format !== "quiet") console.error("⏳ Scanning collection for external references...");
+			if (format === "human") console.error("⏳ Scanning collection for external references...");
 
 			// Track what's already ingested
 			const ingestedRepos = new Set<string>();

--- a/packages/cli/src/commands/themes.ts
+++ b/packages/cli/src/commands/themes.ts
@@ -167,7 +167,7 @@ export function registerThemesCommand(program: Command): void {
 				return;
 			}
 
-			if (format !== "quiet") console.error("Loading collection...");
+			if (format === "human") console.error("Loading collection...");
 			const { segments } = await loadCollection(store, head.manifest);
 
 			const idToContent = new Map<string, string>();
@@ -197,7 +197,7 @@ export function registerThemesCommand(program: Command): void {
 			// Check if stored snapshot is still fresh (skip expensive recompute)
 			const stored = head.manifest.themes;
 			if (stored && !opts.force && isSnapshotFresh(stored, ids.length, filteredCount, threshold)) {
-				if (format !== "quiet") console.error("Themes are up to date (use --force to recompute).");
+				if (format === "human") console.error("Themes are up to date (use --force to recompute).");
 				if (format === "json") {
 					console.log(JSON.stringify(stored, null, "\t"));
 					return;
@@ -207,7 +207,7 @@ export function registerThemesCommand(program: Command): void {
 				return;
 			}
 
-			if (format !== "quiet") {
+			if (format === "human") {
 				const filterMsg = filteredCount > 0 ? `, ${filteredCount} config chunks filtered` : "";
 				console.error(`Clustering ${ids.length} chunks (threshold=${threshold}${filterMsg})...`);
 			}
@@ -234,7 +234,7 @@ export function registerThemesCommand(program: Command): void {
 			let noiseCategories: Array<{ name: string; count: number; description: string }> = [];
 			if (llmConfig.enabled) {
 				const enabledConfig = llmConfig as LlmExtractorEnabled;
-				if (format !== "quiet") console.error("Generating LLM labels...");
+				if (format === "human") console.error("Generating LLM labels...");
 
 				const clusterRequests = result.clusters.map((c) => ({
 					clusterId: c.id,
@@ -250,7 +250,7 @@ export function registerThemesCommand(program: Command): void {
 				}
 
 				if (result.noise.length > 0) {
-					if (format !== "quiet") console.error("Summarizing noise...");
+					if (format === "human") console.error("Summarizing noise...");
 					const noiseContents = result.noise
 						.map((id) => idToContent.get(id))
 						.filter((s): s is string => s !== undefined);
@@ -288,7 +288,7 @@ export function registerThemesCommand(program: Command): void {
 					updatedAt: new Date().toISOString(),
 				};
 				await store.manifests.putHead(opts.collection, updatedManifest, head.headId);
-				if (format !== "quiet") console.error("Themes persisted to collection manifest.");
+				if (format === "human") console.error("Themes persisted to collection manifest.");
 			}
 
 			if (format === "json") {

--- a/packages/cli/src/commands/trace.ts
+++ b/packages/cli/src/commands/trace.ts
@@ -67,7 +67,7 @@ export function registerTraceCommand(program: Command): void {
 				process.exit(1);
 			}
 
-			if (format !== "quiet") console.error("⏳ Loading embedder + index...");
+			if (format === "human") console.error("⏳ Loading embedder + index...");
 			const { embedder } = createEmbedder(opts, getProjectConfig()?.embedder);
 
 			// Load document catalog — trace includes archived chunks for historical context
@@ -88,7 +88,7 @@ export function registerTraceCommand(program: Command): void {
 				derivedEdges = await loadDerivedEdgeLayers(derivedLayers, (id, s) =>
 					store.storage.download(id, s),
 				);
-				if (format !== "quiet") {
+				if (format === "human") {
 					console.error(
 						`🔗 Loaded ${derivedEdges.length} edges from ${derivedLayers.length} derived layer(s)`,
 					);
@@ -99,7 +99,7 @@ export function registerTraceCommand(program: Command): void {
 			if (derivedEdges.length === 0) {
 				const overlay = await readOverlayEdges(overlayFilePath(manifestDir, opts.collection));
 				derivedEdges = overlay?.edges ?? [];
-				if (derivedEdges.length > 0 && format !== "quiet") {
+				if (derivedEdges.length > 0 && format === "human") {
 					console.error(`🔗 Loaded ${derivedEdges.length} overlay edges (legacy)`);
 				}
 			}

--- a/packages/cli/src/commands/unresolved-edges.ts
+++ b/packages/cli/src/commands/unresolved-edges.ts
@@ -19,7 +19,7 @@ export function registerUnresolvedEdgesCommand(program: Command): void {
 				process.exit(1);
 			}
 
-			if (format !== "quiet") console.error("⏳ Loading segments...");
+			if (format === "human") console.error("⏳ Loading segments...");
 
 			const allSegments: Segment[] = [];
 			for (const segSummary of head.manifest.segments) {


### PR DESCRIPTION
## Summary

- All CLI commands used `format !== "quiet"` to gate progress messages, which let them through in `--json` mode
- Changed to `format === "human"` so progress/spinner output is only shown in human-readable mode
- 14 command files updated (~75 occurrences), zero logic changes beyond the condition flip

## Test plan

- [x] All 752 tests pass (`pnpm test`)
- [x] Lint clean (`pnpm lint:fix`)
- [x] Zero remaining `format !== "quiet"` occurrences in CLI commands
- [x] Manual: `wtfoc query "test" -c <collection> --json 2>/dev/null | jq .` produces clean JSON

fixes #190