### PR TITLE
feat: lineage-first trace output with timeline and agent conclusion

### DIFF
--- a/packages/cli/src/commands/trace.ts
+++ b/packages/cli/src/commands/trace.ts
@@ -6,7 +6,7 @@ import {
 	readCatalog,
 	readOverlayEdges,
 } from "@wtfoc/ingest";
-import { type TraceMode, trace } from "@wtfoc/search";
+import { type TraceMode, type TraceView, trace } from "@wtfoc/search";
 import type { Command } from "commander";
 import { getProjectConfig } from "../cli.js";
 import {
@@ -35,13 +35,18 @@ export function registerTraceCommand(program: Command): void {
 			.option("--max-per-source <number>", "Max results per source type (default: 3)")
 			.option("--max-hops <number>", "Max edge hops to follow (default: 3)")
 			.option("--exclude <types...>", "Exclude source types (e.g. github-pr-comment)")
-			.option("--include <types...>", "Only include these source types"),
+			.option("--include <types...>", "Only include these source types")
+			.option(
+				"--view <view>",
+				'Output view: "lineage", "timeline", or "evidence" (default: lineage for analytical, evidence for discovery)',
+			),
 	).action(
 		async (
 			queryText: string,
 			opts: {
 				collection: string;
 				mode: string;
+				view?: string;
 				maxTotal?: string;
 				maxPerSource?: string;
 				maxHops?: string;
@@ -58,6 +63,18 @@ export function registerTraceCommand(program: Command): void {
 			}
 			// Safe after validation above
 			const mode: TraceMode = opts.mode === "analytical" ? "analytical" : "discovery";
+
+			// Resolve view: explicit --view overrides mode default
+			const validViews: TraceView[] = ["lineage", "timeline", "evidence"];
+			if (opts.view && !validViews.includes(opts.view as TraceView)) {
+				console.error(
+					`Error: invalid trace view "${opts.view}". Must be one of: ${validViews.join(", ")}`,
+				);
+				process.exit(2);
+			}
+			const view: TraceView =
+				(opts.view as TraceView) ?? (mode === "analytical" ? "lineage" : "evidence");
+
 			const store = getStore(program);
 			const format = getFormat(program.opts());
 
@@ -140,7 +157,7 @@ export function registerTraceCommand(program: Command): void {
 					excludeSourceTypes: opts.exclude,
 					includeSourceTypes: opts.include,
 				});
-				console.log(formatTrace(result, format));
+				console.log(formatTrace(result, format, view));
 			} catch (err) {
 				if (
 					err instanceof Error &&

--- a/packages/cli/src/output.test.ts
+++ b/packages/cli/src/output.test.ts
@@ -1,0 +1,239 @@
+import type { TraceResult } from "@wtfoc/search";
+import { describe, expect, it } from "vitest";
+import {
+	formatTrace,
+	formatTraceEvidence,
+	formatTraceLineage,
+	formatTraceTimeline,
+} from "./output.js";
+
+function makeResult(overrides?: Partial<TraceResult>): TraceResult {
+	return {
+		query: "test query",
+		groups: {},
+		hops: [],
+		lineageChains: [],
+		insights: [],
+		stats: { totalHops: 0, edgeHops: 0, semanticHops: 0, sourceTypes: [], insightCount: 0 },
+		...overrides,
+	};
+}
+
+describe("formatTrace dispatcher", () => {
+	it("returns JSON for json format regardless of view", () => {
+		const result = makeResult({
+			hops: [
+				{
+					content: "test",
+					sourceType: "code",
+					source: "src/a.ts",
+					storageId: "s1",
+					connection: { method: "semantic", confidence: 0.9 },
+				},
+			],
+		});
+		const json = formatTrace(result, "json", "lineage");
+		expect(() => JSON.parse(json)).not.toThrow();
+		expect(JSON.parse(json).query).toBe("test query");
+	});
+
+	it("returns empty string for quiet format", () => {
+		expect(formatTrace(makeResult(), "quiet", "lineage")).toBe("");
+	});
+
+	it("dispatches to evidence view by default", () => {
+		const output = formatTrace(makeResult(), "human");
+		expect(output).toContain("Trace:");
+	});
+});
+
+describe("formatTraceEvidence", () => {
+	it("renders grouped-by-sourceType output", () => {
+		const result = makeResult({
+			groups: {
+				"github-issue": [
+					{
+						content: "issue text",
+						sourceType: "github-issue",
+						source: "org/repo#1",
+						storageId: "s1",
+						connection: {
+							method: "edge",
+							edgeType: "references",
+							evidence: "ref #1",
+							confidence: 1.0,
+						},
+					},
+				],
+			},
+			stats: {
+				totalHops: 1,
+				edgeHops: 1,
+				semanticHops: 0,
+				sourceTypes: ["github-issue"],
+				insightCount: 0,
+			},
+		});
+		const output = formatTraceEvidence(result);
+		expect(output).toContain("github-issue");
+		expect(output).toContain("org/repo#1");
+		expect(output).toContain("references");
+		expect(output).toContain("1 results");
+	});
+
+	it("handles empty result gracefully", () => {
+		const output = formatTraceEvidence(makeResult());
+		expect(output).toContain("0 results");
+	});
+});
+
+describe("formatTraceLineage", () => {
+	it("renders chains with type sequence headers", () => {
+		const result = makeResult({
+			hops: [
+				{
+					content: "slack msg",
+					sourceType: "slack-message",
+					source: "#foc",
+					storageId: "s1",
+					connection: { method: "semantic", confidence: 0.9 },
+				},
+				{
+					content: "issue text",
+					sourceType: "github-issue",
+					source: "org/repo#1",
+					storageId: "s2",
+					parentHopIndex: 0,
+					connection: { method: "edge", edgeType: "references", evidence: "ref", confidence: 1.0 },
+				},
+			],
+			lineageChains: [
+				{
+					hopIndices: [0, 1],
+					typeSequence: ["slack-message", "github-issue"],
+					sourceTypeDiversity: 2,
+				},
+			],
+		});
+		const output = formatTraceLineage(result);
+		expect(output).toContain("Chain 1");
+		expect(output).toContain("slack-message");
+		expect(output).toContain("github-issue");
+		expect(output).toContain("#foc");
+	});
+
+	it("shows Related Context for orphan hops", () => {
+		const result = makeResult({
+			hops: [
+				{
+					content: "orphan",
+					sourceType: "code",
+					source: "src/a.ts",
+					storageId: "s1",
+					connection: { method: "semantic", confidence: 0.7 },
+				},
+			],
+			lineageChains: [],
+		});
+		const output = formatTraceLineage(result);
+		expect(output).toContain("Related Context");
+		expect(output).toContain("src/a.ts");
+	});
+
+	it("handles zero hops gracefully", () => {
+		const output = formatTraceLineage(makeResult());
+		expect(output).toContain("No results found");
+	});
+});
+
+describe("formatTraceTimeline", () => {
+	it("groups hops by UTC date", () => {
+		const result = makeResult({
+			hops: [
+				{
+					content: "hop1",
+					sourceType: "slack-message",
+					source: "#ch",
+					storageId: "s1",
+					timestamp: "2026-04-10T14:00:00Z",
+					connection: { method: "semantic", confidence: 0.9 },
+				},
+				{
+					content: "hop2",
+					sourceType: "github-issue",
+					source: "org/repo#1",
+					storageId: "s2",
+					timestamp: "2026-04-11T10:00:00Z",
+					connection: { method: "edge", edgeType: "references", confidence: 1.0 },
+				},
+			],
+		});
+		const output = formatTraceTimeline(result);
+		expect(output).toContain("2026-04-10");
+		expect(output).toContain("2026-04-11");
+	});
+
+	it("puts undated hops at the end", () => {
+		const result = makeResult({
+			hops: [
+				{
+					content: "dated",
+					sourceType: "code",
+					source: "a.ts",
+					storageId: "s1",
+					timestamp: "2026-04-10T12:00:00Z",
+					connection: { method: "semantic", confidence: 0.8 },
+				},
+				{
+					content: "undated",
+					sourceType: "code",
+					source: "b.ts",
+					storageId: "s2",
+					connection: { method: "semantic", confidence: 0.7 },
+				},
+			],
+		});
+		const output = formatTraceTimeline(result);
+		const datedIdx = output.indexOf("2026-04-10");
+		const undatedIdx = output.indexOf("(no timestamp)");
+		expect(datedIdx).toBeLessThan(undatedIdx);
+	});
+
+	it("handles all undated hops", () => {
+		const result = makeResult({
+			hops: [
+				{
+					content: "hop1",
+					sourceType: "code",
+					source: "a.ts",
+					storageId: "s1",
+					connection: { method: "semantic", confidence: 0.8 },
+				},
+			],
+		});
+		const output = formatTraceTimeline(result);
+		expect(output).toContain("(no timestamp)");
+	});
+
+	it("handles malformed timestamps without crash", () => {
+		const result = makeResult({
+			hops: [
+				{
+					content: "hop1",
+					sourceType: "code",
+					source: "a.ts",
+					storageId: "s1",
+					timestamp: "not-a-date",
+					connection: { method: "semantic", confidence: 0.8 },
+				},
+			],
+		});
+		const output = formatTraceTimeline(result);
+		expect(output).toContain("(no timestamp)");
+	});
+
+	it("handles zero hops gracefully", () => {
+		const output = formatTraceTimeline(makeResult());
+		expect(output).toContain("No results found");
+	});
+});

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,79 +1,220 @@
-import type { QueryResult, TraceResult } from "@wtfoc/search";
+import type { QueryResult, TraceHop, TraceResult, TraceView } from "@wtfoc/search";
 
 export type OutputFormat = "human" | "json" | "quiet";
 
+const sourceIcons: Record<string, string> = {
+	"slack-message": "📨",
+	"discord-message": "💬",
+	"github-issue": "📋",
+	"github-pr": "🔀",
+	"github-issue-comment": "💬",
+	"github-pr-review": "👀",
+	code: "📄",
+	markdown: "📝",
+	"doc-page": "🌐",
+};
+
 /**
  * Format trace results for terminal output.
+ * Dispatches to view-specific formatters for human output.
  */
-export function formatTrace(result: TraceResult, format: OutputFormat): string {
+export function formatTrace(result: TraceResult, format: OutputFormat, view?: TraceView): string {
 	if (format === "json") return JSON.stringify(result, null, "\t");
 	if (format === "quiet") return "";
 
+	const resolvedView = view ?? "evidence";
+	switch (resolvedView) {
+		case "lineage":
+			return formatTraceLineage(result);
+		case "timeline":
+			return formatTraceTimeline(result);
+		case "evidence":
+			return formatTraceEvidence(result);
+	}
+}
+
+function formatHopLine(hop: TraceHop): string[] {
+	const lines: string[] = [];
+	const snippet = hop.content.slice(0, 120).replace(/\n/g, " ");
+	const score = hop.connection.confidence.toFixed(2);
+	lines.push(`  [${score}] ${hop.source}`);
+	lines.push(`         ${snippet}${hop.content.length > 120 ? "..." : ""}`);
+	if (hop.connection.method === "edge") {
+		lines.push(`         🔗 ${hop.connection.edgeType}: ${hop.connection.evidence ?? ""}`);
+	}
+	if (hop.sourceUrl) {
+		lines.push(`         ${hop.sourceUrl}`);
+	}
+	lines.push(`         ID: ${hop.storageId}`);
+	return lines;
+}
+
+function formatInsights(result: TraceResult): string[] {
+	if (!result.insights || result.insights.length === 0) return [];
+
+	const insightIcons: Record<string, string> = {
+		convergence: "🔄",
+		"evidence-chain": "🔗",
+		"temporal-cluster": "📅",
+	};
+
+	const lines: string[] = ["─── Cross-Source Insights ───\n"];
+	for (const insight of result.insights) {
+		const icon = insightIcons[insight.kind] ?? "💡";
+		const strength = (insight.strength * 100).toFixed(0);
+		lines.push(`${icon} [${strength}%] ${insight.summary}`);
+	}
+	lines.push("");
+	return lines;
+}
+
+function formatStats(result: TraceResult): string {
+	return (
+		`📊 ${result.stats.totalHops} results (${result.stats.edgeHops} via edges, ${result.stats.semanticHops} semantic) across ${result.stats.sourceTypes.length} source types` +
+		(result.stats.insightCount > 0
+			? `, ${result.stats.insightCount} insight${result.stats.insightCount === 1 ? "" : "s"}`
+			: "")
+	);
+}
+
+/**
+ * Evidence view: grouped by source type (the original/current output).
+ */
+export function formatTraceEvidence(result: TraceResult): string {
 	const lines: string[] = [];
 	lines.push(`🔍 Trace: "${result.query}"\n`);
-
-	const sourceIcons: Record<string, string> = {
-		"slack-message": "📨",
-		"discord-message": "💬",
-		"github-issue": "📋",
-		"github-pr": "🔀",
-		"github-issue-comment": "💬",
-		"github-pr-review": "👀",
-		code: "📄",
-		markdown: "📝",
-		"doc-page": "🌐",
-	};
 
 	for (const [sourceType, hops] of Object.entries(result.groups)) {
 		const icon = sourceIcons[sourceType] ?? "📎";
 		lines.push(`${icon} ${sourceType} (${hops.length} matches)`);
 
 		for (const hop of hops) {
-			const snippet = hop.content.slice(0, 120).replace(/\n/g, " ");
-			const score = hop.connection.confidence.toFixed(2);
-			lines.push(`  [${score}] ${hop.source}`);
-			lines.push(`         ${snippet}${hop.content.length > 120 ? "..." : ""}`);
-
-			if (hop.connection.method === "edge") {
-				lines.push(`         🔗 ${hop.connection.edgeType}: ${hop.connection.evidence ?? ""}`);
-			}
-
-			if (hop.sourceUrl) {
-				lines.push(`         ${hop.sourceUrl}`);
-			}
-
-			lines.push(`         ID: ${hop.storageId}`);
+			lines.push(...formatHopLine(hop));
 			lines.push("");
 		}
 	}
 
-	// Show cross-source insights (analytical mode)
-	if (result.insights && result.insights.length > 0) {
-		lines.push("─── Cross-Source Insights ───\n");
+	lines.push(...formatInsights(result));
+	lines.push(formatStats(result));
+	return lines.join("\n");
+}
 
-		const insightIcons: Record<string, string> = {
-			convergence: "🔄",
-			"evidence-chain": "🔗",
-			"temporal-cluster": "📅",
-		};
+/**
+ * Lineage view: causal chains reconstructed from DFS tree.
+ */
+export function formatTraceLineage(result: TraceResult): string {
+	const lines: string[] = [];
+	lines.push(`🔍 Trace: "${result.query}"\n`);
 
-		for (const insight of result.insights) {
-			const icon = insightIcons[insight.kind] ?? "💡";
-			const strength = (insight.strength * 100).toFixed(0);
-			lines.push(`${icon} [${strength}%] ${insight.summary}`);
+	if (result.hops.length === 0) {
+		lines.push("No results found.");
+		return lines.join("\n");
+	}
+
+	const chains = result.lineageChains;
+	const hopsInChains = new Set<number>();
+
+	for (let ci = 0; ci < chains.length; ci++) {
+		const chain = chains[ci];
+		const typeHeader = chain.typeSequence.join(" → ");
+		lines.push(`Chain ${ci + 1} (${typeHeader})`);
+
+		for (let si = 0; si < chain.hopIndices.length; si++) {
+			const hopIdx = chain.hopIndices[si];
+			hopsInChains.add(hopIdx);
+			const hop = result.hops[hopIdx];
+			const icon = sourceIcons[hop.sourceType] ?? "📎";
+			const snippet = hop.content.slice(0, 120).replace(/\n/g, " ");
+			const score = hop.connection.confidence.toFixed(2);
+
+			lines.push(
+				`  ${si + 1}. ${icon} [${hop.sourceType}] ${hop.source}  (${hop.connection.method}, ${score})`,
+			);
+			lines.push(`     ${snippet}${hop.content.length > 120 ? "..." : ""}`);
+
+			if (hop.connection.method === "edge" && hop.connection.edgeType) {
+				lines.push(`     🔗 ${hop.connection.edgeType}: ${hop.connection.evidence ?? ""}`);
+			}
+			if (hop.sourceUrl) {
+				lines.push(`     ${hop.sourceUrl}`);
+			}
 		}
-
 		lines.push("");
 	}
 
-	lines.push(
-		`📊 ${result.stats.totalHops} results (${result.stats.edgeHops} via edges, ${result.stats.semanticHops} semantic) across ${result.stats.sourceTypes.length} source types` +
-			(result.stats.insightCount > 0
-				? `, ${result.stats.insightCount} insight${result.stats.insightCount === 1 ? "" : "s"}`
-				: ""),
-	);
+	// Orphan hops not in any chain
+	const orphans = result.hops.filter((_, i) => !hopsInChains.has(i));
+	if (orphans.length > 0) {
+		lines.push("─── Related Context ───\n");
+		for (const hop of orphans) {
+			lines.push(...formatHopLine(hop));
+			lines.push("");
+		}
+	}
 
+	lines.push(...formatInsights(result));
+	lines.push(formatStats(result));
 	return lines.join("\n");
+}
+
+/**
+ * Timeline view: all hops sorted by UTC timestamp.
+ */
+export function formatTraceTimeline(result: TraceResult): string {
+	const lines: string[] = [];
+	lines.push(`🔍 Trace: "${result.query}"\n`);
+
+	if (result.hops.length === 0) {
+		lines.push("No results found.");
+		return lines.join("\n");
+	}
+
+	// Sort hops: dated first by timestamp, undated at end. Stable sort by index for ties.
+	const indexed = result.hops.map((hop, i) => ({ hop, i }));
+	indexed.sort((a, b) => {
+		const aDate = parseTimestamp(a.hop.timestamp);
+		const bDate = parseTimestamp(b.hop.timestamp);
+		if (aDate && bDate) return aDate.getTime() - bDate.getTime() || a.i - b.i;
+		if (aDate && !bDate) return -1;
+		if (!aDate && bDate) return 1;
+		return a.i - b.i;
+	});
+
+	let currentDateHeader = "";
+	for (const { hop } of indexed) {
+		const ts = parseTimestamp(hop.timestamp);
+		const dateHeader = ts ? ts.toISOString().slice(0, 10) : "(no timestamp)";
+
+		if (dateHeader !== currentDateHeader) {
+			if (currentDateHeader) lines.push("");
+			lines.push(`📅 ${dateHeader}`);
+			currentDateHeader = dateHeader;
+		}
+
+		const icon = sourceIcons[hop.sourceType] ?? "📎";
+		const score = hop.connection.confidence.toFixed(2);
+		const snippet = hop.content.slice(0, 100).replace(/\n/g, " ");
+		lines.push(`  ${icon} [${score}] ${hop.source}`);
+		lines.push(`         ${snippet}${hop.content.length > 100 ? "..." : ""}`);
+		if (hop.connection.method === "edge" && hop.connection.edgeType) {
+			lines.push(`         🔗 ${hop.connection.edgeType}`);
+		}
+		if (hop.sourceUrl) {
+			lines.push(`         ${hop.sourceUrl}`);
+		}
+	}
+
+	lines.push("");
+	lines.push(...formatInsights(result));
+	lines.push(formatStats(result));
+	return lines.join("\n");
+}
+
+/** Parse a timestamp string to Date, returning null for invalid/missing values. */
+function parseTimestamp(ts: string | undefined): Date | null {
+	if (!ts) return null;
+	const d = new Date(ts);
+	return Number.isNaN(d.getTime()) ? null : d;
 }
 
 /**

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -111,7 +111,9 @@ export function formatTraceLineage(result: TraceResult): string {
 		return lines.join("\n");
 	}
 
-	const chains = result.lineageChains;
+	// Only show chains with 2+ hops (real traversals). Single-hop seeds go to Related Context.
+	// Follows the pattern from insights.ts detectEvidenceChains (3+ source types for insights).
+	const chains = result.lineageChains.filter((c) => c.hopIndices.length >= 2);
 	const hopsInChains = new Set<number>();
 
 	for (let ci = 0; ci < chains.length; ci++) {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -118,13 +118,16 @@ export function formatTraceLineage(result: TraceResult): string {
 
 	for (let ci = 0; ci < chains.length; ci++) {
 		const chain = chains[ci];
+		if (!chain) continue;
 		const typeHeader = chain.typeSequence.join(" → ");
 		lines.push(`Chain ${ci + 1} (${typeHeader})`);
 
 		for (let si = 0; si < chain.hopIndices.length; si++) {
 			const hopIdx = chain.hopIndices[si];
+			if (hopIdx == null) continue;
 			hopsInChains.add(hopIdx);
 			const hop = result.hops[hopIdx];
+			if (!hop) continue;
 			const icon = sourceIcons[hop.sourceType] ?? "📎";
 			const snippet = hop.content.slice(0, 120).replace(/\n/g, " ");
 			const score = hop.connection.confidence.toFixed(2);

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -30,6 +30,8 @@ export function formatTrace(result: TraceResult, format: OutputFormat, view?: Tr
 			return formatTraceTimeline(result);
 		case "evidence":
 			return formatTraceEvidence(result);
+		default:
+			return formatTraceEvidence(result);
 	}
 }
 
@@ -39,7 +41,7 @@ function formatHopLine(hop: TraceHop): string[] {
 	const score = hop.connection.confidence.toFixed(2);
 	lines.push(`  [${score}] ${hop.source}`);
 	lines.push(`         ${snippet}${hop.content.length > 120 ? "..." : ""}`);
-	if (hop.connection.method === "edge") {
+	if (hop.connection.method === "edge" && hop.connection.edgeType) {
 		lines.push(`         🔗 ${hop.connection.edgeType}: ${hop.connection.evidence ?? ""}`);
 	}
 	if (hop.sourceUrl) {

--- a/packages/mcp-server/src/tools/trace.ts
+++ b/packages/mcp-server/src/tools/trace.ts
@@ -1,5 +1,5 @@
 import type { Embedder } from "@wtfoc/common";
-import { type TraceMode, trace } from "@wtfoc/search";
+import { type TraceMode, type TraceView, trace } from "@wtfoc/search";
 import type { createStore } from "@wtfoc/store";
 import type { CollectionLoader } from "../helpers.js";
 import { resolveCollection } from "../helpers.js";
@@ -11,6 +11,8 @@ export async function handleTrace(
 		query: string;
 		collection: string;
 		mode?: TraceMode;
+		/** Hint for how the client should render results */
+		view?: TraceView;
 		maxTotal?: number;
 		maxPerSource?: number;
 		maxHops?: number;

--- a/packages/mcp-server/src/tools/trace.ts
+++ b/packages/mcp-server/src/tools/trace.ts
@@ -1,5 +1,5 @@
 import type { Embedder } from "@wtfoc/common";
-import { type TraceMode, type TraceView, trace } from "@wtfoc/search";
+import { type TraceMode, trace } from "@wtfoc/search";
 import type { createStore } from "@wtfoc/store";
 import type { CollectionLoader } from "../helpers.js";
 import { resolveCollection } from "../helpers.js";
@@ -11,8 +11,6 @@ export async function handleTrace(
 		query: string;
 		collection: string;
 		mode?: TraceMode;
-		/** Hint for how the client should render results */
-		view?: TraceView;
 		maxTotal?: number;
 		maxPerSource?: number;
 		maxHops?: number;

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -19,10 +19,12 @@ export type { QueryOptions, QueryResult } from "./query.js";
 export { query } from "./query.js";
 export type {
 	InsightKind,
+	LineageChain,
 	TraceHop,
 	TraceInsight,
 	TraceMode,
 	TraceOptions,
 	TraceResult,
+	TraceView,
 } from "./trace/index.js";
 export { detectInsights, trace } from "./trace/index.js";

--- a/packages/search/src/trace.test.ts
+++ b/packages/search/src/trace.test.ts
@@ -390,6 +390,70 @@ describe("trace", () => {
 		expect(issueHop?.connection.method).toBe("edge");
 		expect(issueHop?.connection.edgeType).toBe("implements");
 	});
+
+	it("carries chunk timestamps through to TraceHop", async () => {
+		const timestampedSegment: Segment = {
+			schemaVersion: 1,
+			embeddingModel: "test",
+			embeddingDimensions: 3,
+			chunks: [
+				{
+					id: "slack-msg-1",
+					storageId: "storage-slack-1",
+					content: "users are seeing upload timeouts",
+					embedding: [1.0, 0.0, 0.0],
+					terms: ["upload", "timeout"],
+					source: "#foc-support",
+					sourceType: "slack-message",
+					timestamp: "2026-04-10T14:30:00Z",
+					metadata: {},
+				},
+				{
+					id: "issue-142",
+					storageId: "storage-issue-142",
+					content: "Upload timeout on large files",
+					embedding: [0.9, 0.1, 0.0],
+					terms: ["upload", "timeout", "large"],
+					source: "FilOzone/synapse-sdk#142",
+					sourceType: "github-issue",
+					sourceUrl: "https://github.com/FilOzone/synapse-sdk/issues/142",
+					timestamp: "2026-04-10T16:00:00Z",
+					metadata: {},
+				},
+			],
+			edges: [
+				{
+					type: "references",
+					sourceId: "slack-msg-1",
+					targetType: "issue",
+					targetId: "FilOzone/synapse-sdk#142",
+					evidence: "#142 in message",
+					confidence: 1.0,
+				},
+			],
+		};
+
+		const index = createMockIndex([slackChunk]);
+		const result = await trace("upload failures", mockEmbedder, index, [timestampedSegment]);
+
+		// Seed hop should carry timestamp
+		const slackHop = result.hops.find((h) => h.sourceType === "slack-message");
+		expect(slackHop?.timestamp).toBe("2026-04-10T14:30:00Z");
+
+		// Edge-traversed hop should carry timestamp
+		const issueHop = result.hops.find((h) => h.sourceType === "github-issue");
+		expect(issueHop?.timestamp).toBe("2026-04-10T16:00:00Z");
+	});
+
+	it("leaves timestamp undefined when chunk has no timestamp", async () => {
+		const index = createMockIndex([slackChunk]);
+		const result = await trace("upload failures", mockEmbedder, index, [testSegment]);
+
+		// testSegment chunks have no timestamp field
+		for (const hop of result.hops) {
+			expect(hop.timestamp).toBeUndefined();
+		}
+	});
 });
 
 describe("buildEdgeIndex", () => {

--- a/packages/search/src/trace/conclusion.test.ts
+++ b/packages/search/src/trace/conclusion.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { buildConclusion } from "./conclusion.js";
+import type { LineageChain } from "./lineage.js";
+import type { TraceHop } from "./trace.js";
+
+function makeHop(overrides: Partial<TraceHop> & { sourceType: string }): TraceHop {
+	return {
+		content: "test content",
+		source: "test-source",
+		storageId: "test-storage",
+		connection: { method: "semantic", confidence: 0.9 },
+		...overrides,
+	};
+}
+
+describe("buildConclusion", () => {
+	it("returns undefined for empty hops", () => {
+		expect(buildConclusion([], [])).toBeUndefined();
+	});
+
+	it("sets primaryArtifact to the highest-confidence seed hop", () => {
+		const hops: TraceHop[] = [
+			makeHop({
+				sourceType: "slack-message",
+				connection: { method: "semantic", confidence: 0.85 },
+			}),
+			makeHop({ sourceType: "github-issue", connection: { method: "semantic", confidence: 0.95 } }),
+		];
+		const conclusion = buildConclusion(hops, []);
+		expect(conclusion).toBeDefined();
+		expect(conclusion?.primaryArtifact).toEqual({
+			hopIndex: 1,
+			summary: "github-issue: test-source",
+		});
+	});
+
+	it("populates candidateFixes from edge-based hops with closes/addresses types", () => {
+		const hops: TraceHop[] = [
+			makeHop({ sourceType: "github-issue", connection: { method: "semantic", confidence: 0.9 } }),
+			makeHop({
+				sourceType: "github-pr",
+				parentHopIndex: 0,
+				connection: {
+					method: "edge",
+					edgeType: "closes",
+					evidence: "Closes #142",
+					confidence: 1.0,
+				},
+			}),
+			makeHop({
+				sourceType: "code",
+				parentHopIndex: 0,
+				connection: {
+					method: "edge",
+					edgeType: "addresses",
+					evidence: "Addresses #142",
+					confidence: 0.8,
+				},
+			}),
+		];
+		const conclusion = buildConclusion(hops, []);
+		expect(conclusion?.candidateFixes).toHaveLength(2);
+		expect(conclusion?.candidateFixes[0].hopIndex).toBe(1);
+		expect(conclusion?.candidateFixes[1].hopIndex).toBe(2);
+	});
+
+	it("excludes semantic hops from candidateFixes even if they look like fixes", () => {
+		const hops: TraceHop[] = [
+			makeHop({ sourceType: "github-issue", connection: { method: "semantic", confidence: 0.9 } }),
+			makeHop({
+				sourceType: "github-pr",
+				connection: { method: "semantic", confidence: 0.85 },
+			}),
+		];
+		const conclusion = buildConclusion(hops, []);
+		expect(conclusion?.candidateFixes).toHaveLength(0);
+	});
+
+	it("populates relatedContext from orphan hops not in chains", () => {
+		const hops: TraceHop[] = [
+			makeHop({ sourceType: "slack-message" }),
+			makeHop({ sourceType: "github-issue", parentHopIndex: 0 }),
+			makeHop({ sourceType: "code" }), // orphan - not in any chain
+		];
+		const chains: LineageChain[] = [
+			{
+				hopIndices: [0, 1],
+				typeSequence: ["slack-message", "github-issue"],
+				sourceTypeDiversity: 2,
+			},
+		];
+		const conclusion = buildConclusion(hops, chains);
+		expect(conclusion?.relatedContext).toHaveLength(1);
+		expect(conclusion?.relatedContext[0].hopIndex).toBe(2);
+	});
+
+	it("populates recommendedNextReads from chain leaf hops", () => {
+		const hops: TraceHop[] = [
+			makeHop({ sourceType: "slack-message" }),
+			makeHop({ sourceType: "github-issue", parentHopIndex: 0 }),
+			makeHop({ sourceType: "github-pr", parentHopIndex: 1 }),
+		];
+		const chains: LineageChain[] = [
+			{
+				hopIndices: [0, 1, 2],
+				typeSequence: ["slack-message", "github-issue", "github-pr"],
+				sourceTypeDiversity: 3,
+			},
+		];
+		const conclusion = buildConclusion(hops, chains);
+		expect(conclusion?.recommendedNextReads).toHaveLength(1);
+		expect(conclusion?.recommendedNextReads[0].hopIndex).toBe(2);
+	});
+
+	it("returns conclusion with empty candidateFixes when no fix edges exist", () => {
+		const hops: TraceHop[] = [
+			makeHop({ sourceType: "slack-message", connection: { method: "semantic", confidence: 0.9 } }),
+		];
+		const conclusion = buildConclusion(hops, []);
+		expect(conclusion).toBeDefined();
+		expect(conclusion?.candidateFixes).toEqual([]);
+		expect(conclusion?.primaryArtifact).toBeDefined();
+	});
+});

--- a/packages/search/src/trace/conclusion.test.ts
+++ b/packages/search/src/trace/conclusion.test.ts
@@ -60,8 +60,8 @@ describe("buildConclusion", () => {
 		];
 		const conclusion = buildConclusion(hops, []);
 		expect(conclusion?.candidateFixes).toHaveLength(2);
-		expect(conclusion?.candidateFixes[0].hopIndex).toBe(1);
-		expect(conclusion?.candidateFixes[1].hopIndex).toBe(2);
+		expect(conclusion?.candidateFixes.at(0)?.hopIndex).toBe(1);
+		expect(conclusion?.candidateFixes.at(1)?.hopIndex).toBe(2);
 	});
 
 	it("excludes semantic hops from candidateFixes even if they look like fixes", () => {
@@ -91,7 +91,7 @@ describe("buildConclusion", () => {
 		];
 		const conclusion = buildConclusion(hops, chains);
 		expect(conclusion?.relatedContext).toHaveLength(1);
-		expect(conclusion?.relatedContext[0].hopIndex).toBe(2);
+		expect(conclusion?.relatedContext.at(0)?.hopIndex).toBe(2);
 	});
 
 	it("populates recommendedNextReads from chain leaf hops", () => {
@@ -109,7 +109,7 @@ describe("buildConclusion", () => {
 		];
 		const conclusion = buildConclusion(hops, chains);
 		expect(conclusion?.recommendedNextReads).toHaveLength(1);
-		expect(conclusion?.recommendedNextReads[0].hopIndex).toBe(2);
+		expect(conclusion?.recommendedNextReads.at(0)?.hopIndex).toBe(2);
 	});
 
 	it("returns conclusion with empty candidateFixes when no fix edges exist", () => {

--- a/packages/search/src/trace/conclusion.ts
+++ b/packages/search/src/trace/conclusion.ts
@@ -43,8 +43,10 @@ export function buildConclusion(
 			summary: `${hop.sourceType}: ${hop.source} (${hop.connection.edgeType})`,
 		}));
 
-	// Related context: hops not in any chain
-	const hopsInChains = new Set(chains.flatMap((c) => c.hopIndices));
+	// Related context: hops not in any multi-hop chain (2+ hops).
+	// Single-hop roots are "related context", not meaningful chains.
+	const multiHopChains = chains.filter((c) => c.hopIndices.length >= 2);
+	const hopsInChains = new Set(multiHopChains.flatMap((c) => c.hopIndices));
 	const relatedContext = hops
 		.map((hop, i) => ({ hop, i }))
 		.filter(({ i }) => !hopsInChains.has(i))
@@ -53,8 +55,8 @@ export function buildConclusion(
 			summary: `${hop.sourceType}: ${hop.source}`,
 		}));
 
-	// Recommended next reads: leaf hops of chains (last hop in each chain)
-	const leafIndices = new Set(chains.map((c) => c.hopIndices[c.hopIndices.length - 1]));
+	// Recommended next reads: leaf hops of multi-hop chains
+	const leafIndices = new Set(multiHopChains.map((c) => c.hopIndices[c.hopIndices.length - 1]));
 	const recommendedNextReads = [...leafIndices].map((i) => ({
 		hopIndex: i,
 		reason: `End of evidence chain — follow up on ${hops[i].sourceType}: ${hops[i].source}`,

--- a/packages/search/src/trace/conclusion.ts
+++ b/packages/search/src/trace/conclusion.ts
@@ -1,0 +1,72 @@
+import type { LineageChain } from "./lineage.js";
+import type { TraceHop } from "./trace.js";
+
+export interface TraceConclusion {
+	primaryArtifact?: { hopIndex: number; summary: string };
+	candidateFixes: Array<{ hopIndex: number; summary: string }>;
+	relatedContext: Array<{ hopIndex: number; summary: string }>;
+	recommendedNextReads: Array<{ hopIndex: number; reason: string }>;
+}
+
+const FIX_EDGE_TYPES = new Set(["closes", "addresses"]);
+
+/**
+ * Build a heuristic-based conclusion block for agent consumers.
+ * Returns undefined if no hops (no signal to analyze).
+ */
+export function buildConclusion(
+	hops: TraceHop[],
+	chains: LineageChain[],
+): TraceConclusion | undefined {
+	if (hops.length === 0) return undefined;
+
+	// Primary artifact: highest-confidence seed (no parentHopIndex)
+	const seeds = hops.map((h, i) => ({ hop: h, i })).filter(({ hop }) => hop.parentHopIndex == null);
+	const primary =
+		seeds.length > 0
+			? seeds.reduce((best, cur) =>
+					cur.hop.connection.confidence > best.hop.connection.confidence ? cur : best,
+				)
+			: { hop: hops[0], i: 0 };
+
+	// Candidate fixes: edge-based hops with closes/addresses edge types
+	const candidateFixes = hops
+		.map((hop, i) => ({ hop, i }))
+		.filter(
+			({ hop }) =>
+				hop.connection.method === "edge" &&
+				hop.connection.edgeType != null &&
+				FIX_EDGE_TYPES.has(hop.connection.edgeType),
+		)
+		.map(({ hop, i }) => ({
+			hopIndex: i,
+			summary: `${hop.sourceType}: ${hop.source} (${hop.connection.edgeType})`,
+		}));
+
+	// Related context: hops not in any chain
+	const hopsInChains = new Set(chains.flatMap((c) => c.hopIndices));
+	const relatedContext = hops
+		.map((hop, i) => ({ hop, i }))
+		.filter(({ i }) => !hopsInChains.has(i))
+		.map(({ hop, i }) => ({
+			hopIndex: i,
+			summary: `${hop.sourceType}: ${hop.source}`,
+		}));
+
+	// Recommended next reads: leaf hops of chains (last hop in each chain)
+	const leafIndices = new Set(chains.map((c) => c.hopIndices[c.hopIndices.length - 1]));
+	const recommendedNextReads = [...leafIndices].map((i) => ({
+		hopIndex: i,
+		reason: `End of evidence chain — follow up on ${hops[i].sourceType}: ${hops[i].source}`,
+	}));
+
+	return {
+		primaryArtifact: {
+			hopIndex: primary.i,
+			summary: `${primary.hop.sourceType}: ${primary.hop.source}`,
+		},
+		candidateFixes,
+		relatedContext,
+		recommendedNextReads,
+	};
+}

--- a/packages/search/src/trace/conclusion.ts
+++ b/packages/search/src/trace/conclusion.ts
@@ -59,13 +59,16 @@ export function buildConclusion(
 	const leafIndices = new Set(
 		multiHopChains.map((c) => c.hopIndices.at(-1)).filter((i): i is number => i != null),
 	);
-	const recommendedNextReads = [...leafIndices]
-		.filter((i) => hops[i] != null)
-		.map((i) => ({
-			hopIndex: i,
-			// biome-ignore lint: index is validated by filter above
-			reason: `End of evidence chain — follow up on ${hops[i]!.sourceType}: ${hops[i]!.source}`,
-		}));
+	const recommendedNextReads: Array<{ hopIndex: number; reason: string }> = [];
+	for (const i of leafIndices) {
+		const hop = hops[i];
+		if (hop) {
+			recommendedNextReads.push({
+				hopIndex: i,
+				reason: `End of evidence chain — follow up on ${hop.sourceType}: ${hop.source}`,
+			});
+		}
+	}
 
 	const primaryHop = primary.hop;
 	if (!primaryHop) return undefined;

--- a/packages/search/src/trace/conclusion.ts
+++ b/packages/search/src/trace/conclusion.ts
@@ -56,16 +56,24 @@ export function buildConclusion(
 		}));
 
 	// Recommended next reads: leaf hops of multi-hop chains
-	const leafIndices = new Set(multiHopChains.map((c) => c.hopIndices[c.hopIndices.length - 1]));
-	const recommendedNextReads = [...leafIndices].map((i) => ({
-		hopIndex: i,
-		reason: `End of evidence chain — follow up on ${hops[i].sourceType}: ${hops[i].source}`,
-	}));
+	const leafIndices = new Set(
+		multiHopChains.map((c) => c.hopIndices.at(-1)).filter((i): i is number => i != null),
+	);
+	const recommendedNextReads = [...leafIndices]
+		.filter((i) => hops[i] != null)
+		.map((i) => ({
+			hopIndex: i,
+			// biome-ignore lint: index is validated by filter above
+			reason: `End of evidence chain — follow up on ${hops[i]!.sourceType}: ${hops[i]!.source}`,
+		}));
+
+	const primaryHop = primary.hop;
+	if (!primaryHop) return undefined;
 
 	return {
 		primaryArtifact: {
 			hopIndex: primary.i,
-			summary: `${primary.hop.sourceType}: ${primary.hop.source}`,
+			summary: `${primaryHop.sourceType}: ${primaryHop.source}`,
 		},
 		candidateFixes,
 		relatedContext,

--- a/packages/search/src/trace/index.ts
+++ b/packages/search/src/trace/index.ts
@@ -1,8 +1,12 @@
+export type { TraceConclusion } from "./conclusion.js";
+export { buildConclusion } from "./conclusion.js";
 export type { ChunkData, ChunkIndexes } from "./indexing.js";
 export { buildChunkIndexes, buildEdgeIndex } from "./indexing.js";
 export type { InsightKind, TraceInsight } from "./insights.js";
 export { detectInsights } from "./insights.js";
+export type { LineageChain } from "./lineage.js";
+export { buildLineageChains } from "./lineage.js";
 export { findChunksByTarget } from "./resolution.js";
-export type { TraceHop, TraceMode, TraceOptions, TraceResult } from "./trace.js";
+export type { TraceHop, TraceMode, TraceOptions, TraceResult, TraceView } from "./trace.js";
 export { trace } from "./trace.js";
 export { followEdges } from "./traversal.js";

--- a/packages/search/src/trace/indexing.ts
+++ b/packages/search/src/trace/indexing.ts
@@ -6,6 +6,7 @@ export interface ChunkData {
 	source: string;
 	sourceUrl?: string;
 	storageId: string;
+	timestamp?: string;
 }
 
 export interface ChunkIndexes {
@@ -30,6 +31,7 @@ export function buildChunkIndexes(segments: Segment[]): ChunkIndexes {
 				source: chunk.source,
 				sourceUrl: chunk.sourceUrl,
 				storageId: chunk.storageId,
+				timestamp: chunk.timestamp,
 			};
 			byId.set(chunk.id, data);
 

--- a/packages/search/src/trace/lineage.test.ts
+++ b/packages/search/src/trace/lineage.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { buildLineageChains } from "./lineage.js";
+import type { TraceHop } from "./trace.js";
+
+function makeHop(overrides: Partial<TraceHop> & { sourceType: string }): TraceHop {
+	return {
+		content: "test",
+		source: "test-source",
+		storageId: "test-storage",
+		connection: { method: "edge", confidence: 1.0 },
+		...overrides,
+	};
+}
+
+describe("buildLineageChains", () => {
+	it("returns empty array for empty hops", () => {
+		expect(buildLineageChains([])).toEqual([]);
+	});
+
+	it("produces single-hop chains for seed-only hops (no parentHopIndex)", () => {
+		const hops: TraceHop[] = [
+			makeHop({ sourceType: "slack-message" }),
+			makeHop({ sourceType: "github-issue" }),
+		];
+		const chains = buildLineageChains(hops);
+		expect(chains).toHaveLength(2);
+		expect(chains[0].hopIndices).toEqual([0]);
+		expect(chains[1].hopIndices).toEqual([1]);
+	});
+
+	it("reconstructs a linear chain from parentHopIndex links", () => {
+		const hops: TraceHop[] = [
+			makeHop({ sourceType: "slack-message" }),
+			makeHop({ sourceType: "github-issue", parentHopIndex: 0 }),
+			makeHop({ sourceType: "github-pr", parentHopIndex: 1 }),
+			makeHop({ sourceType: "code", parentHopIndex: 2 }),
+		];
+		const chains = buildLineageChains(hops);
+		// Should produce one chain: 0 → 1 → 2 → 3
+		expect(chains).toHaveLength(1);
+		expect(chains[0].hopIndices).toEqual([0, 1, 2, 3]);
+		expect(chains[0].typeSequence).toEqual(["slack-message", "github-issue", "github-pr", "code"]);
+		expect(chains[0].sourceTypeDiversity).toBe(4);
+	});
+
+	it("produces separate chains for branching DFS trees", () => {
+		const hops: TraceHop[] = [
+			makeHop({ sourceType: "slack-message" }), // 0: root
+			makeHop({ sourceType: "github-issue", parentHopIndex: 0 }), // 1: child of 0
+			makeHop({ sourceType: "github-pr", parentHopIndex: 1 }), // 2: child of 1 (branch A leaf)
+			makeHop({ sourceType: "code", parentHopIndex: 1 }), // 3: child of 1 (branch B leaf)
+		];
+		const chains = buildLineageChains(hops);
+		// Two chains: 0→1→2 and 0→1→3
+		expect(chains).toHaveLength(2);
+		// Sorted by length desc (both length 3), then by diversity
+		const chainPaths = chains.map((c) => c.hopIndices);
+		expect(chainPaths).toContainEqual([0, 1, 2]);
+		expect(chainPaths).toContainEqual([0, 1, 3]);
+	});
+
+	it("deduplicates consecutive repeated sourceTypes in typeSequence", () => {
+		const hops: TraceHop[] = [
+			makeHop({ sourceType: "github-pr" }),
+			makeHop({ sourceType: "github-pr", parentHopIndex: 0 }),
+			makeHop({ sourceType: "code", parentHopIndex: 1 }),
+		];
+		const chains = buildLineageChains(hops);
+		expect(chains).toHaveLength(1);
+		// "github-pr" appears twice consecutively → deduplicated
+		expect(chains[0].typeSequence).toEqual(["github-pr", "code"]);
+		// But sourceTypeDiversity counts unique types
+		expect(chains[0].sourceTypeDiversity).toBe(2);
+	});
+
+	it("sorts chains by length descending, then diversity descending", () => {
+		const hops: TraceHop[] = [
+			makeHop({ sourceType: "slack-message" }), // 0: root A
+			makeHop({ sourceType: "github-issue", parentHopIndex: 0 }), // 1
+			makeHop({ sourceType: "github-pr", parentHopIndex: 1 }), // 2 (chain A: length 3, diversity 3)
+			makeHop({ sourceType: "code" }), // 3: root B (chain B: length 1, diversity 1)
+		];
+		const chains = buildLineageChains(hops);
+		expect(chains[0].hopIndices).toEqual([0, 1, 2]); // longer chain first
+		expect(chains[1].hopIndices).toEqual([3]); // shorter chain second
+	});
+
+	it("handles unknown sourceTypes as-is", () => {
+		const hops: TraceHop[] = [
+			makeHop({ sourceType: "custom-adapter" }),
+			makeHop({ sourceType: "custom-adapter-v2", parentHopIndex: 0 }),
+		];
+		const chains = buildLineageChains(hops);
+		expect(chains[0].typeSequence).toEqual(["custom-adapter", "custom-adapter-v2"]);
+	});
+});

--- a/packages/search/src/trace/lineage.test.ts
+++ b/packages/search/src/trace/lineage.test.ts
@@ -24,8 +24,8 @@ describe("buildLineageChains", () => {
 		];
 		const chains = buildLineageChains(hops);
 		expect(chains).toHaveLength(2);
-		expect(chains[0].hopIndices).toEqual([0]);
-		expect(chains[1].hopIndices).toEqual([1]);
+		expect(chains.at(0)?.hopIndices).toEqual([0]);
+		expect(chains.at(1)?.hopIndices).toEqual([1]);
 	});
 
 	it("reconstructs a linear chain from parentHopIndex links", () => {
@@ -36,11 +36,15 @@ describe("buildLineageChains", () => {
 			makeHop({ sourceType: "code", parentHopIndex: 2 }),
 		];
 		const chains = buildLineageChains(hops);
-		// Should produce one chain: 0 → 1 → 2 → 3
 		expect(chains).toHaveLength(1);
-		expect(chains[0].hopIndices).toEqual([0, 1, 2, 3]);
-		expect(chains[0].typeSequence).toEqual(["slack-message", "github-issue", "github-pr", "code"]);
-		expect(chains[0].sourceTypeDiversity).toBe(4);
+		expect(chains.at(0)?.hopIndices).toEqual([0, 1, 2, 3]);
+		expect(chains.at(0)?.typeSequence).toEqual([
+			"slack-message",
+			"github-issue",
+			"github-pr",
+			"code",
+		]);
+		expect(chains.at(0)?.sourceTypeDiversity).toBe(4);
 	});
 
 	it("produces separate chains for branching DFS trees", () => {
@@ -51,9 +55,7 @@ describe("buildLineageChains", () => {
 			makeHop({ sourceType: "code", parentHopIndex: 1 }), // 3: child of 1 (branch B leaf)
 		];
 		const chains = buildLineageChains(hops);
-		// Two chains: 0→1→2 and 0→1→3
 		expect(chains).toHaveLength(2);
-		// Sorted by length desc (both length 3), then by diversity
 		const chainPaths = chains.map((c) => c.hopIndices);
 		expect(chainPaths).toContainEqual([0, 1, 2]);
 		expect(chainPaths).toContainEqual([0, 1, 3]);
@@ -67,10 +69,8 @@ describe("buildLineageChains", () => {
 		];
 		const chains = buildLineageChains(hops);
 		expect(chains).toHaveLength(1);
-		// "github-pr" appears twice consecutively → deduplicated
-		expect(chains[0].typeSequence).toEqual(["github-pr", "code"]);
-		// But sourceTypeDiversity counts unique types
-		expect(chains[0].sourceTypeDiversity).toBe(2);
+		expect(chains.at(0)?.typeSequence).toEqual(["github-pr", "code"]);
+		expect(chains.at(0)?.sourceTypeDiversity).toBe(2);
 	});
 
 	it("sorts chains by length descending, then diversity descending", () => {
@@ -81,8 +81,8 @@ describe("buildLineageChains", () => {
 			makeHop({ sourceType: "code" }), // 3: root B (chain B: length 1, diversity 1)
 		];
 		const chains = buildLineageChains(hops);
-		expect(chains[0].hopIndices).toEqual([0, 1, 2]); // longer chain first
-		expect(chains[1].hopIndices).toEqual([3]); // shorter chain second
+		expect(chains.at(0)?.hopIndices).toEqual([0, 1, 2]);
+		expect(chains.at(1)?.hopIndices).toEqual([3]);
 	});
 
 	it("handles unknown sourceTypes as-is", () => {
@@ -91,6 +91,6 @@ describe("buildLineageChains", () => {
 			makeHop({ sourceType: "custom-adapter-v2", parentHopIndex: 0 }),
 		];
 		const chains = buildLineageChains(hops);
-		expect(chains[0].typeSequence).toEqual(["custom-adapter", "custom-adapter-v2"]);
+		expect(chains.at(0)?.typeSequence).toEqual(["custom-adapter", "custom-adapter-v2"]);
 	});
 });

--- a/packages/search/src/trace/lineage.ts
+++ b/packages/search/src/trace/lineage.ts
@@ -21,7 +21,9 @@ export function buildLineageChains(hops: TraceHop[]): LineageChain[] {
 	const roots: number[] = [];
 
 	for (let i = 0; i < hops.length; i++) {
-		const parent = hops[i].parentHopIndex;
+		const hop = hops[i];
+		if (!hop) continue;
+		const parent = hop.parentHopIndex;
 		if (parent == null) {
 			roots.push(i);
 		} else {
@@ -62,7 +64,7 @@ export function buildLineageChains(hops: TraceHop[]): LineageChain[] {
 }
 
 function buildChain(hopIndices: number[], hops: TraceHop[]): LineageChain {
-	const types = hopIndices.map((i) => hops[i].sourceType);
+	const types = hopIndices.map((i) => hops[i]?.sourceType ?? "unknown");
 	const uniqueTypes = new Set(types);
 
 	// Deduplicate consecutive types

--- a/packages/search/src/trace/lineage.ts
+++ b/packages/search/src/trace/lineage.ts
@@ -1,0 +1,81 @@
+import type { TraceHop } from "./trace.js";
+
+export interface LineageChain {
+	/** Hop indices forming this causal chain, root to leaf */
+	hopIndices: number[];
+	/** Source type sequence with consecutive duplicates removed */
+	typeSequence: string[];
+	/** Number of distinct source types in the chain */
+	sourceTypeDiversity: number;
+}
+
+/**
+ * Reconstruct lineage chains from TraceHop DFS tree via parentHopIndex.
+ * Each chain is a root-to-leaf path. Sorted by length desc, then diversity desc.
+ */
+export function buildLineageChains(hops: TraceHop[]): LineageChain[] {
+	if (hops.length === 0) return [];
+
+	// Build children index
+	const children = new Map<number, number[]>();
+	const roots: number[] = [];
+
+	for (let i = 0; i < hops.length; i++) {
+		const parent = hops[i].parentHopIndex;
+		if (parent == null) {
+			roots.push(i);
+		} else {
+			const kids = children.get(parent) ?? [];
+			kids.push(i);
+			children.set(parent, kids);
+		}
+	}
+
+	// Walk each root to all leaves, collecting paths
+	const chains: LineageChain[] = [];
+
+	function walk(index: number, path: number[]): void {
+		const currentPath = [...path, index];
+		const kids = children.get(index);
+		if (!kids || kids.length === 0) {
+			// Leaf — emit chain
+			chains.push(buildChain(currentPath, hops));
+		} else {
+			for (const child of kids) {
+				walk(child, currentPath);
+			}
+		}
+	}
+
+	for (const root of roots) {
+		walk(root, []);
+	}
+
+	// Sort by length desc, then diversity desc
+	chains.sort((a, b) => {
+		const lenDiff = b.hopIndices.length - a.hopIndices.length;
+		if (lenDiff !== 0) return lenDiff;
+		return b.sourceTypeDiversity - a.sourceTypeDiversity;
+	});
+
+	return chains;
+}
+
+function buildChain(hopIndices: number[], hops: TraceHop[]): LineageChain {
+	const types = hopIndices.map((i) => hops[i].sourceType);
+	const uniqueTypes = new Set(types);
+
+	// Deduplicate consecutive types
+	const typeSequence: string[] = [];
+	for (const t of types) {
+		if (typeSequence.length === 0 || typeSequence[typeSequence.length - 1] !== t) {
+			typeSequence.push(t);
+		}
+	}
+
+	return {
+		hopIndices,
+		typeSequence,
+		sourceTypeDiversity: uniqueTypes.size,
+	};
+}

--- a/packages/search/src/trace/trace.ts
+++ b/packages/search/src/trace/trace.ts
@@ -1,9 +1,12 @@
 import type { Embedder, Segment, VectorIndex } from "@wtfoc/common";
+import { buildConclusion, type TraceConclusion } from "./conclusion.js";
 import { buildChunkIndexes, buildEdgeIndex } from "./indexing.js";
 import { detectInsights, type TraceInsight } from "./insights.js";
+import { buildLineageChains, type LineageChain } from "./lineage.js";
 import { followEdges } from "./traversal.js";
 
 export type TraceMode = "discovery" | "analytical";
+export type TraceView = "lineage" | "timeline" | "evidence";
 
 export interface TraceOptions {
 	/** Max results per source type (default: 3) */
@@ -43,6 +46,8 @@ export interface TraceHop {
 	sourceUrl?: string;
 	/** Storage ID for verification */
 	storageId: string;
+	/** Timestamp from the source chunk (if available) */
+	timestamp?: string;
 	/** Index of the hop that led to this one (undefined for seeds) */
 	parentHopIndex?: number;
 	/** How this hop was found */
@@ -64,6 +69,10 @@ export interface TraceResult {
 	groups: Record<string, TraceHop[]>;
 	/** Flat list of all hops in traversal order */
 	hops: TraceHop[];
+	/** Lineage chains reconstructed from hop DFS tree (always populated) */
+	lineageChains: LineageChain[];
+	/** Agent-oriented conclusion block (only populated in analytical mode, omitted when no signal) */
+	conclusion?: TraceConclusion;
 	/** Cross-source insights (only populated in analytical mode) */
 	insights: TraceInsight[];
 	/** Summary of the trace */
@@ -147,6 +156,7 @@ export async function trace(
 			source: seed.entry.metadata.source ?? "unknown",
 			sourceUrl: seed.entry.metadata.sourceUrl,
 			storageId: seed.entry.storageId,
+			timestamp: chunkData?.timestamp,
 			connection: {
 				method: "semantic",
 				confidence: seed.score,
@@ -213,6 +223,7 @@ export async function trace(
 					source: candidate.entry.metadata.source ?? "unknown",
 					sourceUrl: candidate.entry.metadata.sourceUrl,
 					storageId: candidate.entry.storageId,
+					timestamp: chunkData?.timestamp,
 					connection: {
 						method: "semantic",
 						confidence: candidate.score,
@@ -240,6 +251,12 @@ export async function trace(
 	const sourceTypes = Object.keys(groups);
 	const edgeHops = hops.filter((h) => h.connection.method === "edge").length;
 
+	// Build lineage chains from DFS tree (always, cheap)
+	const lineageChains = buildLineageChains(hops);
+
+	// Build conclusion block in analytical mode (omitted when no signal)
+	const conclusion = mode === "analytical" ? buildConclusion(hops, lineageChains) : undefined;
+
 	// Detect cross-source insights in analytical mode
 	const insights = mode === "analytical" ? detectInsights(hops, segments, options?.signal) : [];
 
@@ -247,6 +264,8 @@ export async function trace(
 		query,
 		groups,
 		hops,
+		lineageChains,
+		conclusion,
 		insights,
 		stats: {
 			totalHops: hops.length,

--- a/packages/search/src/trace/traversal.ts
+++ b/packages/search/src/trace/traversal.ts
@@ -57,6 +57,7 @@ export function followEdges(
 				source: targetData.source,
 				sourceUrl: targetData.sourceUrl,
 				storageId: targetData.storageId,
+				timestamp: targetData.timestamp,
 				parentHopIndex,
 				connection: {
 					method: "edge",


### PR DESCRIPTION
## Summary

- Add `--view lineage|timeline|evidence` flag to `wtfoc trace`
- Lineage view shows inferred causal chains (problem → fix → review) from DFS tree
- Timeline view sorts hops by UTC timestamp with date headers
- Evidence view preserves existing grouped-by-source output unchanged
- Agent conclusion block in JSON: `primaryArtifact`, `candidateFixes[]`, `relatedContext[]`, `recommendedNextReads[]`
- TraceHop now carries optional `timestamp` from Chunk.timestamp
- TraceResult always includes `lineageChains`; `conclusion` in analytical mode only

## Design decisions

- View is presentation-only — `trace()` always returns full TraceResult
- Explicit `--view` overrides mode-based default
- Conclusion uses heuristics (closes/addresses edge types), not LLM
- No breaking JSON changes — all new fields are additive
- Codex (gpt-5.4) peer-reviewed the plan; 3 HIGH + 5 MEDIUM findings addressed

## Test plan

- [x] 29 new tests across 4 files (lineage, conclusion, output formatters, trace integration)
- [x] 810 total tests pass (was 781)
- [x] Lint clean
- [x] Zero hops, single hop, all undated, malformed timestamps edge cases covered
- [x] Manual test with real collection data

## Deferred

- Insights DFS refactor to share code with lineage builder → #211

fixes #54