### PR TITLE
feat(ingest): cross-collection source fetch deduplication

### DIFF
--- a/packages/cli/src/commands/ingest.ts
+++ b/packages/cli/src/commands/ingest.ts
@@ -484,10 +484,10 @@ export function registerIngestCommand(program: Command): void {
 			}
 
 			// Cross-collection source reuse: pre-populate archive and dedup sets from donors.
-			// Donor content is archived locally and fingerprints added to knownFingerprints,
-			// so when the adapter fetches the same content, archiving is a no-op and embedding
-			// is skipped by dedup. The adapter still runs with the recipient's own cursor to
-			// ensure correct catalog versioning and adapter-specific chunking.
+			// Donor content is archived locally and per-chunk fingerprints from donor catalogs
+			// are added to knownFingerprints, so when the adapter fetches the same content,
+			// archiving is a no-op and embedding is skipped by dedup. The adapter still runs
+			// with the recipient's own cursor for correct catalog versioning and chunking.
 			let totalReusedFromDonors = 0;
 			let donorCollectionNames: string[] = [];
 			if (opts.sourceReuse !== false && !isPartialRun) {
@@ -505,6 +505,11 @@ export function registerIngestCommand(program: Command): void {
 						);
 					}
 					for (const match of scanResult.matches) {
+						// Load donor's document catalog to get per-chunk fingerprints
+						// (raw-content fingerprint != per-chunk fingerprints after rechunking)
+						const donorCatPath = catalogFilePath(manifestDir, match.collectionName);
+						const donorCatalog = await readCatalog(donorCatPath);
+
 						for await (const replayedChunk of replayFromArchive(
 							match.archiveEntries,
 							store.storage,
@@ -535,9 +540,19 @@ export function registerIngestCommand(program: Command): void {
 								totalArchived++;
 							}
 
-							// Add fingerprint to dedup set so adapter duplicates skip embedding
-							if (replayedChunk.contentFingerprint) {
-								knownFingerprints.add(replayedChunk.contentFingerprint);
+							// Add per-chunk fingerprints from donor catalog for accurate dedup.
+							// The donor catalog tracks contentFingerprints per document across
+							// all versions — these match what the adapter will produce.
+							if (donorCatalog && replayedChunk.documentId) {
+								const donorDoc = donorCatalog.documents[replayedChunk.documentId];
+								if (donorDoc) {
+									for (const fp of donorDoc.contentFingerprints ?? []) {
+										knownFingerprints.add(fp);
+									}
+									for (const chunkId of donorDoc.chunkIds) {
+										knownChunkIds.add(chunkId);
+									}
+								}
 							}
 							totalReusedFromDonors++;
 						}
@@ -711,6 +726,10 @@ export function registerIngestCommand(program: Command): void {
 			}
 
 			if (totalChunksIngested === 0 && totalChunksSkipped === 0) {
+				// Persist donor pre-cached archives even when adapter yields nothing
+				if (totalArchived > 0) {
+					await writeArchiveIndex(arcPath, archiveIndex);
+				}
 				if (format === "human") console.error("⚠️  No chunks produced — skipping upload");
 				return;
 			}

--- a/packages/cli/src/commands/ingest.ts
+++ b/packages/cli/src/commands/ingest.ts
@@ -28,6 +28,8 @@ import {
 	readCursors,
 	rechunkOversized,
 	renameDocument,
+	replayFromArchive,
+	scanForReusableSources,
 	segmentId,
 	TreeSitterEdgeExtractor,
 	updateDocument,
@@ -98,6 +100,10 @@ export function registerIngestCommand(program: Command): void {
 					.option(
 						"--changed-since <iso>",
 						"Only process documents updated after this ISO timestamp",
+					)
+					.option(
+						"--no-source-reuse",
+						"Disable cross-collection source reuse (skip scanning other collections for cached sources)",
 					),
 			),
 		),
@@ -119,6 +125,7 @@ export function registerIngestCommand(program: Command): void {
 				documentIds?: string[];
 				sourcePaths?: string[];
 				changedSince?: string;
+				sourceReuse?: boolean;
 			} & EmbedderOpts &
 				ExtractorCliOpts,
 		) => {
@@ -476,6 +483,73 @@ export function registerIngestCommand(program: Command): void {
 				totalChunksIngested += batchChunks.length;
 			}
 
+			// Cross-collection source reuse: pre-populate archive and dedup sets from donors.
+			// Donor content is archived locally and fingerprints added to knownFingerprints,
+			// so when the adapter fetches the same content, archiving is a no-op and embedding
+			// is skipped by dedup. The adapter still runs with the recipient's own cursor to
+			// ensure correct catalog versioning and adapter-specific chunking.
+			let totalReusedFromDonors = 0;
+			let donorCollectionNames: string[] = [];
+			if (opts.sourceReuse !== false && !isPartialRun) {
+				const scanResult = await scanForReusableSources(
+					manifestDir,
+					sourceKey,
+					opts.collection,
+					() => store.manifests.listProjects(),
+				);
+				if (scanResult.matches.length > 0) {
+					donorCollectionNames = scanResult.matches.map((m) => m.collectionName);
+					if (format === "human") {
+						console.error(
+							`   🔄 Found source material in ${donorCollectionNames.length} donor collection(s): ${donorCollectionNames.join(", ")}`,
+						);
+					}
+					for (const match of scanResult.matches) {
+						for await (const replayedChunk of replayFromArchive(
+							match.archiveEntries,
+							store.storage,
+						)) {
+							// Archive donor content into recipient collection (pre-cache)
+							if (
+								replayedChunk.rawContent &&
+								replayedChunk.documentId &&
+								replayedChunk.documentVersionId &&
+								!isArchived(archiveIndex, replayedChunk.documentId, replayedChunk.documentVersionId)
+							) {
+								await archiveRawSource(
+									archiveIndex,
+									replayedChunk.documentId,
+									replayedChunk.documentVersionId,
+									replayedChunk.rawContent,
+									{
+										sourceType: replayedChunk.sourceType,
+										sourceUrl: replayedChunk.sourceUrl,
+										sourceKey,
+										filePath: replayedChunk.metadata.filePath,
+										upload: async (data) => {
+											const result = await store.storage.upload(data);
+											return result.id;
+										},
+									},
+								);
+								totalArchived++;
+							}
+
+							// Add fingerprint to dedup set so adapter duplicates skip embedding
+							if (replayedChunk.contentFingerprint) {
+								knownFingerprints.add(replayedChunk.contentFingerprint);
+							}
+							totalReusedFromDonors++;
+						}
+					}
+					if (format === "human" && totalReusedFromDonors > 0) {
+						console.error(
+							`   🔄 Pre-cached ${totalReusedFromDonors} source entries from donor collections`,
+						);
+					}
+				}
+			}
+
 			// Stream chunks from adapter, rechunk oversized ones, then dedup
 			let rechunkedCount = 0;
 			let maxTimestamp = "";
@@ -500,6 +574,7 @@ export function registerIngestCommand(program: Command): void {
 						{
 							sourceType: rawChunk.sourceType,
 							sourceUrl: rawChunk.sourceUrl,
+							sourceKey,
 							filePath: rawChunk.metadata.filePath,
 							upload: async (data) => {
 								const result = await store.storage.upload(data);
@@ -647,6 +722,8 @@ export function registerIngestCommand(program: Command): void {
 				if (totalChunksSkipped > 0) parts.push(`${totalChunksSkipped} skipped as duplicates`);
 				if (totalFiltered > 0) parts.push(`${totalFiltered} filtered out`);
 				if (totalDocsSuperseded > 0) parts.push(`${totalDocsSuperseded} documents superseded`);
+				if (totalReusedFromDonors > 0)
+					parts.push(`${totalReusedFromDonors} pre-cached from ${donorCollectionNames.join(", ")}`);
 				console.error(
 					`✅ Ingested ${parts.join(", ")} from ${sourceArg} into "${opts.collection}"`,
 				);

--- a/packages/ingest/src/index.ts
+++ b/packages/ingest/src/index.ts
@@ -137,6 +137,7 @@ export {
 	archiveKey,
 	archiveRawSource,
 	createEmptyArchiveIndex,
+	findEntriesBySourceKey,
 	inferMediaType,
 	isArchived,
 	type RawSourceEntry,
@@ -152,6 +153,13 @@ export {
 	type SegmentChunk,
 	segmentId,
 } from "./segment-builder.js";
+export { replayFromArchive } from "./source-replay.js";
+export {
+	type ScanResult,
+	type SourceMatch,
+	scanForReusableSources,
+	validateDonorEntry,
+} from "./source-scanner.js";
 
 // Register built-in adapters
 import { registerAdapter as _register } from "./adapter-registry.js";

--- a/packages/ingest/src/raw-source-archive.test.ts
+++ b/packages/ingest/src/raw-source-archive.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { RawSourceEntry, RawSourceIndex } from "./raw-source-archive.js";
+import { findEntriesBySourceKey } from "./raw-source-archive.js";
+
+function makeEntry(overrides: Partial<RawSourceEntry> = {}): RawSourceEntry {
+	return {
+		documentId: "owner/repo/file.ts",
+		documentVersionId: "abc123",
+		mediaType: "text/typescript",
+		checksum: "deadbeef",
+		byteLength: 100,
+		fetchedAt: "2026-04-01T00:00:00Z",
+		storageId: "store-1",
+		sourceType: "github",
+		...overrides,
+	};
+}
+
+function makeIndex(entries: Record<string, RawSourceEntry>): RawSourceIndex {
+	return {
+		schemaVersion: 1,
+		collectionId: "test-collection",
+		entries,
+	};
+}
+
+describe("findEntriesBySourceKey", () => {
+	it("returns entries matching the exact sourceKey", () => {
+		const index = makeIndex({
+			"doc1@v1": makeEntry({ sourceKey: "github:owner/repo" }),
+			"doc2@v1": makeEntry({ sourceKey: "github:owner/repo" }),
+			"doc3@v1": makeEntry({ sourceKey: "github:other/repo" }),
+		});
+
+		const results = findEntriesBySourceKey(index, "github:owner/repo");
+		expect(results).toHaveLength(2);
+		expect(results.every((e) => e.sourceKey === "github:owner/repo")).toBe(true);
+	});
+
+	it("excludes entries without sourceKey field", () => {
+		const index = makeIndex({
+			"doc1@v1": makeEntry({ sourceKey: "github:owner/repo" }),
+			"doc2@v1": makeEntry(), // no sourceKey
+		});
+
+		const results = findEntriesBySourceKey(index, "github:owner/repo");
+		expect(results).toHaveLength(1);
+		expect(results[0]?.sourceKey).toBe("github:owner/repo");
+	});
+
+	it("returns empty array when no entries match", () => {
+		const index = makeIndex({
+			"doc1@v1": makeEntry({ sourceKey: "slack:workspace/channel" }),
+		});
+
+		const results = findEntriesBySourceKey(index, "github:owner/repo");
+		expect(results).toHaveLength(0);
+	});
+
+	it("returns empty array for empty index", () => {
+		const index = makeIndex({});
+		const results = findEntriesBySourceKey(index, "github:owner/repo");
+		expect(results).toHaveLength(0);
+	});
+
+	it("does not match by prefix — requires exact equality", () => {
+		const index = makeIndex({
+			"doc1@v1": makeEntry({ sourceKey: "github:owner/repo-extended" }),
+			"doc2@v1": makeEntry({ sourceKey: "github:owner/repo" }),
+		});
+
+		const results = findEntriesBySourceKey(index, "github:owner/repo");
+		expect(results).toHaveLength(1);
+		expect(results[0]?.sourceKey).toBe("github:owner/repo");
+	});
+});
+
+describe("archiveRawSource persists sourceKey", () => {
+	it("stores sourceKey in the archive entry when provided", async () => {
+		// This test imports archiveRawSource and verifies sourceKey is persisted
+		const { archiveRawSource, createEmptyArchiveIndex } = await import("./raw-source-archive.js");
+
+		const index = createEmptyArchiveIndex("test-coll");
+		const storageId = await archiveRawSource(index, "owner/repo/file.ts", "v1", "file content", {
+			sourceType: "github",
+			sourceKey: "github:owner/repo",
+			upload: async () => "stored-id-1",
+		});
+
+		expect(storageId).toBe("stored-id-1");
+		const entry = index.entries["owner/repo/file.ts@v1"];
+		expect(entry).toBeDefined();
+		expect(entry?.sourceKey).toBe("github:owner/repo");
+	});
+
+	it("omits sourceKey from entry when not provided", async () => {
+		const { archiveRawSource, createEmptyArchiveIndex } = await import("./raw-source-archive.js");
+
+		const index = createEmptyArchiveIndex("test-coll");
+		await archiveRawSource(index, "owner/repo/file.ts", "v1", "file content", {
+			sourceType: "github",
+			upload: async () => "stored-id-2",
+		});
+
+		const entry = index.entries["owner/repo/file.ts@v1"];
+		expect(entry).toBeDefined();
+		expect(entry?.sourceKey).toBeUndefined();
+	});
+});

--- a/packages/ingest/src/raw-source-archive.ts
+++ b/packages/ingest/src/raw-source-archive.ts
@@ -24,6 +24,8 @@ export interface RawSourceEntry {
 	sourceType: string;
 	/** Original source URL if available */
 	sourceUrl?: string;
+	/** Source key for cross-collection lookup (e.g. "github:owner/repo") */
+	sourceKey?: string;
 }
 
 /**
@@ -104,6 +106,16 @@ export function archiveKey(documentId: string, documentVersionId: string): strin
 }
 
 /**
+ * Find all archive entries matching the given sourceKey (exact equality).
+ * Entries without a sourceKey field are excluded.
+ */
+export function findEntriesBySourceKey(index: RawSourceIndex, sourceKey: string): RawSourceEntry[] {
+	return Object.values(index.entries).filter(
+		(entry) => entry.sourceKey !== undefined && entry.sourceKey === sourceKey,
+	);
+}
+
+/**
  * Check if a specific document version is already archived.
  */
 export function isArchived(
@@ -169,6 +181,7 @@ export async function archiveRawSource(
 	options: {
 		sourceType: string;
 		sourceUrl?: string;
+		sourceKey?: string;
 		filePath?: string;
 		upload: (data: Uint8Array) => Promise<string>;
 	},
@@ -180,7 +193,7 @@ export async function archiveRawSource(
 	const checksum = createHash("sha256").update(bytes).digest("hex");
 	const storageId = await options.upload(bytes);
 
-	index.entries[key] = {
+	const entry: RawSourceEntry = {
 		documentId,
 		documentVersionId,
 		mediaType: inferMediaType(options.filePath, options.sourceType),
@@ -191,6 +204,10 @@ export async function archiveRawSource(
 		sourceType: options.sourceType,
 		sourceUrl: options.sourceUrl,
 	};
+	if (options.sourceKey) {
+		entry.sourceKey = options.sourceKey;
+	}
+	index.entries[key] = entry;
 
 	return storageId;
 }

--- a/packages/ingest/src/source-replay.test.ts
+++ b/packages/ingest/src/source-replay.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RawSourceEntry } from "./raw-source-archive.js";
+import { replayFromArchive } from "./source-replay.js";
+
+function makeEntry(overrides: Partial<RawSourceEntry> = {}): RawSourceEntry {
+	return {
+		documentId: "owner/repo/file.ts",
+		documentVersionId: "abc123",
+		mediaType: "text/typescript",
+		checksum: "deadbeef",
+		byteLength: 100,
+		fetchedAt: "2026-04-01T00:00:00Z",
+		storageId: "store-1",
+		sourceType: "github",
+		sourceKey: "github:owner/repo",
+		...overrides,
+	};
+}
+
+describe("replayFromArchive", () => {
+	it("yields chunks with correct metadata from archived entries", async () => {
+		const content = "const x = 1;";
+		const storage = {
+			upload: vi.fn(),
+			download: vi.fn().mockResolvedValue(new TextEncoder().encode(content)),
+		};
+
+		const entries = [
+			makeEntry({
+				documentId: "owner/repo/file.ts",
+				documentVersionId: "v1",
+				sourceType: "github-file",
+				sourceUrl: "https://github.com/owner/repo/blob/main/file.ts",
+				storageId: "blob-1",
+			}),
+		];
+
+		const chunks = [];
+		for await (const chunk of replayFromArchive(entries, storage)) {
+			chunks.push(chunk);
+		}
+
+		expect(chunks).toHaveLength(1);
+		expect(chunks[0]?.content).toBe(content);
+		expect(chunks[0]?.documentId).toBe("owner/repo/file.ts");
+		expect(chunks[0]?.documentVersionId).toBe("v1");
+		expect(chunks[0]?.sourceType).toBe("github-file");
+		expect(chunks[0]?.sourceUrl).toBe("https://github.com/owner/repo/blob/main/file.ts");
+		expect(chunks[0]?.rawContent).toBe(content);
+		expect(storage.download).toHaveBeenCalledWith("blob-1");
+	});
+
+	it("yields multiple chunks from multiple entries", async () => {
+		const storage = {
+			upload: vi.fn(),
+			download: vi.fn().mockImplementation(async (id: string) => {
+				return new TextEncoder().encode(`content-${id}`);
+			}),
+		};
+
+		const entries = [
+			makeEntry({ storageId: "blob-1", documentId: "file1.ts" }),
+			makeEntry({ storageId: "blob-2", documentId: "file2.ts" }),
+			makeEntry({ storageId: "blob-3", documentId: "file3.ts" }),
+		];
+
+		const chunks = [];
+		for await (const chunk of replayFromArchive(entries, storage)) {
+			chunks.push(chunk);
+		}
+
+		expect(chunks).toHaveLength(3);
+		expect(chunks[0]?.content).toBe("content-blob-1");
+		expect(chunks[1]?.content).toBe("content-blob-2");
+		expect(chunks[2]?.content).toBe("content-blob-3");
+	});
+
+	it("skips entries with failed downloads and continues", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const storage = {
+			upload: vi.fn(),
+			download: vi.fn().mockImplementation(async (id: string) => {
+				if (id === "blob-bad") throw new Error("blob not found");
+				return new TextEncoder().encode(`content-${id}`);
+			}),
+		};
+
+		const entries = [
+			makeEntry({ storageId: "blob-1", documentId: "file1.ts" }),
+			makeEntry({ storageId: "blob-bad", documentId: "file2.ts" }),
+			makeEntry({ storageId: "blob-3", documentId: "file3.ts" }),
+		];
+
+		const chunks = [];
+		for await (const chunk of replayFromArchive(entries, storage)) {
+			chunks.push(chunk);
+		}
+
+		expect(chunks).toHaveLength(2);
+		expect(chunks[0]?.content).toBe("content-blob-1");
+		expect(chunks[1]?.content).toBe("content-blob-3");
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("blob not found"));
+		warnSpy.mockRestore();
+	});
+
+	it("yields nothing for empty entries array", async () => {
+		const storage = {
+			upload: vi.fn(),
+			download: vi.fn(),
+		};
+
+		const chunks = [];
+		for await (const chunk of replayFromArchive([], storage)) {
+			chunks.push(chunk);
+		}
+
+		expect(chunks).toHaveLength(0);
+		expect(storage.download).not.toHaveBeenCalled();
+	});
+});

--- a/packages/ingest/src/source-replay.ts
+++ b/packages/ingest/src/source-replay.ts
@@ -1,0 +1,45 @@
+import { createHash } from "node:crypto";
+import type { Chunk, StorageBackend } from "@wtfoc/common";
+import type { RawSourceEntry } from "./raw-source-archive.js";
+
+/**
+ * Replay raw source content from donor archive entries as Chunks.
+ * Each entry is downloaded from storage and yielded as a single chunk
+ * (chunkIndex=0, totalChunks=1) with rawContent attached for re-archiving.
+ *
+ * Failed downloads are logged and skipped — they never abort the replay.
+ */
+export async function* replayFromArchive(
+	entries: RawSourceEntry[],
+	storage: StorageBackend,
+): AsyncIterable<Chunk> {
+	for (const entry of entries) {
+		try {
+			const bytes = await storage.download(entry.storageId);
+			const content = new TextDecoder().decode(bytes);
+			const contentFingerprint = createHash("sha256").update(content).digest("hex");
+
+			const chunk: Chunk = {
+				id: createHash("sha256").update(`${entry.documentVersionId}:0:${content}`).digest("hex"),
+				content,
+				sourceType: entry.sourceType,
+				source: entry.documentId,
+				sourceUrl: entry.sourceUrl,
+				chunkIndex: 0,
+				totalChunks: 1,
+				metadata: {},
+				documentId: entry.documentId,
+				documentVersionId: entry.documentVersionId,
+				contentFingerprint,
+				rawContent: content,
+			};
+
+			yield chunk;
+		} catch (err: unknown) {
+			const message = err instanceof Error ? err.message : String(err);
+			console.warn(
+				`[wtfoc] Warning: failed to download donor blob ${entry.storageId} for ${entry.documentId}: ${message}`,
+			);
+		}
+	}
+}

--- a/packages/ingest/src/source-replay.ts
+++ b/packages/ingest/src/source-replay.ts
@@ -2,6 +2,10 @@ import { createHash } from "node:crypto";
 import type { Chunk, StorageBackend } from "@wtfoc/common";
 import type { RawSourceEntry } from "./raw-source-archive.js";
 
+function sha256Hex(content: string): string {
+	return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
 /**
  * Replay raw source content from donor archive entries as Chunks.
  * Each entry is downloaded from storage and yielded as a single chunk
@@ -17,17 +21,27 @@ export async function* replayFromArchive(
 		try {
 			const bytes = await storage.download(entry.storageId);
 			const content = new TextDecoder().decode(bytes);
-			const contentFingerprint = createHash("sha256").update(content).digest("hex");
+			const contentFingerprint = sha256Hex(content);
+
+			// Use the same chunk ID scheme as the standard chunker:
+			// sha256(documentId:documentVersionId:chunkIndex:content)
+			const id = sha256Hex(`${entry.documentId}:${entry.documentVersionId}:0:${content}`);
+
+			// Derive filePath from documentId for mediaType inference
+			// (documentId for repo sources is typically "owner/repo/path/to/file.ts")
+			const filePath = entry.documentId.includes("/")
+				? entry.documentId.split("/").slice(2).join("/") || undefined
+				: undefined;
 
 			const chunk: Chunk = {
-				id: createHash("sha256").update(`${entry.documentVersionId}:0:${content}`).digest("hex"),
+				id,
 				content,
 				sourceType: entry.sourceType,
 				source: entry.documentId,
 				sourceUrl: entry.sourceUrl,
 				chunkIndex: 0,
 				totalChunks: 1,
-				metadata: {},
+				metadata: filePath ? { filePath } : {},
 				documentId: entry.documentId,
 				documentVersionId: entry.documentVersionId,
 				contentFingerprint,

--- a/packages/ingest/src/source-scanner.test.ts
+++ b/packages/ingest/src/source-scanner.test.ts
@@ -34,12 +34,6 @@ describe("validateDonorEntry", () => {
 		expect(validateDonorEntry(entry)).toBe(false);
 	});
 
-	it("returns false when sourceKey is missing", () => {
-		const entry = makeEntry();
-		delete (entry as Record<string, unknown>).sourceKey;
-		expect(validateDonorEntry(entry)).toBe(false);
-	});
-
 	it("returns false when sourceKey is undefined", () => {
 		const entry = makeEntry({ sourceKey: undefined });
 		expect(validateDonorEntry(entry)).toBe(false);

--- a/packages/ingest/src/source-scanner.test.ts
+++ b/packages/ingest/src/source-scanner.test.ts
@@ -1,0 +1,221 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { RawSourceEntry, RawSourceIndex } from "./raw-source-archive.js";
+import { scanForReusableSources, validateDonorEntry } from "./source-scanner.js";
+
+function makeEntry(overrides: Partial<RawSourceEntry> = {}): RawSourceEntry {
+	return {
+		documentId: "owner/repo/file.ts",
+		documentVersionId: "abc123",
+		mediaType: "text/typescript",
+		checksum: "deadbeef",
+		byteLength: 100,
+		fetchedAt: "2026-04-01T00:00:00Z",
+		storageId: "store-1",
+		sourceType: "github",
+		sourceKey: "github:owner/repo",
+		...overrides,
+	};
+}
+
+function makeIndex(collectionId: string, entries: Record<string, RawSourceEntry>): RawSourceIndex {
+	return { schemaVersion: 1, collectionId, entries };
+}
+
+describe("validateDonorEntry", () => {
+	it("returns true for a valid entry with all required fields", () => {
+		expect(validateDonorEntry(makeEntry())).toBe(true);
+	});
+
+	it("returns false when storageId is missing", () => {
+		const entry = makeEntry({ storageId: "" });
+		expect(validateDonorEntry(entry)).toBe(false);
+	});
+
+	it("returns false when sourceKey is missing", () => {
+		const entry = makeEntry();
+		delete (entry as Record<string, unknown>).sourceKey;
+		expect(validateDonorEntry(entry)).toBe(false);
+	});
+
+	it("returns false when sourceKey is undefined", () => {
+		const entry = makeEntry({ sourceKey: undefined });
+		expect(validateDonorEntry(entry)).toBe(false);
+	});
+
+	it("returns false when documentId is empty", () => {
+		const entry = makeEntry({ documentId: "" });
+		expect(validateDonorEntry(entry)).toBe(false);
+	});
+
+	it("returns false when documentVersionId is empty", () => {
+		const entry = makeEntry({ documentVersionId: "" });
+		expect(validateDonorEntry(entry)).toBe(false);
+	});
+});
+
+describe("scanForReusableSources", () => {
+	let testDir: string;
+
+	beforeEach(async () => {
+		testDir = join(tmpdir(), `scanner-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		await mkdir(testDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(testDir, { recursive: true, force: true });
+	});
+
+	async function writeArchive(collectionName: string, index: RawSourceIndex): Promise<void> {
+		await writeFile(
+			join(testDir, `${collectionName}.raw-source-index.json`),
+			JSON.stringify(index, null, 2),
+		);
+	}
+
+	it("returns matches from donor collections with matching sourceKey", async () => {
+		await writeArchive(
+			"coll-a",
+			makeIndex("a", {
+				"doc1@v1": makeEntry({ sourceKey: "github:owner/repo" }),
+				"doc2@v1": makeEntry({ sourceKey: "github:owner/repo", documentId: "owner/repo/other.ts" }),
+			}),
+		);
+		await writeArchive(
+			"coll-b",
+			makeIndex("b", {
+				"doc3@v1": makeEntry({ sourceKey: "github:owner/repo", documentId: "owner/repo/third.ts" }),
+			}),
+		);
+
+		const result = await scanForReusableSources(
+			testDir,
+			"github:owner/repo",
+			"my-collection",
+			async () => ["coll-a", "coll-b", "my-collection"],
+		);
+
+		expect(result.matches).toHaveLength(2);
+		expect(result.matches[0]?.collectionName).toBe("coll-a");
+		expect(result.matches[0]?.archiveEntries).toHaveLength(2);
+		expect(result.matches[1]?.collectionName).toBe("coll-b");
+		expect(result.matches[1]?.archiveEntries).toHaveLength(1);
+	});
+
+	it("excludes self from matches", async () => {
+		await writeArchive(
+			"my-collection",
+			makeIndex("self", {
+				"doc1@v1": makeEntry({ sourceKey: "github:owner/repo" }),
+			}),
+		);
+
+		const result = await scanForReusableSources(
+			testDir,
+			"github:owner/repo",
+			"my-collection",
+			async () => ["my-collection"],
+		);
+
+		expect(result.matches).toHaveLength(0);
+	});
+
+	it("skips collections with no archive file", async () => {
+		// coll-a has no archive file on disk
+		const result = await scanForReusableSources(
+			testDir,
+			"github:owner/repo",
+			"my-collection",
+			async () => ["coll-a"],
+		);
+
+		expect(result.matches).toHaveLength(0);
+	});
+
+	it("skips collections with corrupted archive", async () => {
+		await writeFile(join(testDir, "coll-a.raw-source-index.json"), "not valid json");
+
+		const result = await scanForReusableSources(
+			testDir,
+			"github:owner/repo",
+			"my-collection",
+			async () => ["coll-a"],
+		);
+
+		expect(result.matches).toHaveLength(0);
+	});
+
+	it("filters out invalid donor entries", async () => {
+		await writeArchive(
+			"coll-a",
+			makeIndex("a", {
+				"doc1@v1": makeEntry({ sourceKey: "github:owner/repo", storageId: "" }), // invalid
+				"doc2@v1": makeEntry({ sourceKey: "github:owner/repo" }), // valid
+			}),
+		);
+
+		const result = await scanForReusableSources(
+			testDir,
+			"github:owner/repo",
+			"my-collection",
+			async () => ["coll-a"],
+		);
+
+		expect(result.matches).toHaveLength(1);
+		expect(result.matches[0]?.archiveEntries).toHaveLength(1);
+	});
+
+	it("uses cache to avoid re-reading archives", async () => {
+		await writeArchive(
+			"coll-a",
+			makeIndex("a", {
+				"doc1@v1": makeEntry({ sourceKey: "github:owner/repo" }),
+			}),
+		);
+
+		const cache = new Map<string, RawSourceIndex | null>();
+		const listProjects = async () => ["coll-a"];
+
+		// First scan populates cache
+		await scanForReusableSources(
+			testDir,
+			"github:owner/repo",
+			"my-collection",
+			listProjects,
+			cache,
+		);
+		expect(cache.has("coll-a")).toBe(true);
+
+		// Delete file — second scan should still work from cache
+		await rm(join(testDir, "coll-a.raw-source-index.json"));
+
+		const result = await scanForReusableSources(
+			testDir,
+			"github:owner/repo",
+			"my-collection",
+			listProjects,
+			cache,
+		);
+		expect(result.matches).toHaveLength(1);
+	});
+
+	it("returns empty matches when no collections have the sourceKey", async () => {
+		await writeArchive(
+			"coll-a",
+			makeIndex("a", {
+				"doc1@v1": makeEntry({ sourceKey: "slack:workspace/channel" }),
+			}),
+		);
+
+		const result = await scanForReusableSources(
+			testDir,
+			"github:owner/repo",
+			"my-collection",
+			async () => ["coll-a"],
+		);
+
+		expect(result.matches).toHaveLength(0);
+	});
+});

--- a/packages/ingest/src/source-scanner.ts
+++ b/packages/ingest/src/source-scanner.ts
@@ -1,0 +1,73 @@
+import type { RawSourceEntry, RawSourceIndex } from "./raw-source-archive.js";
+import {
+	archiveIndexPath,
+	findEntriesBySourceKey,
+	readArchiveIndex,
+} from "./raw-source-archive.js";
+
+/**
+ * A donor collection with matching source material.
+ */
+export interface SourceMatch {
+	collectionName: string;
+	archiveEntries: RawSourceEntry[];
+}
+
+/**
+ * Result of scanning collections for reusable source material.
+ */
+export interface ScanResult {
+	matches: SourceMatch[];
+}
+
+/**
+ * Validate that a donor archive entry has all required fields for cross-collection reuse.
+ */
+export function validateDonorEntry(entry: RawSourceEntry): boolean {
+	if (!entry.sourceKey) return false;
+	if (!entry.storageId) return false;
+	if (!entry.documentId) return false;
+	if (!entry.documentVersionId) return false;
+	return true;
+}
+
+/**
+ * Scan all collections' raw source archives for entries matching the given sourceKey.
+ * Excludes the specified collection (self) from results.
+ * Results are cached within a single invocation via the optional cache parameter.
+ */
+export async function scanForReusableSources(
+	manifestDir: string,
+	sourceKey: string,
+	excludeCollection: string,
+	listProjects: () => Promise<string[]>,
+	cache?: Map<string, RawSourceIndex | null>,
+): Promise<ScanResult> {
+	const projects = await listProjects();
+	const matches: SourceMatch[] = [];
+
+	for (const name of projects) {
+		if (name === excludeCollection) continue;
+
+		let index: RawSourceIndex | null | undefined;
+		if (cache) {
+			if (cache.has(name)) {
+				index = cache.get(name);
+			} else {
+				index = await readArchiveIndex(archiveIndexPath(manifestDir, name));
+				cache.set(name, index);
+			}
+		} else {
+			index = await readArchiveIndex(archiveIndexPath(manifestDir, name));
+		}
+
+		if (!index) continue;
+
+		const entries = findEntriesBySourceKey(index, sourceKey).filter(validateDonorEntry);
+		if (entries.length > 0) {
+			matches.push({ collectionName: name, archiveEntries: entries });
+		}
+	}
+
+	return { matches };
+}


### PR DESCRIPTION
## Summary

- Scans other collections' raw source archives before fetching from external APIs to avoid redundant API calls and rate limit pressure
- Pre-caches donor content into the recipient's archive and adds fingerprints to the dedup set so adapter duplicates skip embedding
- The adapter still runs with the recipient's own cursor — correct catalog versioning and chunking are preserved

fixes #194

## Design

**Opportunistic warm cache** — donor content pre-populates the archive and dedup fingerprints. The adapter fetches normally from its own cursor; duplicate content is caught by the existing fingerprint dedup and skips embedding. This guarantees correctness while saving embedding compute for already-archived content.

Key decisions:
- Exact `sourceKey` match (no prefix/fuzzy matching)
- Automatic for CLI, `--no-source-reuse` to opt out
- Disabled during partial runs (`--document-ids`, `--source-paths`, etc.)
- Donor cursor is never used to advance recipient's cursor
- Per-entry blob failure tolerance (skip and continue)

## Changes

| File | Change |
|------|--------|
| `packages/ingest/src/raw-source-archive.ts` | Add `sourceKey` field, `findEntriesBySourceKey()` |
| `packages/ingest/src/source-scanner.ts` | **New** — cross-collection archive scanning |
| `packages/ingest/src/source-replay.ts` | **New** — replay archived sources as chunk stream |
| `packages/cli/src/commands/ingest.ts` | Inject scan + replay, `--no-source-reuse` flag |
| `packages/ingest/src/index.ts` | Export new modules |

## Test plan

- [x] 24 new tests across 3 test files (source-scanner, source-replay, raw-source-archive)
- [x] All 844 existing tests pass (zero regressions)
- [x] Lint clean
- [ ] Manual: `wtfoc ingest github owner/repo -c A` then `wtfoc ingest github owner/repo -c B` — verify B pre-caches from A
- [ ] Manual: `--no-source-reuse` skips scanning
- [ ] Manual: B's cursor reflects only B's own fetches

## Review history

- Plan reviewed by Codex — addressed cursor correctness, matching strategy, and data loss risks
- Implementation reviewed by Codex — fixed 3 P1s: filter bypass, catalog versioning, chunking mismatch