### PR TITLE
fix: collection name validation and sidecar file filtering

### DIFF
--- a/packages/cli/src/commands/ingest.ts
+++ b/packages/cli/src/commands/ingest.ts
@@ -35,7 +35,7 @@ import {
 	writeCatalog,
 	writeCursors,
 } from "@wtfoc/ingest";
-import { bundleAndUpload, generateCollectionId } from "@wtfoc/store";
+import { bundleAndUpload, generateCollectionId, validateCollectionName } from "@wtfoc/store";
 import type { Command } from "commander";
 import { getProjectConfig } from "../cli.js";
 import { type ExtractorCliOpts, resolveExtractorConfig } from "../extractor-config.js";
@@ -124,6 +124,14 @@ export function registerIngestCommand(program: Command): void {
 		) => {
 			const store = getStore(program);
 			const format = getFormat(program.opts());
+
+			// Validate collection name early (before any work)
+			try {
+				validateCollectionName(opts.collection);
+			} catch (err) {
+				console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+				process.exit(2);
+			}
 
 			// Get or create manifest
 			const head = await store.manifests.getHead(opts.collection);

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -24,7 +24,7 @@ export {
 export { computeRevisionDiff, generateContentIdentity, type RevisionDiff } from "./diff.js";
 export type { Store, StoreConfig } from "./factory.js";
 export { createStore } from "./factory.js";
-export { LocalManifestStore } from "./manifest/local.js";
+export { LocalManifestStore, validateCollectionName } from "./manifest/local.js";
 export { deserializeRevision, serializeRevision } from "./revision.js";
 export {
 	MAX_SUPPORTED_SCHEMA_VERSION,

--- a/packages/store/src/manifest/local.test.ts
+++ b/packages/store/src/manifest/local.test.ts
@@ -186,6 +186,16 @@ describe("LocalManifestStore", () => {
 			expect(() => validateCollectionName("foo/bar")).toThrow("Invalid collection name");
 			expect(() => validateCollectionName("foo@bar")).toThrow("Invalid collection name");
 		});
+
+		it("rejects names longer than 128 characters", () => {
+			const longName = "a".repeat(129);
+			expect(() => validateCollectionName(longName)).toThrow("too long");
+		});
+
+		it("accepts names up to 128 characters", () => {
+			const maxName = "a".repeat(128);
+			expect(() => validateCollectionName(maxName)).not.toThrow();
+		});
 	});
 
 	describe("listProjects excludes sidecar files", () => {
@@ -218,14 +228,14 @@ describe("LocalManifestStore", () => {
 		});
 	});
 
-	describe("getHead returns null for non-manifest files", () => {
-		it("returns null for sidecar JSON files", async () => {
+	describe("getHead returns null for invalid manifest files", () => {
+		it("returns null for JSON that is not a valid manifest", async () => {
 			await writeFile(
-				join(manifestDir, "test-sidecar.json"),
+				join(manifestDir, "invalid-manifest.json"),
 				JSON.stringify({ cursors: {}, notAManifest: true }),
 			);
 			const store = new LocalManifestStore(manifestDir);
-			const head = await store.getHead("test-sidecar");
+			const head = await store.getHead("invalid-manifest");
 			expect(head).toBeNull();
 		});
 

--- a/packages/store/src/manifest/local.test.ts
+++ b/packages/store/src/manifest/local.test.ts
@@ -1,9 +1,9 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CollectionHead } from "@wtfoc/common";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { LocalManifestStore } from "./local.js";
+import { LocalManifestStore, validateCollectionName } from "./local.js";
 
 function makeManifest(overrides?: Partial<CollectionHead>): CollectionHead {
 	return {
@@ -161,6 +161,79 @@ describe("LocalManifestStore", () => {
 			const result = await nestedStore.putHead("nested-test", manifest, null);
 
 			expect(result.headId).toBeTruthy();
+		});
+	});
+
+	describe("collection name validation", () => {
+		it("accepts valid names (letters, numbers, hyphens, underscores)", () => {
+			expect(() => validateCollectionName("my-collection")).not.toThrow();
+			expect(() => validateCollectionName("test_v2")).not.toThrow();
+			expect(() => validateCollectionName("foc-ecosystem-v2")).not.toThrow();
+			expect(() => validateCollectionName("ABC123")).not.toThrow();
+		});
+
+		it("rejects names containing dots", () => {
+			expect(() => validateCollectionName("my.collection")).toThrow("Invalid collection name");
+			expect(() => validateCollectionName("foo.bar.baz")).toThrow("Invalid collection name");
+		});
+
+		it("rejects empty names", () => {
+			expect(() => validateCollectionName("")).toThrow("Invalid collection name");
+		});
+
+		it("rejects names with spaces or special characters", () => {
+			expect(() => validateCollectionName("my collection")).toThrow("Invalid collection name");
+			expect(() => validateCollectionName("foo/bar")).toThrow("Invalid collection name");
+			expect(() => validateCollectionName("foo@bar")).toThrow("Invalid collection name");
+		});
+	});
+
+	describe("listProjects excludes sidecar files", () => {
+		it("only returns manifest files, not sidecars", async () => {
+			const store = new LocalManifestStore(manifestDir);
+
+			// Create a valid manifest
+			const manifest = makeManifest({ name: "real-collection" });
+			await store.putHead("real-collection", manifest, null);
+
+			// Create sidecar files that should be excluded
+			await writeFile(
+				join(manifestDir, "real-collection.ingest-cursors.json"),
+				JSON.stringify({ schemaVersion: 1, cursors: {} }),
+			);
+			await writeFile(
+				join(manifestDir, "real-collection.document-catalog.json"),
+				JSON.stringify({ schemaVersion: 1, documents: {} }),
+			);
+			await writeFile(
+				join(manifestDir, "real-collection.edges-overlay.json"),
+				JSON.stringify({ edges: [] }),
+			);
+
+			const projects = await store.listProjects();
+			expect(projects).toContain("real-collection");
+			expect(projects).not.toContain("real-collection.ingest-cursors");
+			expect(projects).not.toContain("real-collection.document-catalog");
+			expect(projects).not.toContain("real-collection.edges-overlay");
+		});
+	});
+
+	describe("getHead returns null for non-manifest files", () => {
+		it("returns null for sidecar JSON files", async () => {
+			await writeFile(
+				join(manifestDir, "test-sidecar.json"),
+				JSON.stringify({ cursors: {}, notAManifest: true }),
+			);
+			const store = new LocalManifestStore(manifestDir);
+			const head = await store.getHead("test-sidecar");
+			expect(head).toBeNull();
+		});
+
+		it("returns null for corrupt JSON", async () => {
+			await writeFile(join(manifestDir, "corrupt.json"), "not json at all");
+			const store = new LocalManifestStore(manifestDir);
+			const head = await store.getHead("corrupt");
+			expect(head).toBeNull();
 		});
 	});
 });

--- a/packages/store/src/manifest/local.ts
+++ b/packages/store/src/manifest/local.ts
@@ -6,10 +6,11 @@ import { ManifestConflictError, WtfocError } from "@wtfoc/common";
 import { validateManifestSchema } from "../schema.js";
 
 /**
- * Pattern matching manifest files: name with no dots, followed by .json.
+ * Pattern matching manifest files: valid collection name followed by .json.
+ * Must match the same character set as VALID_COLLECTION_NAME.
  * Excludes sidecar files like {name}.ingest-cursors.json, {name}.document-catalog.json, etc.
  */
-const MANIFEST_FILE_PATTERN = /^[^.]+\.json$/;
+const MANIFEST_FILE_PATTERN = /^[a-zA-Z0-9_-]+\.json$/;
 
 /**
  * Valid collection name pattern: alphanumeric, hyphens, underscores.
@@ -24,7 +25,14 @@ const VALID_COLLECTION_NAME = /^[a-zA-Z0-9_-]+$/;
 export function validateCollectionName(name: string): void {
 	if (!name || !VALID_COLLECTION_NAME.test(name)) {
 		throw new WtfocError(
-			`Invalid collection name "${name}": must contain only letters, numbers, hyphens, and underscores (no dots)`,
+			`Invalid collection name "${name}": must contain only letters, numbers, hyphens, and underscores (1-128 chars, no dots)`,
+			"COLLECTION_INVALID_NAME",
+			{ projectName: name },
+		);
+	}
+	if (name.length > 128) {
+		throw new WtfocError(
+			`Collection name too long (${name.length} chars): max 128 characters`,
 			"COLLECTION_INVALID_NAME",
 			{ projectName: name },
 		);

--- a/packages/store/src/manifest/local.ts
+++ b/packages/store/src/manifest/local.ts
@@ -6,6 +6,32 @@ import { ManifestConflictError, WtfocError } from "@wtfoc/common";
 import { validateManifestSchema } from "../schema.js";
 
 /**
+ * Pattern matching manifest files: name with no dots, followed by .json.
+ * Excludes sidecar files like {name}.ingest-cursors.json, {name}.document-catalog.json, etc.
+ */
+const MANIFEST_FILE_PATTERN = /^[^.]+\.json$/;
+
+/**
+ * Valid collection name pattern: alphanumeric, hyphens, underscores.
+ * No dots allowed — dots are used to separate collection names from sidecar suffixes.
+ */
+const VALID_COLLECTION_NAME = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * Validate a collection name. Throws if the name contains dots or other
+ * characters that would create ambiguity with sidecar file naming.
+ */
+export function validateCollectionName(name: string): void {
+	if (!name || !VALID_COLLECTION_NAME.test(name)) {
+		throw new WtfocError(
+			`Invalid collection name "${name}": must contain only letters, numbers, hyphens, and underscores (no dots)`,
+			"COLLECTION_INVALID_NAME",
+			{ projectName: name },
+		);
+	}
+}
+
+/**
  * Local filesystem manifest store. Persists head manifests as JSON files.
  * Conflict detection via content-hash-based headId.
  *
@@ -26,10 +52,15 @@ export class LocalManifestStore implements ManifestStore {
 		} catch {
 			return null;
 		}
-		const parsed: unknown = JSON.parse(data);
-		const manifest = validateManifestSchema(parsed);
-		const headId = this.computeHeadId(data);
-		return { headId, manifest };
+		try {
+			const parsed: unknown = JSON.parse(data);
+			const manifest = validateManifestSchema(parsed);
+			const headId = this.computeHeadId(data);
+			return { headId, manifest };
+		} catch {
+			// File exists but is not a valid manifest (corrupt, sidecar, etc.)
+			return null;
+		}
 	}
 
 	async putHead(
@@ -55,13 +86,20 @@ export class LocalManifestStore implements ManifestStore {
 	async listProjects(): Promise<string[]> {
 		try {
 			const files = await readdir(this.dir);
-			return files.filter((f) => f.endsWith(".json")).map((f) => f.replace(/\.json$/, ""));
+			// Only match base manifest files: {name}.json where name contains no dots.
+			// Sidecar files (cursors, catalog, overlay, etc.) all have multi-segment
+			// suffixes like .ingest-cursors.json, so they contain at least one dot
+			// before the .json extension.
+			return files
+				.filter((f) => MANIFEST_FILE_PATTERN.test(f))
+				.map((f) => f.replace(/\.json$/, ""));
 		} catch {
 			return [];
 		}
 	}
 
 	private filePath(projectName: string): string {
+		validateCollectionName(projectName);
 		const base = resolve(this.dir);
 		const resolved = resolve(base, `${projectName}.json`);
 		const rel = relative(base, resolved);


### PR DESCRIPTION
## Summary

Fixes #188 — `wtfoc collections` crashes when sidecar files (cursors, catalog, overlay, etc.) are returned by `listProjects()` as phantom collection names.

**Root cause:** 6 file types share the same flat directory (`{name}.json`, `{name}.ingest-cursors.json`, etc.) but `listProjects()` matched all `.json` files.

**Fix:**
- Validate collection names: only `[a-zA-Z0-9_-]+` (no dots)
- Filter `listProjects()` with `/^[^.]+\.json$/` pattern
- Harden `getHead()` to return null on parse/validation errors
- Early validation in `ingest` command before any work starts

## Test plan

- [x] 774 tests pass (7 new)
- [x] Lint clean
- [x] E2E: dot-named collection rejected immediately
- [x] E2E: `collections` command works without crash
- [x] E2E: valid names still work