### PR TITLE
feat(ingest): add temporal metadata to code chunks (#231)

### DIFF
--- a/.specweave/increments/0057-temporal-code-chunks/metadata.json
+++ b/.specweave/increments/0057-temporal-code-chunks/metadata.json
@@ -1,0 +1,16 @@
+{
+  "id": "0057-temporal-code-chunks",
+  "status": "completed",
+  "type": "feature",
+  "priority": "P1",
+  "created": "2026-04-13T05:10:53.997Z",
+  "lastActivity": "2026-04-13T05:36:21.317Z",
+  "testMode": "TDD",
+  "coverageTarget": 0,
+  "feature_id": null,
+  "epic_id": null,
+  "externalLinks": {},
+  "project": "wtfoc",
+  "readyForReviewAt": "2026-04-13T05:27:20.575Z",
+  "approvedAt": "2026-04-13T05:36:21.317Z"
+}

--- a/.specweave/increments/0057-temporal-code-chunks/plan.md
+++ b/.specweave/increments/0057-temporal-code-chunks/plan.md
@@ -1,0 +1,34 @@
+# Implementation Plan: Add temporal metadata to code chunks
+
+## Overview
+
+Add two new functions to `git-diff.ts` (`getFileLastCommit`, `getFilesLastCommits`) and wire them into the repo adapter's ingest loop. No schema changes needed — `Chunk.timestamp` and `ChunkerDocument.timestamp` already exist as optional fields, and all chunkers already propagate `document.timestamp` to output chunks.
+
+## Architecture
+
+### Components
+- **git-diff.ts**: New `getFileLastCommit()` and `getFilesLastCommits()` functions using `execFileAsync` pattern
+- **adapter.ts**: Calls `getFilesLastCommits()` after file discovery, populates `timestamp` and commit metadata on `ChunkerDocument`
+
+### Data Flow
+1. File discovery produces list of absolute paths
+2. `getFilesLastCommits()` runs `git log -1 --format=%H%x09%aI%x09%an%x09%s` per file with concurrency pool
+3. Returns `Map<string, FileCommitInfo>` keyed by relative path
+4. Adapter sets `timestamp` on `ChunkerDocument` and adds `lastCommitSha`, `lastCommitAuthor`, `lastCommitMessage` to metadata
+5. Chunkers propagate `timestamp` to all output chunks automatically
+6. Metadata propagates via existing `...chunk.metadata` spread
+
+### Key Design Decisions
+- **Per-file git log with concurrency pool** over single batched command: simpler, correct, fast enough for repos up to ~5000 files
+- **Concurrency default of 20**: balances throughput vs shell process limits
+- **Tab separator (`%x09`)** in git format: avoids conflicts with pipe characters in commit messages
+- **No schema changes**: leverages existing optional fields
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `packages/ingest/src/adapters/repo/git-diff.ts` | Add `FileCommitInfo`, `getFileLastCommit()`, `getFilesLastCommits()` |
+| `packages/ingest/src/adapters/repo/adapter.ts` | Import new functions, call after file discovery, populate timestamp + metadata |
+| `packages/ingest/src/adapters/repo/git-diff.test.ts` | New test file for git log functions |
+| `packages/ingest/src/adapters/repo.test.ts` | New "temporal metadata" describe block |

--- a/.specweave/increments/0057-temporal-code-chunks/reports/code-review-report.json
+++ b/.specweave/increments/0057-temporal-code-chunks/reports/code-review-report.json
@@ -1,0 +1,50 @@
+{
+  "version": "1.1",
+  "scope": "increment 0057-temporal-code-chunks (uncommitted changes)",
+  "date": "2026-04-12",
+  "reviewers": ["logic", "security", "types", "silent-failures", "spec-compliance"],
+  "gateCheck": { "passed": true, "reason": null },
+  "summary": {
+    "total": 1,
+    "critical": 0,
+    "high": 0,
+    "medium": 0,
+    "low": 1,
+    "info": 0
+  },
+  "validation": {
+    "performed": false,
+    "preValidation": { "critical": 0, "high": 0 },
+    "postValidation": { "critical": 0, "high": 0 },
+    "rejected": 0
+  },
+  "findings": [
+    {
+      "id": "F-001",
+      "severity": "LOW",
+      "reviewer": "types",
+      "file": "packages/ingest/src/adapters/repo/git-diff.ts",
+      "line": 84,
+      "category": "Type assertion",
+      "title": "Type assertion on error object uses broad union",
+      "description": "The error is cast to { code?: string | number }. Node.js child_process errors use numeric `code` for exit codes and string `code` for system errors (e.g., 'ENOENT'). The union is correct for handling both, but the comparison `code === 128` only matches the numeric case. If a future Node version changes exit code representation, the string comparison path would silently fall through to the warning log, which is acceptable behavior.",
+      "impact": "Negligible. The function returns null in all error cases regardless. The warning log path is best-effort diagnostics only.",
+      "recommendation": "No action required. The current approach is pragmatic. For strict correctness, a type guard could distinguish ExecException (numeric code) from SystemError (string code), but the added complexity is not warranted for this use case.",
+      "validated": true
+    }
+  ],
+  "specCompliance": {
+    "summary": "All ACs pass. The uncommitted change is a minor refinement to error handling in getFileLastCommit, improving robustness for ENOENT (git binary not found). No ACs are affected by this change.",
+    "criteria": [
+      { "id": "AC-US1-01", "verdict": "PASS", "evidence": "Code chunks get timestamp from git history via getFileLastCommit/getFilesLastCommits" },
+      { "id": "AC-US1-02", "verdict": "PASS", "evidence": "Markdown chunks use same path as code chunks" },
+      { "id": "AC-US1-03", "verdict": "PASS", "evidence": "lastCommitSha set from FileCommitInfo.sha" },
+      { "id": "AC-US1-04", "verdict": "PASS", "evidence": "lastCommitAuthor set from FileCommitInfo.author" },
+      { "id": "AC-US1-05", "verdict": "PASS", "evidence": "lastCommitMessage set from FileCommitInfo.message" },
+      { "id": "AC-US2-01", "verdict": "PASS", "evidence": "getFilesLastCommits uses Semaphore with default concurrency 20" },
+      { "id": "AC-US2-02", "verdict": "PASS", "evidence": "getFileLastCommit returns null for missing files; getFilesLastCommits skips nulls" },
+      { "id": "AC-US2-03", "verdict": "PASS", "evidence": "Exit code 128 (not a git repo) returns null silently" }
+    ],
+    "scopeCreep": []
+  }
+}

--- a/.specweave/increments/0057-temporal-code-chunks/reports/grill-report.json
+++ b/.specweave/increments/0057-temporal-code-chunks/reports/grill-report.json
@@ -1,0 +1,36 @@
+{
+  "version": "1.1",
+  "incrementId": "0057",
+  "timestamp": "2026-04-12T00:25:00Z",
+  "verdict": "FAIL",
+  "shipReadiness": "NEEDS REVIEW",
+  "summary": { "totalFindings": 1, "critical": 0, "high": 1, "medium": 0 },
+  "acCompliance": {
+    "totalACs": 8,
+    "passed": 7,
+    "failed": 1,
+    "scopeCreep": [],
+    "results": [
+      { "acId": "AC-US1-01", "status": "pass", "evidence": "adapter.ts:233 sets timestamp from commitInfo.date; test in repo.test.ts:112-122 validates ISO 8601 timestamp on code chunks" },
+      { "acId": "AC-US1-02", "status": "pass", "evidence": "adapter.ts:233 sets timestamp from commitInfo.date; test in repo.test.ts:125-136 validates ISO 8601 timestamp on markdown chunks" },
+      { "acId": "AC-US1-03", "status": "fail", "evidence": "lastCommitSha is set in doc.metadata (adapter.ts:219) and propagated by AstHeuristicChunker and MarkdownChunker, but CodeWindowChunker (used for .json/.yaml/.yml/.toml files) does not propagate document.metadata — chunkCode() in chunking.ts:124-128 creates metadata with only filePath/language/repo. Tests pass because fixtures are .ts files (using AstHeuristicChunker). The AC says 'All chunks' but non-AST files lose this metadata." },
+      { "acId": "AC-US1-04", "status": "pass", "evidence": "Same propagation path as AC-US1-03. For AST-supported and markdown files, lastCommitAuthor propagates correctly. The CodeWindowChunker gap applies here too but is covered under AC-US1-03 finding. Test in repo.test.ts:150-160." },
+      { "acId": "AC-US1-05", "status": "pass", "evidence": "Same propagation path. lastCommitMessage set in adapter.ts:221, propagated via doc.metadata spread in chunkers. Test in repo.test.ts:162-170." },
+      { "acId": "AC-US2-01", "status": "pass", "evidence": "getFilesLastCommits in git-diff.ts:95-114 uses Semaphore with configurable concurrency (default 20). Test in git-diff.test.ts:26-39." },
+      { "acId": "AC-US2-02", "status": "pass", "evidence": "getFileLastCommit returns null for missing files (git-diff.ts:77), getFilesLastCommits skips nulls (git-diff.ts:107). Tests in git-diff.test.ts:19-22 and 47-53." },
+      { "acId": "AC-US2-03", "status": "pass", "evidence": "adapter.ts:162 uses empty Map for non-git repos, commitInfo is undefined so metadata fields are not set and no crash occurs. No explicit test but code path is clear." }
+    ]
+  },
+  "findings": [
+    {
+      "title": "CodeWindowChunker does not propagate document.metadata — commit metadata lost for .json/.yaml/.yml/.toml files",
+      "severity": "high",
+      "confidence": 85,
+      "category": "correctness",
+      "file": "packages/ingest/src/chunkers/code-chunker.ts:17",
+      "issue": "CodeWindowChunker delegates to chunkCode() which creates chunk metadata with only { filePath, language, repo }. Unlike AstHeuristicChunker and MarkdownChunker which spread document.metadata, CodeWindowChunker discards it. This means lastCommitSha, lastCommitAuthor, and lastCommitMessage are lost for any file routed to this chunker (.json, .yaml, .yml, .toml, and any non-AST-supported extension). The adapter yield block (adapter.ts:234) spreads chunk.metadata but never re-adds the commit fields, so they vanish.",
+      "suggestion": "Either (a) modify CodeWindowChunker.chunk() to spread document.metadata into each chunk's metadata (matching AstHeuristicChunker behavior), or (b) add the commit metadata fields in the adapter yield block alongside filePath/language/repo. Option (b) is simpler and makes the adapter authoritative for commit metadata regardless of chunker implementation.",
+      "impact": "Any file type not supported by the AST chunker (.json, .yaml, .yml, .toml, .py, .go, etc.) will have null/undefined lastCommitSha, lastCommitAuthor, and lastCommitMessage in its chunks. This partially defeats the purpose of the increment for non-JS/TS codebases."
+    }
+  ]
+}

--- a/.specweave/increments/0057-temporal-code-chunks/reports/judge-llm-report.json
+++ b/.specweave/increments/0057-temporal-code-chunks/reports/judge-llm-report.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "incrementId": "0057-temporal-code-chunks",
+  "timestamp": "2026-04-13T05:27:00.000Z",
+  "verdict": "WAIVED",
+  "consentStatus": "not-configured",
+  "reason": "External API consent not configured in .specweave/config.json. No ANTHROPIC_API_KEY usage without explicit consent."
+}

--- a/.specweave/increments/0057-temporal-code-chunks/spec.md
+++ b/.specweave/increments/0057-temporal-code-chunks/spec.md
@@ -1,0 +1,63 @@
+---
+increment: 0057-temporal-code-chunks
+title: Add temporal metadata to code chunks
+type: feature
+priority: P1
+status: completed
+created: 2026-04-13T00:00:00.000Z
+structure: user-stories
+test_mode: TDD
+coverage_target: 0
+total_tasks: 4
+checked_tasks: 4
+---
+
+# Feature: Add temporal metadata to code chunks
+
+## Overview
+
+The repo adapter sets `timestamp: null` on all code/markdown chunks, while GitHub issue/PR chunks have proper timestamps. This blocks temporal queries ("what changed recently?") and temporal edge extraction for code files. Dogfood collection shows 2901 code chunks with null timestamps vs 737 GitHub chunks with timestamps.
+
+This increment adds git-based temporal metadata to every code and markdown chunk during repo ingest.
+
+## User Stories
+
+### US-001: Temporal metadata on code chunks (P1)
+**Project**: wtfoc
+
+**As a** knowledge graph user
+**I want** code chunks to include the last commit timestamp, SHA, author, and message
+**So that** temporal queries and temporal edge extraction work for code files, not just GitHub issues/PRs
+
+**Acceptance Criteria**:
+- [x] **AC-US1-01**: Code chunks have `timestamp` set to the ISO 8601 date of their file's last git commit
+- [x] **AC-US1-02**: Markdown chunks have `timestamp` set to the ISO 8601 date of their file's last git commit
+- [x] **AC-US1-03**: All chunks include `lastCommitSha` (40-char hex) in metadata
+- [x] **AC-US1-04**: All chunks include `lastCommitAuthor` (non-empty string) in metadata
+- [x] **AC-US1-05**: All chunks include `lastCommitMessage` in metadata
+
+---
+
+### US-002: Batched git log for performance (P1)
+**Project**: wtfoc
+
+**As a** developer ingesting large repos
+**I want** git log calls to be batched with concurrency limiting
+**So that** ingest performance is acceptable for repos with thousands of files
+
+**Acceptance Criteria**:
+- [x] **AC-US2-01**: `getFilesLastCommits()` processes files in concurrent batches (default 20)
+- [x] **AC-US2-02**: Files with no git history are gracefully skipped (no errors)
+- [x] **AC-US2-03**: Non-git repos produce chunks without temporal metadata (no crash)
+
+## Out of Scope
+
+- Per-hunk/per-chunk git blame attribution (follow-up: #239)
+- Commit node creation for full history traversal (#239)
+- Commit → PR → Issue provenance chains (#239)
+
+## Dependencies
+
+- Existing `Chunk.timestamp` field (already optional string in schema)
+- Existing `ChunkerDocument.timestamp` field (already propagated by all chunkers)
+- Existing `execFileAsync` pattern in git-diff.ts

--- a/.specweave/increments/0057-temporal-code-chunks/tasks.md
+++ b/.specweave/increments/0057-temporal-code-chunks/tasks.md
@@ -1,0 +1,41 @@
+---
+total_tasks: 4
+checked_tasks: 4
+---
+
+# Tasks: Add temporal metadata to code chunks
+
+## Phase 1: Git Helpers
+
+### T-001: Add getFileLastCommit to git-diff.ts
+**User Story**: US-002 | **Satisfies ACs**: AC-US2-02 | **Status**: [x] completed
+**Test Plan**:
+- Given a known fixture file, When getFileLastCommit is called, Then it returns sha (40-char hex), date (ISO 8601), author, and message
+- Given a non-existent file path, When getFileLastCommit is called, Then it returns null
+
+### T-002: Add getFilesLastCommits batch function to git-diff.ts
+**User Story**: US-002 | **Satisfies ACs**: AC-US2-01, AC-US2-02 | **Status**: [x] completed
+**Test Plan**:
+- Given 3 known fixture files, When getFilesLastCommits is called, Then it returns a Map of size 3 with valid commit info
+- Given an empty file list, When getFilesLastCommits is called, Then it returns an empty Map
+- Given a mix of existing and non-existent files, When getFilesLastCommits is called, Then it returns info only for existing files
+
+## Phase 2: Adapter Integration
+
+### T-003: Wire git commit info into repo adapter chunk creation
+**User Story**: US-001 | **Satisfies ACs**: AC-US1-01, AC-US1-02, AC-US1-03, AC-US1-04, AC-US1-05, AC-US2-03 | **Status**: [x] completed
+**Test Plan**:
+- Given the test-repo fixture, When ingest runs, Then code chunks have ISO 8601 timestamp from git history
+- Given the test-repo fixture, When ingest runs, Then markdown chunks have ISO 8601 timestamp from git history
+- Given the test-repo fixture, When ingest runs, Then all chunks have lastCommitSha (40-char hex) in metadata
+- Given the test-repo fixture, When ingest runs, Then all chunks have non-empty lastCommitAuthor in metadata
+- Given the test-repo fixture, When ingest runs, Then all chunks have lastCommitMessage in metadata
+
+## Phase 3: Verification
+
+### T-004: Build, test, and lint verification
+**User Story**: US-001, US-002 | **Satisfies ACs**: all | **Status**: [x] completed
+**Test Plan**:
+- Given all changes, When pnpm test runs, Then 907 tests pass
+- Given all changes, When pnpm build runs, Then no TypeScript errors
+- Given all changes, When pnpm lint:fix runs, Then no lint errors

--- a/packages/ingest/src/adapters/repo.test.ts
+++ b/packages/ingest/src/adapters/repo.test.ts
@@ -108,6 +108,69 @@ describe("RepoAdapter", () => {
 		});
 	});
 
+	describe("temporal metadata", () => {
+		it("sets timestamp on code chunks from git history", async () => {
+			const chunks = [];
+			for await (const chunk of adapter.ingest(adapter.parseConfig({ source: FIXTURE_PATH }))) {
+				chunks.push(chunk);
+			}
+
+			const codeChunks = chunks.filter((c) => c.sourceType === "code");
+			for (const chunk of codeChunks) {
+				expect(chunk.timestamp).toBeDefined();
+				expect(chunk.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+			}
+		});
+
+		it("sets timestamp on markdown chunks from git history", async () => {
+			const chunks = [];
+			for await (const chunk of adapter.ingest(adapter.parseConfig({ source: FIXTURE_PATH }))) {
+				chunks.push(chunk);
+			}
+
+			const mdChunks = chunks.filter((c) => c.sourceType === "markdown");
+			for (const chunk of mdChunks) {
+				expect(chunk.timestamp).toBeDefined();
+				expect(chunk.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+			}
+		});
+
+		it("includes lastCommitSha in chunk metadata", async () => {
+			const chunks = [];
+			for await (const chunk of adapter.ingest(adapter.parseConfig({ source: FIXTURE_PATH }))) {
+				chunks.push(chunk);
+			}
+
+			for (const chunk of chunks) {
+				expect(chunk.metadata.lastCommitSha).toBeDefined();
+				expect(chunk.metadata.lastCommitSha).toMatch(/^[0-9a-f]{40}$/);
+			}
+		});
+
+		it("includes lastCommitAuthor in chunk metadata", async () => {
+			const chunks = [];
+			for await (const chunk of adapter.ingest(adapter.parseConfig({ source: FIXTURE_PATH }))) {
+				chunks.push(chunk);
+			}
+
+			for (const chunk of chunks) {
+				expect(chunk.metadata.lastCommitAuthor).toBeDefined();
+				expect((chunk.metadata.lastCommitAuthor ?? "").length).toBeGreaterThan(0);
+			}
+		});
+
+		it("includes lastCommitMessage in chunk metadata", async () => {
+			const chunks = [];
+			for await (const chunk of adapter.ingest(adapter.parseConfig({ source: FIXTURE_PATH }))) {
+				chunks.push(chunk);
+			}
+
+			for (const chunk of chunks) {
+				expect(chunk.metadata.lastCommitMessage).toBeDefined();
+			}
+		});
+	});
+
 	describe("extractEdges", () => {
 		it("extracts import references from code", async () => {
 			const chunks = [];

--- a/packages/ingest/src/adapters/repo/adapter.ts
+++ b/packages/ingest/src/adapters/repo/adapter.ts
@@ -11,6 +11,7 @@ import {
 	type ChangedFile,
 	commitExists,
 	getChangedFiles,
+	getFilesLastCommits,
 	getHeadCommit,
 	isGitRepo,
 } from "./git-diff.js";
@@ -156,6 +157,10 @@ export class RepoAdapter implements SourceAdapter<RepoAdapterConfig> {
 		// Store rename info for catalog lifecycle management
 		this.lastIngestMetadata = { headCommitSha: headSha, renamedFiles };
 
+		// Get git commit info for all files (batched with concurrency)
+		const relPaths = files.map((f) => relative(repoPath, f));
+		const commitInfoMap = gitRepo ? await getFilesLastCommits(repoPath, relPaths) : new Map();
+
 		// Emit tombstone chunks for deleted files so the catalog can archive them
 		for (const deletedPath of deletedFiles) {
 			yield {
@@ -195,6 +200,7 @@ export class RepoAdapter implements SourceAdapter<RepoAdapterConfig> {
 
 			const language = isMarkdown ? "markdown" : extname(filePath).slice(1);
 			const chunker = selectChunker(sourceType, relPath);
+			const commitInfo = commitInfoMap.get(relPath);
 
 			const doc: ChunkerDocument = {
 				documentId,
@@ -203,11 +209,17 @@ export class RepoAdapter implements SourceAdapter<RepoAdapterConfig> {
 				sourceType,
 				source: `${repo}/${relPath}`,
 				sourceUrl,
+				timestamp: commitInfo?.date,
 				filePath: relPath,
 				metadata: {
 					filePath: relPath,
 					language,
 					repo,
+					...(commitInfo && {
+						lastCommitSha: commitInfo.sha,
+						lastCommitAuthor: commitInfo.author,
+						lastCommitMessage: commitInfo.message,
+					}),
 				},
 			};
 

--- a/packages/ingest/src/adapters/repo/adapter.ts
+++ b/packages/ingest/src/adapters/repo/adapter.ts
@@ -235,6 +235,11 @@ export class RepoAdapter implements SourceAdapter<RepoAdapterConfig> {
 						filePath: relPath,
 						language,
 						repo,
+						...(commitInfo && {
+							lastCommitSha: commitInfo.sha,
+							lastCommitAuthor: commitInfo.author,
+							lastCommitMessage: commitInfo.message,
+						}),
 					},
 				};
 				if (chunk.chunkIndex === 0) yieldChunk.rawContent = content;

--- a/packages/ingest/src/adapters/repo/adapter.ts
+++ b/packages/ingest/src/adapters/repo/adapter.ts
@@ -229,6 +229,7 @@ export class RepoAdapter implements SourceAdapter<RepoAdapterConfig> {
 					...chunk,
 					sourceType,
 					sourceUrl,
+					timestamp: commitInfo?.date ?? chunk.timestamp,
 					metadata: {
 						...chunk.metadata,
 						filePath: relPath,

--- a/packages/ingest/src/adapters/repo/git-diff.test.ts
+++ b/packages/ingest/src/adapters/repo/git-diff.test.ts
@@ -1,0 +1,54 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { getFileLastCommit, getFilesLastCommits } from "./git-diff.js";
+
+// The test-repo fixture lives inside this git repo, so git log works on its files
+const REPO_ROOT = resolve(import.meta.dirname ?? ".", "../../../../..");
+const FIXTURE_REL = "fixtures/test-repo";
+
+describe("getFileLastCommit", () => {
+	it("returns commit info for a known file", async () => {
+		const info = await getFileLastCommit(REPO_ROOT, `${FIXTURE_REL}/src/storage.ts`);
+		expect(info).not.toBeNull();
+		expect(info?.sha).toMatch(/^[0-9a-f]{40}$/);
+		expect(info?.date).toMatch(/^\d{4}-\d{2}-\d{2}T/); // ISO 8601
+		expect(info?.author).toBeTruthy();
+		expect(typeof info?.message).toBe("string");
+	});
+
+	it("returns null for a non-existent file", async () => {
+		const info = await getFileLastCommit(REPO_ROOT, "does/not/exist.ts");
+		expect(info).toBeNull();
+	});
+});
+
+describe("getFilesLastCommits", () => {
+	it("returns a map of commit info for multiple files", async () => {
+		const files = [
+			`${FIXTURE_REL}/src/storage.ts`,
+			`${FIXTURE_REL}/src/upload.ts`,
+			`${FIXTURE_REL}/docs/getting-started.md`,
+		];
+		const map = await getFilesLastCommits(REPO_ROOT, files);
+		expect(map.size).toBe(3);
+		for (const fp of files) {
+			const info = map.get(fp);
+			expect(info).toBeDefined();
+			expect(info?.sha).toMatch(/^[0-9a-f]{40}$/);
+			expect(info?.date).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+		}
+	});
+
+	it("returns an empty map for an empty file list", async () => {
+		const map = await getFilesLastCommits(REPO_ROOT, []);
+		expect(map.size).toBe(0);
+	});
+
+	it("skips files that have no git history", async () => {
+		const files = [`${FIXTURE_REL}/src/storage.ts`, "does/not/exist.ts"];
+		const map = await getFilesLastCommits(REPO_ROOT, files);
+		expect(map.size).toBe(1);
+		expect(map.has(`${FIXTURE_REL}/src/storage.ts`)).toBe(true);
+		expect(map.has("does/not/exist.ts")).toBe(false);
+	});
+});

--- a/packages/ingest/src/adapters/repo/git-diff.ts
+++ b/packages/ingest/src/adapters/repo/git-diff.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { Semaphore } from "../../edges/semaphore.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -97,14 +98,18 @@ export async function getFilesLastCommits(
 	concurrency = 20,
 ): Promise<Map<string, FileCommitInfo>> {
 	const results = new Map<string, FileCommitInfo>();
-	for (let i = 0; i < filePaths.length; i += concurrency) {
-		const batch = filePaths.slice(i, i + concurrency);
-		const promises = batch.map(async (fp) => {
-			const info = await getFileLastCommit(repoPath, fp);
-			if (info) results.set(fp, info);
-		});
-		await Promise.all(promises);
-	}
+	const semaphore = new Semaphore(concurrency);
+	await Promise.all(
+		filePaths.map(async (fp) => {
+			const release = await semaphore.acquire();
+			try {
+				const info = await getFileLastCommit(repoPath, fp);
+				if (info) results.set(fp, info);
+			} finally {
+				release();
+			}
+		}),
+	);
 	return results;
 }
 

--- a/packages/ingest/src/adapters/repo/git-diff.ts
+++ b/packages/ingest/src/adapters/repo/git-diff.ts
@@ -80,11 +80,11 @@ export async function getFileLastCommit(
 		return { sha, date, author, message: messageParts.join("\t") };
 	} catch (err: unknown) {
 		// Exit code 128 = expected (not a git repo, file never committed)
-		// Anything else is unexpected — warn so systemic failures aren't silent
-		const code = (err as { code?: number })?.code;
-		if (code !== undefined && code !== 128) {
-			console.error(`   git log warning for ${filePath}: exit code ${code}`);
-		}
+		// ENOENT = git binary not found; other codes = unexpected
+		const errObj = err as { code?: string | number };
+		const code = errObj?.code;
+		if (code === 128 || code === undefined) return null;
+		console.error(`   git log warning for ${filePath}: ${code}`);
 		return null;
 	}
 }

--- a/packages/ingest/src/adapters/repo/git-diff.ts
+++ b/packages/ingest/src/adapters/repo/git-diff.ts
@@ -77,7 +77,13 @@ export async function getFileLastCommit(
 		const [sha, date, author, ...messageParts] = line.split("\t");
 		if (!sha || !date || !author) return null;
 		return { sha, date, author, message: messageParts.join("\t") };
-	} catch {
+	} catch (err: unknown) {
+		// Exit code 128 = expected (not a git repo, file never committed)
+		// Anything else is unexpected — warn so systemic failures aren't silent
+		const code = (err as { code?: number })?.code;
+		if (code !== undefined && code !== 128) {
+			console.error(`   git log warning for ${filePath}: exit code ${code}`);
+		}
 		return null;
 	}
 }

--- a/packages/ingest/src/adapters/repo/git-diff.ts
+++ b/packages/ingest/src/adapters/repo/git-diff.ts
@@ -3,6 +3,13 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
+export interface FileCommitInfo {
+	sha: string;
+	date: string;
+	author: string;
+	message: string;
+}
+
 export type FileChangeStatus = "added" | "modified" | "deleted" | "renamed";
 
 export interface ChangedFile {
@@ -49,6 +56,50 @@ export async function commitExists(repoPath: string, sha: string): Promise<boole
 	} catch {
 		return false;
 	}
+}
+
+/**
+ * Get the last commit info for a single file.
+ * Returns null if the file has no git history.
+ */
+export async function getFileLastCommit(
+	repoPath: string,
+	filePath: string,
+): Promise<FileCommitInfo | null> {
+	try {
+		const { stdout } = await execFileAsync(
+			"git",
+			["log", "-1", "--format=%H%x09%aI%x09%an%x09%s", "--", filePath],
+			{ cwd: repoPath },
+		);
+		const line = stdout.trim();
+		if (!line) return null;
+		const [sha, date, author, ...messageParts] = line.split("\t");
+		if (!sha || !date || !author) return null;
+		return { sha, date, author, message: messageParts.join("\t") };
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Get the last commit info for multiple files, with concurrency limiting.
+ */
+export async function getFilesLastCommits(
+	repoPath: string,
+	filePaths: string[],
+	concurrency = 20,
+): Promise<Map<string, FileCommitInfo>> {
+	const results = new Map<string, FileCommitInfo>();
+	for (let i = 0; i < filePaths.length; i += concurrency) {
+		const batch = filePaths.slice(i, i + concurrency);
+		const promises = batch.map(async (fp) => {
+			const info = await getFileLastCommit(repoPath, fp);
+			if (info) results.set(fp, info);
+		});
+		await Promise.all(promises);
+	}
+	return results;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `getFileLastCommit()` and `getFilesLastCommits()` to git-diff.ts — batched git log calls with concurrency pool (20 concurrent) to get last commit info per file
- Repo adapter now populates `timestamp` (ISO 8601 commit date), `lastCommitSha`, `lastCommitAuthor`, and `lastCommitMessage` on all code and markdown chunks
- Existing chunker infrastructure already propagates `document.timestamp` to output chunks — no schema changes needed

## Why

Code chunks had `timestamp: null` while GitHub issue/PR chunks had proper timestamps. This blocked temporal queries ("what changed recently?") and temporal edge extraction for code files. Dogfood collection showed 2901 code chunks without timestamps vs 737 GitHub chunks with timestamps.

## Test plan

- [x] `getFileLastCommit` returns commit info for known files
- [x] `getFileLastCommit` returns null for non-existent files
- [x] `getFilesLastCommits` batches correctly, skips missing files
- [x] Code chunks have ISO 8601 `timestamp` from git history
- [x] Markdown chunks have `timestamp` from git history
- [x] All chunks include `lastCommitSha`, `lastCommitAuthor`, `lastCommitMessage` in metadata
- [x] 907 tests passing, build clean, lint clean

Closes #231
Follow-up: #239 (chunk-level git blame attribution)