### PR TITLE
feat(ingest): auto-resolve GitHub App auth from env vars

### DIFF
--- a/apps/web/server/collections/ingest-worker.ts
+++ b/apps/web/server/collections/ingest-worker.ts
@@ -174,8 +174,8 @@ async function ingestSource(source: Source, signal?: AbortSignal): Promise<Chunk
 
 	switch (source.sourceType) {
 		case "github": {
-			const { GitHubAdapter, createHttpExecFn } = await import("@wtfoc/ingest");
-			const execFn = createHttpExecFn();
+			const { GitHubAdapter, resolveGitHubExecFn } = await import("@wtfoc/ingest");
+			const execFn = resolveGitHubExecFn();
 			const adapter = new GitHubAdapter(execFn);
 			const [owner, repo] = source.identifier.split("/");
 			if (!owner || !repo) throw new Error(`Invalid GitHub identifier: ${source.identifier}`);

--- a/packages/ingest/src/adapters/github/http-transport.ts
+++ b/packages/ingest/src/adapters/github/http-transport.ts
@@ -1,8 +1,9 @@
 import { GitHubApiError, GitHubNotFoundError, GitHubRateLimitError } from "@wtfoc/common";
 import type { GitHubTokenProvider } from "./auth.js";
-import { PatTokenProvider } from "./auth.js";
+import { GitHubAppTokenProvider, PatTokenProvider } from "./auth.js";
+import { decodePrivateKey } from "./jwt.js";
 import type { ExecFn } from "./transport.js";
-import { sleep } from "./transport.js";
+import { defaultExecFn, sleep } from "./transport.js";
 
 const MAX_RATE_LIMIT_WAIT_MS = 5 * 60 * 1000;
 const BASE_BACKOFF_MS = 5000;
@@ -173,6 +174,48 @@ export function createHttpExecFn(tokenProvider?: TokenProvider): ExecFn {
 		const stdout = JSON.stringify(results);
 		return { stdout, stderr: "" };
 	};
+}
+
+/** ExecFn with a transport tag for diagnostics/testing. */
+export type TaggedExecFn = ExecFn & { _transport: "github-app" | "pat" | "cli" };
+
+/**
+ * Resolve the best GitHub ExecFn from environment variables.
+ *
+ * Priority:
+ * 1. GitHub App (GITHUB_APP_ID + GITHUB_PRIVATE_KEY + GITHUB_INSTALLATION_ID)
+ * 2. PAT (GITHUB_TOKEN or WTFOC_GITHUB_TOKEN)
+ * 3. gh CLI fallback (defaultExecFn)
+ */
+export function resolveGitHubExecFn(): TaggedExecFn {
+	const appId = process.env.GITHUB_APP_ID;
+	const privateKey = process.env.GITHUB_PRIVATE_KEY;
+	const installationId = process.env.GITHUB_INSTALLATION_ID;
+
+	if (appId && privateKey && installationId) {
+		const provider = new GitHubAppTokenProvider({
+			appId,
+			privateKey: decodePrivateKey(privateKey),
+			installationId: Number(installationId),
+		});
+		const fn = createHttpExecFn(provider) as TaggedExecFn;
+		fn._transport = "github-app";
+		return fn;
+	}
+
+	const pat = process.env.GITHUB_TOKEN ?? process.env.WTFOC_GITHUB_TOKEN;
+	if (pat) {
+		const provider = new PatTokenProvider(pat);
+		const fn = createHttpExecFn(provider) as TaggedExecFn;
+		fn._transport = "pat";
+		return fn;
+	}
+
+	const fn: TaggedExecFn = Object.assign(
+		(cmd: string, args: string[], signal?: AbortSignal) => defaultExecFn(cmd, args, signal),
+		{ _transport: "cli" as const },
+	);
+	return fn;
 }
 
 async function fetchGraphQL(

--- a/packages/ingest/src/adapters/github/http-transport.ts
+++ b/packages/ingest/src/adapters/github/http-transport.ts
@@ -192,22 +192,31 @@ export function resolveGitHubExecFn(): TaggedExecFn {
 	const privateKey = process.env.GITHUB_PRIVATE_KEY;
 	const installationId = process.env.GITHUB_INSTALLATION_ID;
 
-	if (appId && privateKey && installationId) {
+	const parsedInstallationId = Number(installationId);
+	if (
+		appId &&
+		privateKey &&
+		installationId &&
+		Number.isFinite(parsedInstallationId) &&
+		parsedInstallationId > 0
+	) {
 		const provider = new GitHubAppTokenProvider({
 			appId,
 			privateKey: decodePrivateKey(privateKey),
-			installationId: Number(installationId),
+			installationId: parsedInstallationId,
 		});
-		const fn = createHttpExecFn(provider) as TaggedExecFn;
-		fn._transport = "github-app";
+		const fn: TaggedExecFn = Object.assign(createHttpExecFn(provider), {
+			_transport: "github-app" as const,
+		});
 		return fn;
 	}
 
-	const pat = process.env.GITHUB_TOKEN ?? process.env.WTFOC_GITHUB_TOKEN;
+	const pat = process.env.GITHUB_TOKEN || process.env.WTFOC_GITHUB_TOKEN;
 	if (pat) {
 		const provider = new PatTokenProvider(pat);
-		const fn = createHttpExecFn(provider) as TaggedExecFn;
-		fn._transport = "pat";
+		const fn: TaggedExecFn = Object.assign(createHttpExecFn(provider), {
+			_transport: "pat" as const,
+		});
 		return fn;
 	}
 

--- a/packages/ingest/src/adapters/github/resolve-exec.test.ts
+++ b/packages/ingest/src/adapters/github/resolve-exec.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveGitHubExecFn } from "./http-transport.js";
+
+describe("resolveGitHubExecFn", () => {
+	const originalEnv = { ...process.env };
+
+	beforeEach(() => {
+		// Clear all GitHub-related env vars
+		delete process.env.GITHUB_APP_ID;
+		delete process.env.GITHUB_PRIVATE_KEY;
+		delete process.env.GITHUB_INSTALLATION_ID;
+		delete process.env.GITHUB_TOKEN;
+		delete process.env.WTFOC_GITHUB_TOKEN;
+	});
+
+	afterEach(() => {
+		process.env = { ...originalEnv };
+	});
+
+	it("returns gh CLI exec when no env vars are set", () => {
+		const result = resolveGitHubExecFn();
+		// The default exec function should be a function (gh CLI based)
+		expect(typeof result).toBe("function");
+		// Tag should indicate CLI fallback
+		expect(result._transport).toBe("cli");
+	});
+
+	it("returns HTTP exec with GitHub App provider when all app env vars are set", () => {
+		process.env.GITHUB_APP_ID = "12345";
+		process.env.GITHUB_PRIVATE_KEY = "fake-key";
+		process.env.GITHUB_INSTALLATION_ID = "99";
+
+		const result = resolveGitHubExecFn();
+		expect(typeof result).toBe("function");
+		expect(result._transport).toBe("github-app");
+	});
+
+	it("returns HTTP exec with PAT provider when GITHUB_TOKEN is set", () => {
+		process.env.GITHUB_TOKEN = "ghp_test123";
+
+		const result = resolveGitHubExecFn();
+		expect(typeof result).toBe("function");
+		expect(result._transport).toBe("pat");
+	});
+
+	it("returns HTTP exec with PAT provider when WTFOC_GITHUB_TOKEN is set", () => {
+		process.env.WTFOC_GITHUB_TOKEN = "ghp_wtfoc123";
+
+		const result = resolveGitHubExecFn();
+		expect(typeof result).toBe("function");
+		expect(result._transport).toBe("pat");
+	});
+
+	it("prefers GitHub App over PAT when both are configured", () => {
+		process.env.GITHUB_APP_ID = "12345";
+		process.env.GITHUB_PRIVATE_KEY = "fake-key";
+		process.env.GITHUB_INSTALLATION_ID = "99";
+		process.env.GITHUB_TOKEN = "ghp_also_set";
+
+		const result = resolveGitHubExecFn();
+		expect(result._transport).toBe("github-app");
+	});
+
+	it("falls back to PAT when GitHub App config is incomplete (missing installation ID)", () => {
+		process.env.GITHUB_APP_ID = "12345";
+		process.env.GITHUB_PRIVATE_KEY = "fake-key";
+		// No GITHUB_INSTALLATION_ID
+		process.env.GITHUB_TOKEN = "ghp_fallback";
+
+		const result = resolveGitHubExecFn();
+		expect(result._transport).toBe("pat");
+	});
+
+	it("falls back to CLI when GitHub App config is incomplete and no PAT", () => {
+		process.env.GITHUB_APP_ID = "12345";
+		// Missing GITHUB_PRIVATE_KEY and GITHUB_INSTALLATION_ID
+
+		const result = resolveGitHubExecFn();
+		expect(result._transport).toBe("cli");
+	});
+
+	it("prefers GITHUB_TOKEN over WTFOC_GITHUB_TOKEN", () => {
+		process.env.GITHUB_TOKEN = "ghp_primary";
+		process.env.WTFOC_GITHUB_TOKEN = "ghp_secondary";
+
+		const result = resolveGitHubExecFn();
+		expect(result._transport).toBe("pat");
+	});
+});

--- a/packages/ingest/src/adapters/github/resolve-exec.test.ts
+++ b/packages/ingest/src/adapters/github/resolve-exec.test.ts
@@ -1,20 +1,34 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resolveGitHubExecFn } from "./http-transport.js";
 
+const GITHUB_ENV_KEYS = [
+	"GITHUB_APP_ID",
+	"GITHUB_PRIVATE_KEY",
+	"GITHUB_INSTALLATION_ID",
+	"GITHUB_TOKEN",
+	"WTFOC_GITHUB_TOKEN",
+] as const;
+
 describe("resolveGitHubExecFn", () => {
-	const originalEnv = { ...process.env };
+	const saved: Record<string, string | undefined> = {};
 
 	beforeEach(() => {
-		// Clear all GitHub-related env vars
-		delete process.env.GITHUB_APP_ID;
-		delete process.env.GITHUB_PRIVATE_KEY;
-		delete process.env.GITHUB_INSTALLATION_ID;
-		delete process.env.GITHUB_TOKEN;
-		delete process.env.WTFOC_GITHUB_TOKEN;
+		// Save and clear all GitHub-related env vars
+		for (const key of GITHUB_ENV_KEYS) {
+			saved[key] = process.env[key];
+			delete process.env[key];
+		}
 	});
 
 	afterEach(() => {
-		process.env = { ...originalEnv };
+		// Restore by mutating the existing process.env object
+		for (const key of GITHUB_ENV_KEYS) {
+			if (saved[key] === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = saved[key];
+			}
+		}
 	});
 
 	it("returns gh CLI exec when no env vars are set", () => {
@@ -82,6 +96,24 @@ describe("resolveGitHubExecFn", () => {
 	it("prefers GITHUB_TOKEN over WTFOC_GITHUB_TOKEN", () => {
 		process.env.GITHUB_TOKEN = "ghp_primary";
 		process.env.WTFOC_GITHUB_TOKEN = "ghp_secondary";
+
+		const result = resolveGitHubExecFn();
+		expect(result._transport).toBe("pat");
+	});
+
+	it("falls back to PAT when GITHUB_INSTALLATION_ID is not a number", () => {
+		process.env.GITHUB_APP_ID = "12345";
+		process.env.GITHUB_PRIVATE_KEY = "fake-key";
+		process.env.GITHUB_INSTALLATION_ID = "not-a-number";
+		process.env.GITHUB_TOKEN = "ghp_fallback";
+
+		const result = resolveGitHubExecFn();
+		expect(result._transport).toBe("pat");
+	});
+
+	it("falls back to WTFOC_GITHUB_TOKEN when GITHUB_TOKEN is empty string", () => {
+		process.env.GITHUB_TOKEN = "";
+		process.env.WTFOC_GITHUB_TOKEN = "ghp_wtfoc_fallback";
 
 		const result = resolveGitHubExecFn();
 		expect(result._transport).toBe("pat");

--- a/packages/ingest/src/index.ts
+++ b/packages/ingest/src/index.ts
@@ -5,6 +5,8 @@ export { getAdapter, getAvailableSourceTypes, registerAdapter } from "./adapter-
 export { DiscordAdapter, type DiscordAdapterConfig } from "./adapters/discord.js";
 export {
 	createHttpExecFn,
+	resolveGitHubExecFn,
+	type TaggedExecFn,
 	type TokenProvider,
 } from "./adapters/github/http-transport.js";
 export {
@@ -154,6 +156,7 @@ export {
 // Register built-in adapters
 import { registerAdapter as _register } from "./adapter-registry.js";
 import { DiscordAdapter as _DiscordAdapter } from "./adapters/discord.js";
+import { resolveGitHubExecFn as _resolveGitHubExecFn } from "./adapters/github/http-transport.js";
 import { GitHubAdapter as _GitHubAdapter } from "./adapters/github/index.js";
 import { HackerNewsAdapter as _HackerNewsAdapter } from "./adapters/hackernews.js";
 import { RepoAdapter as _RepoAdapter } from "./adapters/repo/index.js";
@@ -161,7 +164,7 @@ import { SlackAdapter as _SlackAdapter } from "./adapters/slack.js";
 import { WebsiteAdapter as _WebsiteAdapter } from "./adapters/website.js";
 
 _register(new _RepoAdapter());
-_register(new _GitHubAdapter());
+_register(new _GitHubAdapter(_resolveGitHubExecFn()));
 _register(new _HackerNewsAdapter());
 _register(new _WebsiteAdapter());
 _register(new _DiscordAdapter());


### PR DESCRIPTION
## Summary
- Adds `resolveGitHubExecFn()` that auto-selects the best GitHub transport strategy based on environment variables:
  1. **GitHub App** (when `GITHUB_APP_ID` + `GITHUB_PRIVATE_KEY` + `GITHUB_INSTALLATION_ID` are set) — uses installation tokens via JWT
  2. **PAT** (when `GITHUB_TOKEN` or `WTFOC_GITHUB_TOKEN` is set) — static personal access token
  3. **gh CLI** (fallback) — existing behavior, no change needed
- Wires it into the default adapter registry (`packages/ingest/src/index.ts`) and the web ingest worker (`apps/web/server/collections/ingest-worker.ts`)
- Exports `resolveGitHubExecFn` and `TaggedExecFn` from `@wtfoc/ingest`

## Test plan
- [x] 8 new unit tests covering all resolution strategies, priority, incomplete config fallback
- [x] Full test suite passes (789 tests)
- [x] Lint clean
- [x] Manual: set `GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`, `GITHUB_INSTALLATION_ID` in `.env` and run a GitHub source ingestion to verify App token flow
- [x] Manual: unset App env vars, set only `GITHUB_TOKEN`, verify PAT flow works
- [x] Manual: unset all GitHub env vars, verify `gh` CLI fallback works