### PR TITLE
docs: rewrite README; positioning and onboarding

### DIFF
--- a/.specweave/increments/0056G-rewrite-readme-positioning-and-onboarding/metadata.json
+++ b/.specweave/increments/0056G-rewrite-readme-positioning-and-onboarding/metadata.json
@@ -1,0 +1,16 @@
+{
+  "id": "0056G-rewrite-readme-positioning-and-onboarding",
+  "status": "active",
+  "type": "docs",
+  "priority": "P2",
+  "created": "2026-04-12T18:00:00.000Z",
+  "lastActivity": "2026-04-12T18:20:00.000Z",
+  "testMode": "docs",
+  "coverageTarget": 0,
+  "feature_id": null,
+  "epic_id": null,
+  "externalLinks": {
+    "github": "https://github.com/SgtPooki/wtfoc/issues/235"
+  },
+  "project": "wtfoc"
+}

--- a/.specweave/increments/0056G-rewrite-readme-positioning-and-onboarding/plan.md
+++ b/.specweave/increments/0056G-rewrite-readme-positioning-and-onboarding/plan.md
@@ -1,0 +1,28 @@
+# Plan: Rewrite README positioning and onboarding
+
+**Increment**: 0056G-rewrite-readme-positioning-and-onboarding
+**Status**: Planned
+
+## Architecture
+
+No product architecture changes. This increment changes only the information architecture and messaging hierarchy of the root `README.md`.
+
+The authoritative sources for alignment are:
+
+- `docs/why.md` for product problem framing and differentiation
+- `docs/vision.md` for north-star direction and anti-goals
+- `SPEC.md` for architectural invariants and seam terminology
+
+## Approach
+
+1. Reframe the opening copy around audience, problem, and outcome.
+2. Move the search-vs-trace distinction near the top.
+3. Keep a smaller set of top-level onboarding choices.
+4. Compress the FOC/storage explanation so it supports the thesis instead of dominating it.
+5. Add a concrete example section that demonstrates trace value in plain language.
+6. Keep deeper detail in linked docs instead of duplicating long-form vision content.
+
+## Dependencies
+
+- Existing docs must remain the source of truth for deeper rationale and long-term direction.
+- The README must not claim features that lack tracking or active delivery context.

--- a/.specweave/increments/0056G-rewrite-readme-positioning-and-onboarding/spec.md
+++ b/.specweave/increments/0056G-rewrite-readme-positioning-and-onboarding/spec.md
@@ -1,0 +1,66 @@
+# Rewrite README positioning and onboarding
+
+**Increment**: 0056G-rewrite-readme-positioning-and-onboarding
+**Type**: docs | **Priority**: P2 | **Labels**: docs, P2
+**Source**: GitHub #235
+
+## Description
+
+## Problem
+
+The root `README.md` already communicates the broad thesis of `wtfoc`, but it does not present that thesis in the clearest order for a new visitor.
+
+The current document has three messaging problems:
+
+- it introduces multiple entry points before clearly establishing the product outcome and intended audience
+- it underemphasizes the strongest differentiators from `docs/why.md`: search vs trace, evidence-backed edges, and provenance
+- it blurs current product reality with longer-term vision in ways that can make the project sound more complete than the README can immediately prove
+
+This makes the README less effective as the front door for skeptical developers and less aligned with the sharper positioning already developed in `docs/why.md` and `docs/vision.md`.
+
+## Goal
+
+Rewrite the root README so it:
+
+- states the user, problem, and outcome in plain language near the top
+- surfaces the search-vs-trace distinction early
+- keeps the document honest about current capabilities while still pointing at the broader vision
+- simplifies early onboarding choices
+- preserves concrete, runnable ways to try the project
+
+## Non-goals
+
+- changing product behavior, package boundaries, or public APIs
+- introducing new roadmap promises that are not already grounded in the current repo
+- adding private/encrypted collection claims to the README before they have active implementation work
+
+## Proposed shape
+
+The rewritten README should follow this flow:
+
+1. Hero and concise value proposition
+2. Short problem framing
+3. Search vs trace comparison
+4. Quick start paths for hosted MCP, CLI, and self-hosting
+5. What makes `wtfoc` different today
+6. Example or proof section that shows a concrete trace outcome
+7. Packages, seams, and deeper docs
+
+## Acceptance criteria
+
+- The opening section identifies who `wtfoc` is for and what it does without requiring the reader to infer it
+- The README explicitly distinguishes `query` from `trace`
+- The differentiators from `docs/why.md` appear in the README without copying the entire essay
+- The README avoids implying untracked or distant vision items are available now
+- The README still preserves concrete adoption paths: hosted MCP, CLI, and self-host
+
+## User Stories
+
+- **US-001**: As a new visitor, I want the README to explain what `wtfoc` is, why it is different, and how to try it so I can decide quickly whether it fits my workflow
+  - **AC-US1-01**: [x] The rewritten README clearly states user, problem, and differentiation
+  - **AC-US1-02**: [x] The rewritten README keeps current capabilities and longer-term vision appropriately separated
+  - **AC-US1-03**: [x] The rewritten README preserves concrete onboarding paths and links to deeper docs
+
+## Notes
+
+This increment is documentation-only and should validate through doc review rather than code tests.

--- a/.specweave/increments/0056G-rewrite-readme-positioning-and-onboarding/tasks.md
+++ b/.specweave/increments/0056G-rewrite-readme-positioning-and-onboarding/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: Rewrite README positioning and onboarding
+
+**Increment**: 0056G-rewrite-readme-positioning-and-onboarding
+
+### T-001: Rewrite README structure and messaging
+**User Story**: US-001 | **Satisfies ACs**: AC-US1-01, AC-US1-02, AC-US1-03 | **Status**: [x] completed
+**Test Plan**: Given the rewritten README → When reviewed against `docs/why.md`, `docs/vision.md`, and `SPEC.md` → Then the messaging and scope remain aligned
+
+### T-002: Validate doc accuracy and readability
+**User Story**: US-001 | **Satisfies ACs**: AC-US1-01, AC-US1-02, AC-US1-03 | **Status**: [x] completed
+**Test Plan**: Given the final README → When checked for broken assumptions, overstated claims, and preserved try-it-now paths → Then the document remains accurate and actionable

--- a/README.md
+++ b/README.md
@@ -2,21 +2,33 @@
 
 > What the FOC happened? Trace it.
 
-**Cross-source knowledge tracing on [Filecoin Onchain Cloud](https://docs.filecoin.cloud).** Ingest from Slack, GitHub, docs, code, Discord, and Hacker News. Extract relationship edges. Trace evidence-backed connections across all sources — with verifiable, content-addressed citations stored on decentralized storage.
+**wtfoc is a cross-source trace engine for engineering context.** It helps teams and agents answer why something happened across code, issues, docs, and conversations with explicit, evidence-backed links instead of keyword matches alone.
 
-## Why
-
-A customer complains in Slack. Someone files an issue. Someone else fixes it in a PR. These connections live in people's heads. When someone leaves, so does the context.
-
-wtfoc makes those connections queryable. One trace surfaces the Slack complaint, the GitHub issue, the PR that fixed it, and the code that changed — all linked by extracted edges, not keyword matches.
+Use it when search is not enough and you need the chain: the Slack complaint, the GitHub issue, the PR that fixed it, the code that changed, and the docs that were updated.
 
 **Learn more:** [Why wtfoc?](docs/why.md) | [Vision & North-Star Goals](docs/vision.md) | [Pipeline Architecture](docs/pipeline-architecture.md)
 
-## Try It Now
+## Search vs Trace
 
-### Point Claude at the hosted MCP endpoint
+Most tools stop at search: find chunks that look similar to the query.
 
-No setup required. Add this to your Claude Code or Claude Desktop MCP configuration:
+wtfoc does both:
+
+- **`query`** finds semantically relevant chunks.
+- **`trace`** follows explicit edges across sources so you can see how artifacts connect and why they matter.
+
+That makes it useful for questions like:
+
+- What was the full context behind this bug fix?
+- Which discussions led to this architecture decision?
+- What customer feedback, issues, PRs, and docs connect to this feature?
+- If I change this API, what else is affected?
+
+## Choose Your Path
+
+### Hosted MCP
+
+No setup required. Point Claude Code or Claude Desktop at the hosted endpoint:
 
 ```json
 {
@@ -28,38 +40,86 @@ No setup required. Add this to your Claude Code or Claude Desktop MCP configurat
 }
 ```
 
-Then ask Claude: *"List the available wtfoc collections, then trace upload failures in the largest one"*
+Then ask:
 
-### Browse the web UI
+> List the available wtfoc collections, then trace upload failures in the largest one.
 
-Visit [wtfoc.xyz](https://wtfoc.xyz) to search and trace collections interactively, including a force-directed graph visualization of cross-source connections.
+### CLI
 
-### Install agent skills
-
-```bash
-npx skills add SgtPooki/wtfoc
-```
-
-Installs `/trace-analyze`, `/collection-setup`, and `/drift-check` skills for Claude Code, Cursor, Codex, and other agents.
-
-## Use the CLI
+Use the CLI when you want to build and inspect your own local or private collection.
 
 ```bash
 # Install globally (or use npx @wtfoc/cli)
-npm install -g wtfoc
+npm install -g @wtfoc/cli
 
 wtfoc ingest github FilOzone/synapse-sdk -c my-collection
 wtfoc ingest slack ./exports/support.json -c my-collection
 wtfoc ingest website https://docs.example.com -c my-collection
 
 wtfoc trace "upload failures" -c my-collection
-wtfoc trace "what to prioritize" -c my-collection --mode analytical
+wtfoc trace "what should we prioritize next?" -c my-collection --mode analytical
 wtfoc query "session key auth" -c my-collection -k 20
 ```
 
+### Self-Host
+
+Deploy the web UI, REST API, and MCP endpoint yourself:
+
+```bash
+docker pull ghcr.io/sgtpooki/wtfoc
+docker run -p 3577:3577 \
+  -e WTFOC_EMBEDDER_URL=http://ollama:11434/v1 \
+  -e WTFOC_EMBEDDER_MODEL=nomic-embed-text \
+  -v ~/.wtfoc:/root/.wtfoc \
+  ghcr.io/sgtpooki/wtfoc
+```
+
+The container exposes:
+
+- **Web UI** at `/`
+- **REST API** at `/api/collections`
+- **MCP endpoint** at `/mcp`
+
+You can also browse the hosted UI at [wtfoc.xyz](https://wtfoc.xyz).
+
+## What Makes wtfoc Different
+
+### Evidence-Backed Edges
+
+wtfoc does not treat your corpus as a bag of chunks. It extracts typed relationships between artifacts so trace can walk from one source to another with evidence and provenance.
+
+### Portable, Shareable Collections
+
+Collections can be stored locally or on [Filecoin Onchain Cloud](https://docs.filecoin.cloud). FOC is the best default for portable, content-addressed knowledge artifacts, but it is not required. The storage layer stays swappable.
+
+### Living Knowledge, Not Disposable Indexes
+
+Useful computed results should persist with the collection. Chunks, embeddings, edges, and other derived analysis travel with the artifact so another agent or teammate can continue improving it instead of rebuilding from scratch.
+
+### Pluggable by Design
+
+wtfoc is built around interfaces. You can swap embedders, vector indexes, storage backends, source adapters, manifest stores, and edge extractors without changing the whole stack.
+
+## What Works Today
+
+wtfoc already gives you a real path to:
+
+- ingest source material into a collection
+- run semantic query and cross-source trace workflows
+- use it from the CLI, a hosted MCP endpoint, or a self-hosted server
+- store collections locally or through the FOC-backed storage path
+
+For broader north-star direction, read [docs/vision.md](docs/vision.md). The README stays focused on the current front door and concrete ways to try the project.
+
+## Example Trace
+
+The [Upload Flow Trace demo](docs/demos/upload-flow-trace/) follows a real cross-source story through SDK code, GitHub issues, pull requests, documentation, and backend behavior. It shows the kind of evidence chain `trace` is meant to surface when a simple nearest-neighbor search is not enough.
+
+See [docs/user-stories.md](docs/user-stories.md) for more example workflows and story coverage.
+
 ## Run Your Own MCP Server
 
-For local/private collections, run the MCP server on stdio:
+For local or private collections, run the MCP server on stdio:
 
 ```json
 {
@@ -72,66 +132,41 @@ For local/private collections, run the MCP server on stdio:
 }
 ```
 
-## Self-Host the Web Server
-
-Deploy the full web UI + REST API + MCP endpoint:
-
-```bash
-docker pull ghcr.io/sgtpooki/wtfoc
-docker run -p 3577:3577 \
-  -e WTFOC_EMBEDDER_URL=http://ollama:11434/v1 \
-  -e WTFOC_EMBEDDER_MODEL=nomic-embed-text \
-  -v ~/.wtfoc:/root/.wtfoc \
-  ghcr.io/sgtpooki/wtfoc
-```
-
-The server exposes:
-- **Web UI** at `/`
-- **REST API** at `/api/collections`
-- **MCP endpoint** at `/mcp` (Streamable HTTP, read-only)
-
-## FOC for RAG
-
-FOC is the immutable system of record for your knowledge base. Collections are content-addressed — any collection can be verified, shared by CID, rehydrated, and re-queried by anyone without trusting a central server. Embedders and vector indices stay swappable.
-
-**Everything persists, everything is shareable.** As you iterate on a collection — ingesting sources, extracting edges, computing themes — every layer of analysis is stored in the manifest. When you share a collection CID, recipients get the full accumulated knowledge graph: chunks, embeddings, typed edges, theme clusters, noise categorizations, and extraction metadata. Any agent or human can pick up where you left off, extend the collection with new sources or better analysis, and publish a new version. The manifest chain tracks who contributed what, creating a collaborative, ever-improving knowledge base that outlives any single contributor.
-
-See [docs/foc-rag-storage.md](docs/foc-rag-storage.md) for the storage layout and CID reuse story.
-
 ## Packages
 
 | Package | Description | Install |
 |---------|-------------|---------|
 | [`@wtfoc/common`](packages/common/) | Shared types, interfaces, schemas | `npm i @wtfoc/common` |
-| [`@wtfoc/store`](packages/store/) | Storage backends (local, FOC) + manifest management | `npm i @wtfoc/store` |
-| [`@wtfoc/ingest`](packages/ingest/) | Source adapters + chunking + edge extraction | `npm i @wtfoc/ingest` |
-| [`@wtfoc/search`](packages/search/) | Embedders + vector index + query + trace | `npm i @wtfoc/search` |
-| [`@wtfoc/mcp-server`](packages/mcp-server/) | MCP server for Claude and other AI assistants | `npm i @wtfoc/mcp-server` |
-| [`@wtfoc/cli`](packages/cli/) | CLI wrapping all packages | `npm i -g @wtfoc/cli` |
+| [`@wtfoc/store`](packages/store/) | Storage backends and manifest management | `npm i @wtfoc/store` |
+| [`@wtfoc/ingest`](packages/ingest/) | Source adapters, chunking, and edge extraction | `npm i @wtfoc/ingest` |
+| [`@wtfoc/search`](packages/search/) | Embedders, vector index, query, and trace | `npm i @wtfoc/search` |
+| [`@wtfoc/mcp-server`](packages/mcp-server/) | MCP server for AI assistants | `npm i @wtfoc/mcp-server` |
+| [`@wtfoc/cli`](packages/cli/) | CLI that composes the full stack | `npm i -g @wtfoc/cli` |
 
 Every package is standalone. Use only what you need.
 
-## Pluggable at Every Seam
+## Core Seams
 
-wtfoc is built on interfaces, not implementations. Swap any component:
+wtfoc is built on interfaces, not hard lock-in. Core seams include:
 
 | Seam | Default | Swap to |
 |------|---------|---------|
 | **Embedder** | transformers.js (local) | OpenAI, Ollama, Cohere, vLLM |
 | **Vector Index** | In-memory | Qdrant, Pinecone, Weaviate |
-| **Storage** | Local filesystem | FOC (Filecoin-backed IPFS), S3, GCS |
-| **Sources** | Slack, GitHub, Discord, HN, websites, code repos | Any `SourceAdapter` implementation |
-| **Edge Extraction** | Regex-based | LLM-based, AST-based, custom |
+| **Storage Backend** | FOC or local filesystem | S3, GCS, other blob stores |
+| **Source Adapter** | Built-in source adapters | Custom adapters |
+| **Manifest Store** | Built-in manifest handling | Custom mutable index implementations |
+| **Edge Extractor** | Regex-based defaults | LLM-based, AST-based, custom |
 
-See [SPEC.md](SPEC.md) for the full architecture.
+See [SPEC.md](SPEC.md) for the full architecture and project invariants.
 
-## Demos
+## More Docs
 
-| Demo | What it shows |
-|------|--------------|
-| [Upload Flow Trace](docs/demos/upload-flow-trace/) | Map file upload across SDK code, GitHub issues, PRs, docs, and SP backend — 5 source types, ~16K chunks |
-
-See [docs/user-stories.md](docs/user-stories.md) for the full story catalog.
+- [docs/why.md](docs/why.md)
+- [docs/vision.md](docs/vision.md)
+- [docs/pipeline-architecture.md](docs/pipeline-architecture.md)
+- [docs/foc-rag-storage.md](docs/foc-rag-storage.md)
+- [docs/demos/README.md](docs/demos/README.md)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ No setup required. Point Claude Code or Claude Desktop at the hosted endpoint:
 }
 ```
 
+> **Note:** `https://wtfoc.xyz/mcp` is read-only. You can use it to list available hosted collections and run query/trace workflows, but you cannot ingest data or create collections through the hosted MCP endpoint. To ingest data or build your own collection, use the CLI flow below with a local or self-hosted deployment.
+
 Then ask:
 
 > List the available wtfoc collections, then trace upload failures in the largest one.
@@ -78,7 +80,7 @@ The container exposes:
 
 - **Web UI** at `/`
 - **REST API** at `/api/collections`
-- **MCP endpoint** at `/mcp`
+- **MCP endpoint** at `/mcp` (read-only: query/trace only)
 
 You can also browse the hosted UI at [wtfoc.xyz](https://wtfoc.xyz).
 


### PR DESCRIPTION
## Summary
- rewrite the root README to lead with the product thesis and audience
- move the search-vs-trace distinction near the top and simplify the onboarding paths
- add the specweave increment for issue #235 alongside the README changes

## Validation
- checked referenced README doc links locally
- ran `pnpm lint:fix`
