### PR TITLE
feat: improve edge quality — fix prompt-validator mismatch and edge resolution

### DIFF
--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -58,6 +58,7 @@ export interface EdgesResponse {
 	resolvedEdges: number;
 	bareRefs: number;
 	unresolvedEdges: number;
+	conceptEdges?: number;
 	resolution: number;
 	topUnresolved: Record<string, number>;
 }

--- a/packages/cli/src/commands/unresolved-edges.ts
+++ b/packages/cli/src/commands/unresolved-edges.ts
@@ -36,6 +36,7 @@ export function registerUnresolvedEdgesCommand(program: Command): void {
 				resolvedEdges,
 				bareRefs,
 				unresolvedEdges: unresolvedCount,
+				conceptEdges,
 				unresolvedByRepo,
 			} = stats;
 			const sorted = [...unresolvedByRepo.entries()].sort((a, b) => b[1] - a[1]);
@@ -47,6 +48,7 @@ export function registerUnresolvedEdgesCommand(program: Command): void {
 						totalEdges,
 						resolvedEdges,
 						bareRefs,
+						conceptEdges,
 						unresolvedEdges: unresolvedCount,
 						unresolvedByRepo: Object.fromEntries(unresolvedByRepo),
 					}),
@@ -55,9 +57,10 @@ export function registerUnresolvedEdgesCommand(program: Command): void {
 				console.log(`\n📊 Edge resolution for "${opts.collection}"`);
 				console.log(`   Total edges: ${totalEdges}`);
 				console.log(
-					`   Resolved:    ${resolvedEdges} (${Math.round((resolvedEdges / totalEdges) * 100)}%)`,
+					`   Resolved:    ${resolvedEdges} (${totalEdges > 0 ? Math.round((resolvedEdges / totalEdges) * 100) : 0}%)`,
 				);
 				console.log(`   Bare #N:     ${bareRefs} (no repo context)`);
+				console.log(`   Concepts:    ${conceptEdges} (semantic, not resolvable)`);
 				console.log(`   Unresolved:  ${unresolvedCount}`);
 
 				if (sorted.length > 0) {

--- a/packages/cli/src/serve.ts
+++ b/packages/cli/src/serve.ts
@@ -172,7 +172,9 @@ export async function startServer(options: ServeOptions): Promise<ServerHandle> 
 					resolvedEdges: stats.resolvedEdges,
 					bareRefs: stats.bareRefs,
 					unresolvedEdges: stats.unresolvedEdges,
-					resolution: Math.round((stats.resolvedEdges / stats.totalEdges) * 100),
+					conceptEdges: stats.conceptEdges,
+					resolution:
+						stats.totalEdges > 0 ? Math.round((stats.resolvedEdges / stats.totalEdges) * 100) : 0,
 					topUnresolved: Object.fromEntries(sorted.slice(0, 20)),
 				});
 			}

--- a/packages/ingest/src/edges/edge-validator.test.ts
+++ b/packages/ingest/src/edges/edge-validator.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from "vitest";
+import { makeEdge } from "./__test-helpers.js";
+import { validateEdges } from "./edge-validator.js";
+
+/** Helper: validate a single edge and return the first rejection reason (or null). */
+function rejectReason(overrides: Parameters<typeof makeEdge>[0]): string | null {
+	const { rejected } = validateEdges([makeEdge(overrides)]);
+	return rejected.length > 0 ? (rejected[0]?.reason ?? null) : null;
+}
+
+/** Helper: validate a single edge and return whether it was accepted. */
+function accepted(overrides: Parameters<typeof makeEdge>[0]): boolean {
+	return validateEdges([makeEdge(overrides)]).accepted.length === 1;
+}
+
+describe("edge-validator", () => {
+	// ── Gate 1: Placeholder targets ────────────────────────────────
+	describe("Gate 1 — placeholder targets", () => {
+		it("rejects LINK_TO_ prefix", () => {
+			expect(rejectReason({ targetId: "LINK_TO_something" })).toMatch(/placeholder/);
+		});
+
+		it("rejects TODO prefix", () => {
+			expect(rejectReason({ targetId: "TODO: fix later" })).toMatch(/placeholder/);
+		});
+
+		it("rejects TBD", () => {
+			expect(rejectReason({ targetId: "TBD" })).toMatch(/placeholder/);
+		});
+
+		it("rejects bracketed placeholders", () => {
+			expect(rejectReason({ targetId: "[some placeholder]" })).toMatch(/placeholder/);
+		});
+
+		it("rejects owner/repo placeholder", () => {
+			const reason = rejectReason({
+				targetId: "owner/repo",
+				evidence: "This references the owner/repo placeholder in the example docs",
+			});
+			expect(reason).not.toBeNull();
+			expect(reason).toMatch(/placeholder/);
+		});
+
+		it("rejects owner/repo with path suffix", () => {
+			const reason = rejectReason({
+				targetId: "owner/repo/some/path",
+				evidence: "This references the owner/repo/some/path file in the repository",
+			});
+			expect(reason).not.toBeNull();
+			expect(reason).toMatch(/placeholder/);
+		});
+	});
+
+	// ── Gate 2: Proposal language in factual types ─────────────────
+	describe("Gate 2 — proposal language", () => {
+		it("rejects 'should' in implements edge", () => {
+			expect(
+				rejectReason({
+					type: "implements",
+					evidence: "We should implement caching here to improve performance",
+				}),
+			).toMatch(/proposal/);
+		});
+
+		it("allows 'should' in discusses edge (non-factual)", () => {
+			expect(
+				accepted({
+					type: "discusses",
+					targetType: "concept",
+					targetId: "caching-improvement",
+					evidence: "We should implement caching to improve overall performance significantly",
+					confidence: 0.7,
+				}),
+			).toBe(true);
+		});
+	});
+
+	// ── Gate 3: Target ID too short ───────────────────────────────
+	describe("Gate 3 — target ID length", () => {
+		it("rejects 2-char target ID", () => {
+			expect(rejectReason({ targetId: "ab" })).toMatch(/too short/);
+		});
+
+		it("accepts 3-char target ID", () => {
+			expect(
+				accepted({
+					targetType: "concept",
+					targetId: "abc",
+					evidence: "This references abc in the repository context clearly",
+				}),
+			).toBe(true);
+		});
+	});
+
+	// ── Gate 4: Non-resolvable targets for resolvable types ───────
+	describe("Gate 4 — resolvable target types", () => {
+		it("rejects file target without path separator or extension", () => {
+			expect(rejectReason({ targetType: "file", targetId: "somemodule" })).toMatch(
+				/non-resolvable/,
+			);
+		});
+
+		it("accepts file target with path separator", () => {
+			expect(
+				accepted({
+					targetType: "file",
+					targetId: "src/index.ts",
+					evidence: "The implementation is in src/index.ts which handles the routing",
+				}),
+			).toBe(true);
+		});
+
+		it("accepts issue target with number", () => {
+			expect(
+				accepted({
+					targetType: "issue",
+					targetId: "#142",
+					evidence: "This references issue #142 in the repository",
+				}),
+			).toBe(true);
+		});
+	});
+
+	// ── Gate 5: Evidence too short ────────────────────────────────
+	describe("Gate 5 — evidence length", () => {
+		it("rejects evidence shorter than 10 chars", () => {
+			expect(rejectReason({ evidence: "short" })).toMatch(/evidence too short/);
+		});
+
+		it("rejects empty evidence", () => {
+			expect(rejectReason({ evidence: "" })).toMatch(/evidence too short/);
+		});
+	});
+
+	// ── Gate 6: Low-confidence discusses ──────────────────────────
+	describe("Gate 6 — low-confidence discusses", () => {
+		it("rejects discusses edge with confidence < 0.6", () => {
+			expect(
+				rejectReason({
+					type: "discusses",
+					targetType: "concept",
+					targetId: "some-concept-here",
+					confidence: 0.5,
+					evidence: "This discusses the concept in some detail here",
+				}),
+			).toMatch(/low-confidence/);
+		});
+
+		it("accepts discusses edge with confidence >= 0.6", () => {
+			expect(
+				accepted({
+					type: "discusses",
+					targetType: "concept",
+					targetId: "some-concept-here",
+					confidence: 0.6,
+					evidence: "This discusses the concept in some detail here",
+				}),
+			).toBe(true);
+		});
+	});
+
+	// ── Gate 7: Concept grounding ─────────────────────────────────
+	describe("Gate 7 — concept grounding", () => {
+		it("accepts concept where all words appear literally in evidence", () => {
+			expect(
+				accepted({
+					targetType: "concept",
+					targetId: "performance-regression",
+					evidence: "addresses the performance regression discussed in the backend channel",
+				}),
+			).toBe(true);
+		});
+
+		it("accepts concept with morphological variants (deployment/deployed)", () => {
+			expect(
+				accepted({
+					targetType: "concept",
+					targetId: "session-store-deployment",
+					evidence: "The session store needs to be deployed before the auth rewrite can proceed",
+				}),
+			).toBe(true);
+		});
+
+		it("accepts concept with morphological variants (collision/collide)", () => {
+			expect(
+				accepted({
+					targetType: "concept",
+					targetId: "cross-adapter-flag-collision",
+					evidence:
+						"Flags from different adapters could collide when cross-referencing adapter configs",
+				}),
+			).toBe(true);
+		});
+
+		it("accepts concept with morphological variants (initialization/init)", () => {
+			expect(
+				accepted({
+					targetType: "concept",
+					targetId: "abort-signal-handling-during-init",
+					evidence:
+						"The abort signal must be handled properly during initialization of the service",
+				}),
+			).toBe(true);
+		});
+
+		it("rejects concept where <2/3 stemmed words match", () => {
+			expect(
+				rejectReason({
+					targetType: "concept",
+					targetId: "quantum-blockchain-synergy",
+					evidence: "The system uses a simple caching layer for improved response times",
+				}),
+			).toMatch(/synthesized concept not grounded/);
+		});
+
+		it("uses 2/3 threshold (not 1/2)", () => {
+			// 3 significant words, only 1 matches = 1/3 < 2/3 → reject
+			expect(
+				rejectReason({
+					targetType: "concept",
+					targetId: "caching-layer-optimization",
+					evidence: "We added optimization steps to the pipeline for faster processing",
+				}),
+			).toMatch(/synthesized concept not grounded/);
+		});
+
+		it("ignores short words (<=2 chars) in concept slug", () => {
+			// "of" is <=2 chars and should be ignored
+			expect(
+				accepted({
+					targetType: "concept",
+					targetId: "lack-of-testing",
+					evidence: "There is a serious lack of testing in this module which impacts reliability",
+				}),
+			).toBe(true);
+		});
+	});
+
+	// ── Gate 8: Uncertainty in factual types ──────────────────────
+	describe("Gate 8 — uncertainty markers", () => {
+		it("rejects 'maybe' in implements edge", () => {
+			expect(
+				rejectReason({
+					type: "implements",
+					evidence: "This maybe implements the caching layer described in the RFC document",
+				}),
+			).toMatch(/uncertainty/);
+		});
+
+		it("allows 'maybe' in references edge (non-strong)", () => {
+			expect(
+				accepted({
+					type: "references",
+					evidence: "This maybe references the caching layer described in the RFC document",
+				}),
+			).toBe(true);
+		});
+	});
+
+	// ── maybeDowngrade ────────────────────────────────────────────
+	describe("maybeDowngrade", () => {
+		it("downgrades strong type with context-only evidence to references", () => {
+			const { accepted: acc } = validateEdges([
+				makeEdge({
+					type: "implements",
+					evidence: "Context: this relates to the caching implementation described elsewhere",
+				}),
+			]);
+			expect(acc[0]?.type).toBe("references");
+		});
+
+		it("downgrades incompatible target type to references", () => {
+			const { accepted: acc } = validateEdges([
+				makeEdge({
+					type: "closes",
+					targetType: "concept",
+					targetId: "architecture-pattern",
+					evidence: "This closes the discussion about the architecture pattern redesign",
+				}),
+			]);
+			expect(acc[0]?.type).toBe("references");
+		});
+
+		it("downgrades strong type without relation-specific cues to references", () => {
+			const { accepted: acc } = validateEdges([
+				makeEdge({
+					type: "implements",
+					evidence: "The architecture RFC discusses this pattern in the context of scalability",
+				}),
+			]);
+			expect(acc[0]?.type).toBe("references");
+		});
+
+		it("downgrades discusses with temporal language to references", () => {
+			const { accepted: acc } = validateEdges([
+				makeEdge({
+					type: "discusses",
+					targetType: "concept",
+					targetId: "auth-migration-plan",
+					evidence: "The auth migration plan has been merged and landed in production last week",
+					confidence: 0.7,
+				}),
+			]);
+			expect(acc[0]?.type).toBe("references");
+		});
+	});
+
+	// ── Full pipeline ─────────────────────────────────────────────
+	describe("validateEdges pipeline", () => {
+		it("returns accepted and rejected arrays", () => {
+			const result = validateEdges([
+				makeEdge({ evidence: "This references issue #42 in the repository context" }),
+				makeEdge({ targetId: "ab" }), // too short → rejected
+			]);
+			expect(result.accepted).toHaveLength(1);
+			expect(result.rejected).toHaveLength(1);
+		});
+	});
+});

--- a/packages/ingest/src/edges/edge-validator.ts
+++ b/packages/ingest/src/edges/edge-validator.ts
@@ -1,4 +1,5 @@
 import type { Edge } from "@wtfoc/common";
+import { stripSuffix } from "./stem.js";
 
 /**
  * Post-extraction acceptance gates for LLM-produced edges.
@@ -15,6 +16,7 @@ const PLACEHOLDER_PATTERNS = [
 	/^EXAMPLE_/i,
 	/^\[.*\]$/,
 	/^#$/,
+	/^owner\/repo(\/.*)?$/i,
 ];
 
 /** Proposal/planning language — indicates intent, not fact */
@@ -220,15 +222,28 @@ function getRejectReason(edge: Edge): string | null {
 		return `low-confidence discusses edge (${edge.confidence})`;
 	}
 
-	// Gate 7: Reject synthesized concept targets not explicitly named in evidence
+	// Gate 7: Reject synthesized concept targets not grounded in evidence
 	if (edge.targetType === "concept") {
-		// The concept ID should appear (or be closely paraphrased) in the evidence
-		const conceptWords = edge.targetId.replace(/-/g, " ").toLowerCase();
-		const evidenceLower = edge.evidence.toLowerCase();
+		// The concept ID should appear (or be closely paraphrased) in the evidence.
+		// Use suffix-stripped stems to bridge morphological variants
+		// (e.g., "deployment" ↔ "deployed", "collision" ↔ "collide").
+		const conceptWords = edge.targetId
+			.replace(/-/g, " ")
+			.toLowerCase()
+			.split(/\s+/)
+			.filter((w) => w.length > 2);
+		const conceptStems = conceptWords.map(stripSuffix);
+		const evidenceStems = edge.evidence.toLowerCase().split(/\s+/).map(stripSuffix);
+		const matched = conceptStems.filter((stem) =>
+			evidenceStems.some(
+				(es) =>
+					es === stem ||
+					(stem.length >= 3 && es.startsWith(stem)) ||
+					(es.length >= 3 && stem.startsWith(es)),
+			),
+		);
 		// Check if at least 2/3 of the concept words appear in the evidence
-		const words = conceptWords.split(/\s+/).filter((w) => w.length > 2);
-		const matchedWords = words.filter((w) => evidenceLower.includes(w));
-		if (words.length > 0 && matchedWords.length / words.length < 0.5) {
+		if (conceptStems.length > 0 && matched.length / conceptStems.length < 2 / 3) {
 			return `synthesized concept not grounded in evidence: "${edge.targetId}"`;
 		}
 	}

--- a/packages/ingest/src/edges/llm-prompt.ts
+++ b/packages/ingest/src/edges/llm-prompt.ts
@@ -50,7 +50,7 @@ const FEW_SHOT_EXAMPLES: ChatMessage[] = [
 		content: JSON.stringify({
 			chunk_id: "chunk-001",
 			source_type: "github-pr",
-			source: "owner/repo#42",
+			source: "acme-corp/web-api#42",
 			text: "This PR implements the caching layer from the architecture RFC that @alice proposed. It addresses the performance regression discussed in the #backend Slack channel.",
 		}),
 	},
@@ -128,7 +128,7 @@ const FEW_SHOT_EXAMPLES: ChatMessage[] = [
 		content: JSON.stringify({
 			chunk_id: "chunk-003",
 			source_type: "markdown",
-			source: "owner/repo/docs/api.md",
+			source: "acme-corp/web-api/docs/api.md",
 			text: "## Authentication API\n\nThe /auth/token endpoint is implemented in src/auth/handler.ts. See RFC 6749 for the OAuth 2.0 spec. Tests are in src/auth/__tests__/handler.test.ts.",
 		}),
 	},

--- a/packages/ingest/src/edges/stem.test.ts
+++ b/packages/ingest/src/edges/stem.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { stripSuffix } from "./stem.js";
+
+describe("stripSuffix", () => {
+	// ── -ization / -isation ──────────────────────────────────────
+	it("strips -ization", () => {
+		expect(stripSuffix("initialization")).toBe("initial");
+	});
+
+	it("strips -isation", () => {
+		expect(stripSuffix("normalisation")).toBe("normal");
+	});
+
+	// ── -tion / -sion ────────────────────────────────────────────
+	it("strips -sion from collision", () => {
+		expect(stripSuffix("collision")).toBe("colli");
+	});
+
+	it("strips -sion from regression", () => {
+		expect(stripSuffix("regression")).toBe("regres");
+	});
+
+	it("strips -tion from extraction", () => {
+		expect(stripSuffix("extraction")).toBe("extrac");
+	});
+
+	// ── -ment ────────────────────────────────────────────────────
+	it("strips -ment", () => {
+		expect(stripSuffix("deployment")).toBe("deploy");
+	});
+
+	// ── -ness ────────────────────────────────────────────────────
+	it("strips -ness", () => {
+		expect(stripSuffix("readiness")).toBe("readi");
+	});
+
+	// ── -ity ─────────────────────────────────────────────────────
+	it("strips -ity", () => {
+		expect(stripSuffix("complexity")).toBe("complex");
+	});
+
+	// ── -ance / -ence ────────────────────────────────────────────
+	it("strips -ance", () => {
+		expect(stripSuffix("avoidance")).toBe("avoid");
+	});
+
+	it("strips -ence", () => {
+		expect(stripSuffix("reference")).toBe("refer");
+	});
+
+	// ── -ing with doubled consonant ──────────────────────────────
+	it("strips -ing", () => {
+		expect(stripSuffix("handling")).toBe("handl");
+	});
+
+	it("strips -ing with doubled consonant", () => {
+		expect(stripSuffix("running")).toBe("run");
+	});
+
+	it("strips -ing from 'colliding' (bridging collide ↔ collision)", () => {
+		expect(stripSuffix("colliding")).toBe("collid");
+	});
+
+	// ── -ed with doubled consonant ───────────────────────────────
+	it("strips -ed", () => {
+		expect(stripSuffix("deployed")).toBe("deploy");
+	});
+
+	it("strips -ed with doubled consonant", () => {
+		expect(stripSuffix("stopped")).toBe("stop");
+	});
+
+	// ── -ize / -ise ──────────────────────────────────────────────
+	it("strips -ize", () => {
+		expect(stripSuffix("normalize")).toBe("normal");
+	});
+
+	it("strips -ise", () => {
+		expect(stripSuffix("normalise")).toBe("normal");
+	});
+
+	// ── -able / -ible ────────────────────────────────────────────
+	it("strips -able", () => {
+		expect(stripSuffix("resolvable")).toBe("resolv");
+	});
+
+	it("strips -ible", () => {
+		expect(stripSuffix("accessible")).toBe("access");
+	});
+
+	// ── -al / -ly / -ous ─────────────────────────────────────────
+	it("strips -al", () => {
+		expect(stripSuffix("functional")).toBe("function");
+	});
+
+	it("strips -ly", () => {
+		expect(stripSuffix("quickly")).toBe("quick");
+	});
+
+	it("strips -ous", () => {
+		expect(stripSuffix("dangerous")).toBe("danger");
+	});
+
+	// ── -er / -est ───────────────────────────────────────────────
+	it("strips -er", () => {
+		expect(stripSuffix("handler")).toBe("handl");
+	});
+
+	it("strips -est", () => {
+		expect(stripSuffix("fastest")).toBe("fast");
+	});
+
+	// ── Min stem length (3 chars) ────────────────────────────────
+	it("does not strip if result would be < 3 chars", () => {
+		expect(stripSuffix("bed")).toBe("bed");
+	});
+
+	it("does not strip short words", () => {
+		expect(stripSuffix("go")).toBe("go");
+	});
+
+	// ── Edge cases ───────────────────────────────────────────────
+	it("returns empty string for empty input", () => {
+		expect(stripSuffix("")).toBe("");
+	});
+
+	it("passes through words with no matching suffix", () => {
+		expect(stripSuffix("graph")).toBe("graph");
+	});
+
+	it("is case-insensitive (lowercases)", () => {
+		expect(stripSuffix("Deployment")).toBe("deploy");
+	});
+});

--- a/packages/ingest/src/edges/stem.ts
+++ b/packages/ingest/src/edges/stem.ts
@@ -1,0 +1,85 @@
+/**
+ * Lightweight English suffix stripper for concept grounding.
+ *
+ * NOT a full stemmer — just strips common suffixes so that morphological
+ * variants (deployment/deployed, collision/collide) share a common stem.
+ * Used by Gate 7 in edge-validator.ts to match concept slugs against evidence.
+ */
+
+/** Doubled consonants that collapse when removing -ing/-ed (running → run, stopped → stop) */
+const DOUBLED_CONSONANTS = new Set([
+	"bb",
+	"cc",
+	"dd",
+	"ff",
+	"gg",
+	"ll",
+	"mm",
+	"nn",
+	"pp",
+	"rr",
+	"ss",
+	"tt",
+	"zz",
+]);
+
+const MIN_STEM_LENGTH = 3;
+
+/**
+ * Suffixes ordered longest-first so we strip the most specific match.
+ * Each entry: [suffix, extra chars to also remove after stripping]
+ */
+const SUFFIXES = [
+	"ization",
+	"isation",
+	"tion",
+	"sion",
+	"ment",
+	"ness",
+	"ible",
+	"able",
+	"ance",
+	"ence",
+	"ize",
+	"ise",
+	"ing",
+	"ity",
+	"ous",
+	"est",
+	"al",
+	"ly",
+	"er",
+	"ed",
+];
+
+/**
+ * Strip common English suffixes from a word to produce a rough stem.
+ *
+ * @param word - The word to stem (case-insensitive, result is lowercased)
+ * @returns The stemmed word, or the original (lowercased) if no suffix matched
+ *          or stripping would produce a stem shorter than 3 characters.
+ */
+export function stripSuffix(word: string): string {
+	const w = word.toLowerCase();
+
+	for (const suffix of SUFFIXES) {
+		if (!w.endsWith(suffix)) continue;
+
+		let stem = w.slice(0, -suffix.length);
+
+		// Handle doubled consonants for -ing and -ed
+		// e.g. "running" → "runn" → "run", "stopped" → "stopp" → "stop"
+		if ((suffix === "ing" || suffix === "ed") && stem.length >= MIN_STEM_LENGTH) {
+			const lastTwo = stem.slice(-2);
+			if (DOUBLED_CONSONANTS.has(lastTwo)) {
+				stem = stem.slice(0, -1);
+			}
+		}
+
+		if (stem.length >= MIN_STEM_LENGTH) {
+			return stem;
+		}
+	}
+
+	return w;
+}

--- a/packages/search/src/edge-resolution.ts
+++ b/packages/search/src/edge-resolution.ts
@@ -1,4 +1,5 @@
 import type { Segment } from "@wtfoc/common";
+import { normalizeRepoSource } from "./normalize-source.js";
 
 /**
  * Lightweight source index for checking whether edge targets resolve
@@ -25,7 +26,7 @@ export function buildSourceIndex(segments: Segment[]): SourceIndex {
 		for (const chunk of seg.chunks) {
 			chunkIds.add(chunk.id);
 
-			const key = chunk.source.toLowerCase();
+			const key = normalizeRepoSource(chunk.source);
 			const ids = bySource.get(key) ?? [];
 			ids.push(chunk.id);
 			bySource.set(key, ids);
@@ -54,8 +55,8 @@ export function resolves(targetId: string, index: SourceIndex): boolean {
 	// 1. Direct chunk ID match
 	if (index.chunkIds.has(targetId)) return true;
 
-	// 2. Exact source match (case-insensitive)
-	const lower = targetId.toLowerCase();
+	// 2. Exact source match (case-insensitive, URL-normalized)
+	const lower = normalizeRepoSource(targetId);
 	if (index.bySource.has(lower)) return true;
 
 	// 3. Partial source match for structured IDs
@@ -80,6 +81,8 @@ export interface EdgeResolutionStats {
 	resolvedEdges: number;
 	bareRefs: number;
 	unresolvedEdges: number;
+	/** Concept-type edges (unresolvable by design — semantic labels, not chunk IDs) */
+	conceptEdges: number;
 	unresolvedByRepo: Map<string, number>;
 }
 
@@ -94,6 +97,7 @@ export function analyzeEdgeResolution(
 	let totalEdges = 0;
 	let resolvedEdges = 0;
 	let bareRefs = 0;
+	let conceptEdges = 0;
 
 	for (const seg of segments) {
 		for (const edge of seg.edges) {
@@ -101,6 +105,12 @@ export function analyzeEdgeResolution(
 
 			if (/^#\d+$/.test(edge.targetId)) {
 				bareRefs++;
+				continue;
+			}
+
+			// Concept edges are semantic labels, not chunk IDs — track separately
+			if (edge.targetType === "concept") {
+				conceptEdges++;
 				continue;
 			}
 
@@ -122,7 +132,8 @@ export function analyzeEdgeResolution(
 		totalEdges,
 		resolvedEdges,
 		bareRefs,
-		unresolvedEdges: totalEdges - resolvedEdges - bareRefs,
+		unresolvedEdges: totalEdges - resolvedEdges - bareRefs - conceptEdges,
+		conceptEdges,
 		unresolvedByRepo: repoCounts,
 	};
 }

--- a/packages/search/src/eval/edge-resolution-evaluator.test.ts
+++ b/packages/search/src/eval/edge-resolution-evaluator.test.ts
@@ -4,7 +4,7 @@ import { evaluateEdgeResolution } from "./edge-resolution-evaluator.js";
 
 function makeSegment(
 	chunks: Array<{ id: string; source: string; sourceType: string }>,
-	edges: Array<{ sourceId: string; targetId: string; type: string }>,
+	edges: Array<{ sourceId: string; targetId: string; type: string; targetType?: string }>,
 ): Segment {
 	return {
 		schemaVersion: 1,
@@ -24,7 +24,7 @@ function makeSegment(
 		})),
 		edges: edges.map((e) => ({
 			...e,
-			targetType: "document",
+			targetType: e.targetType ?? "document",
 			evidence: "test",
 			confidence: 0.8,
 		})),
@@ -113,5 +113,53 @@ describe("evaluateEdgeResolution", () => {
 		const result = await evaluateEdgeResolution([]);
 		expect(result.verdict).toBe("pass");
 		expect(result.metrics.totalEdges).toBe(0);
+	});
+
+	it("tracks concept edges separately from unresolved", async () => {
+		const segments = [
+			makeSegment(
+				[
+					{ id: "c1", source: "owner/repo#1", sourceType: "github-issue" },
+					{ id: "c2", source: "owner/repo#2", sourceType: "github-pr" },
+				],
+				[
+					{ sourceId: "c1", targetId: "owner/repo#2", type: "references" }, // resolves
+					{
+						sourceId: "c1",
+						targetId: "performance-regression",
+						type: "discusses",
+						targetType: "concept",
+					},
+					{ sourceId: "c2", targetId: "auth-rewrite", type: "discusses", targetType: "concept" },
+					{ sourceId: "c2", targetId: "nonexistent/repo#99", type: "closes" }, // unresolved
+				],
+			),
+		];
+
+		const result = await evaluateEdgeResolution(segments);
+		expect(result.metrics.totalEdges).toBe(4);
+		expect(result.metrics.resolvedEdges).toBe(1);
+		expect(result.metrics.conceptEdges).toBe(2);
+		expect(result.metrics.unresolvedEdges).toBe(1); // only the nonexistent repo
+		// adjustedResolutionRate = 1 / (4 - 2 - 0) = 1/2 = 0.5
+		expect(result.metrics.adjustedResolutionRate).toBe(0.5);
+	});
+
+	it("resolves edges when source uses GitHub URL format", async () => {
+		const segments = [
+			makeSegment(
+				[
+					{ id: "c1", source: "https://github.com/Owner/Repo#1", sourceType: "github-issue" },
+					{ id: "c2", source: "Owner/Repo#2", sourceType: "github-pr" },
+				],
+				[
+					// Target without URL prefix should still resolve to URL-prefixed source
+					{ sourceId: "c2", targetId: "Owner/Repo#1", type: "references" },
+				],
+			),
+		];
+
+		const result = await evaluateEdgeResolution(segments);
+		expect(result.metrics.resolvedEdges).toBe(1);
 	});
 });

--- a/packages/search/src/eval/edge-resolution-evaluator.ts
+++ b/packages/search/src/eval/edge-resolution-evaluator.ts
@@ -1,5 +1,6 @@
 import type { EvalCheck, EvalStageResult, Segment } from "@wtfoc/common";
 import { analyzeEdgeResolution, buildSourceIndex, type SourceIndex } from "../edge-resolution.js";
+import { normalizeRepoSource } from "../normalize-source.js";
 
 /**
  * Resolve a target ID and return the first matched chunk ID, or undefined.
@@ -9,8 +10,8 @@ function resolveTarget(targetId: string, index: SourceIndex): string | undefined
 	// 1. Direct chunk ID match
 	if (index.chunkIds.has(targetId)) return targetId;
 
-	// 2. Exact source match (case-insensitive)
-	const lower = targetId.toLowerCase();
+	// 2. Exact source match (case-insensitive, URL-normalized)
+	const lower = normalizeRepoSource(targetId);
 	const exact = index.bySource.get(lower);
 	if (exact && exact.length > 0) return exact[0];
 
@@ -69,6 +70,11 @@ export async function evaluateEdgeResolution(segments: Segment[]): Promise<EvalS
 
 	const resolutionRate = stats.totalEdges > 0 ? stats.resolvedEdges / stats.totalEdges : 0;
 	const bareRefRate = stats.totalEdges > 0 ? stats.bareRefs / stats.totalEdges : 0;
+	// Adjusted rate excludes concept edges and bare refs from the denominator
+	// (concept edges are semantic labels that can never resolve to chunks)
+	const adjustedDenominator = stats.totalEdges - stats.conceptEdges - stats.bareRefs;
+	const adjustedResolutionRate =
+		adjustedDenominator > 0 ? stats.resolvedEdges / adjustedDenominator : 0;
 
 	// Build chunk → sourceType map for cross-source analysis
 	const chunkSourceType = new Map<string, string>();
@@ -138,7 +144,9 @@ export async function evaluateEdgeResolution(segments: Segment[]): Promise<EvalS
 			resolvedEdges: stats.resolvedEdges,
 			bareRefs: stats.bareRefs,
 			unresolvedEdges: stats.unresolvedEdges,
+			conceptEdges: stats.conceptEdges,
 			resolutionRate,
+			adjustedResolutionRate,
 			bareRefRate,
 			crossSourceEdgeDensity,
 			sourceTypePairs,

--- a/packages/search/src/normalize-source.test.ts
+++ b/packages/search/src/normalize-source.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { normalizeRepoSource } from "./normalize-source.js";
+
+describe("normalizeRepoSource", () => {
+	it("strips https://github.com/ prefix", () => {
+		expect(normalizeRepoSource("https://github.com/SgtPooki/wtfoc")).toBe("sgtpooki/wtfoc");
+	});
+
+	it("strips github.com/ prefix", () => {
+		expect(normalizeRepoSource("github.com/SgtPooki/wtfoc")).toBe("sgtpooki/wtfoc");
+	});
+
+	it("strips https://github.com/ prefix with trailing .git", () => {
+		expect(normalizeRepoSource("https://github.com/SgtPooki/wtfoc.git")).toBe("sgtpooki/wtfoc");
+	});
+
+	it("strips http://github.com/ prefix", () => {
+		expect(normalizeRepoSource("http://github.com/SgtPooki/wtfoc")).toBe("sgtpooki/wtfoc");
+	});
+
+	it("lowercases owner/repo without prefix", () => {
+		expect(normalizeRepoSource("SgtPooki/wtfoc")).toBe("sgtpooki/wtfoc");
+	});
+
+	it("preserves issue/PR suffix", () => {
+		expect(normalizeRepoSource("github.com/Org/repo#42")).toBe("org/repo#42");
+	});
+
+	it("preserves path suffix after repo", () => {
+		expect(normalizeRepoSource("https://github.com/Org/repo/blob/main/file.ts")).toBe(
+			"org/repo/blob/main/file.ts",
+		);
+	});
+
+	it("passes through non-repo strings (lowercased)", () => {
+		expect(normalizeRepoSource("src/index.ts")).toBe("src/index.ts");
+	});
+
+	it("passes through bare file paths", () => {
+		expect(normalizeRepoSource("#general")).toBe("#general");
+	});
+
+	it("handles empty string", () => {
+		expect(normalizeRepoSource("")).toBe("");
+	});
+
+	it("does not strip .git without GitHub URL prefix (ambiguous with file paths)", () => {
+		expect(normalizeRepoSource("SgtPooki/wtfoc.git")).toBe("sgtpooki/wtfoc.git");
+	});
+
+	it("handles full GitHub issue URL", () => {
+		expect(normalizeRepoSource("https://github.com/SgtPooki/wtfoc/issues/42")).toBe(
+			"sgtpooki/wtfoc/issues/42",
+		);
+	});
+
+	it("does not strip .git from file paths", () => {
+		expect(normalizeRepoSource("scripts/deploy.git")).toBe("scripts/deploy.git");
+	});
+
+	it("does not strip .git from bare filenames", () => {
+		expect(normalizeRepoSource("config.git")).toBe("config.git");
+	});
+});

--- a/packages/search/src/normalize-source.ts
+++ b/packages/search/src/normalize-source.ts
@@ -1,0 +1,31 @@
+/**
+ * Normalize repository source strings to a canonical form for edge resolution.
+ *
+ * Strips GitHub URL prefixes (https://github.com/, github.com/) and trailing
+ * .git suffixes, then lowercases. This ensures that the same repo referenced
+ * in different formats resolves to the same index key.
+ *
+ * Examples:
+ *   "https://github.com/SgtPooki/wtfoc"     → "sgtpooki/wtfoc"
+ *   "github.com/SgtPooki/wtfoc"             → "sgtpooki/wtfoc"
+ *   "https://github.com/SgtPooki/wtfoc.git" → "sgtpooki/wtfoc"
+ *   "SgtPooki/wtfoc#42"                     → "sgtpooki/wtfoc#42"
+ *   "src/index.ts"                          → "src/index.ts"
+ */
+
+const GITHUB_PREFIX = /^(?:https?:\/\/)?github\.com\//i;
+
+export function normalizeRepoSource(source: string): string {
+	const hadGitHubPrefix = GITHUB_PREFIX.test(source);
+	let s = source.replace(GITHUB_PREFIX, "");
+
+	// Strip trailing .git only when the source had a GitHub URL prefix
+	// (clone URLs like https://github.com/owner/repo.git).
+	// Without a prefix, "owner/repo.git" is ambiguous with "scripts/deploy.git"
+	// so we leave it alone.
+	if (hadGitHubPrefix && s.endsWith(".git")) {
+		s = s.slice(0, -4);
+	}
+
+	return s.toLowerCase();
+}

--- a/packages/search/src/trace/indexing.ts
+++ b/packages/search/src/trace/indexing.ts
@@ -1,4 +1,5 @@
 import type { Edge, Segment } from "@wtfoc/common";
+import { normalizeRepoSource } from "../normalize-source.js";
 
 export interface ChunkData {
 	content: string;
@@ -35,8 +36,8 @@ export function buildChunkIndexes(segments: Segment[]): ChunkIndexes {
 			};
 			byId.set(chunk.id, data);
 
-			// Index by lowercased source for case-insensitive edge resolution
-			const key = chunk.source.toLowerCase();
+			// Index by normalized source for case-insensitive, URL-normalized edge resolution
+			const key = normalizeRepoSource(chunk.source);
 			const ids = bySource.get(key) ?? [];
 			ids.push(chunk.id);
 			bySource.set(key, ids);

--- a/packages/search/src/trace/resolution.ts
+++ b/packages/search/src/trace/resolution.ts
@@ -1,3 +1,4 @@
+import { normalizeRepoSource } from "../normalize-source.js";
 import type { ChunkData, ChunkIndexes } from "./indexing.js";
 
 /**
@@ -24,8 +25,8 @@ export function findChunksByTarget(
 		return results;
 	}
 
-	// 2. Exact source match (O(1) via lowercased source index)
-	const lowerTarget = targetId.toLowerCase();
+	// 2. Exact source match (O(1) via normalized source index)
+	const lowerTarget = normalizeRepoSource(targetId);
 	const sourceMatches = indexes.bySource.get(lowerTarget);
 	if (sourceMatches) {
 		for (const id of sourceMatches) {


### PR DESCRIPTION
## Summary

- **Fix Gate 7 concept grounding** (#234): Replace raw `includes()` matching with stemmed word comparison (new `stem.ts` utility), correct threshold from 0.5 to 2/3, add `owner/repo` placeholder to rejection patterns
- **Normalize repo URLs for resolution** (#193): New `normalizeRepoSource` utility strips GitHub URL prefixes; wired into all 4 resolution code paths so `github.com/X/Y` and `https://github.com/X/Y` resolve correctly
- **Separate concept edges from resolution stats** (#193): Concept edges tracked separately (unresolvable by design), `adjustedResolutionRate` metric added, `EdgesResponse` type extended

Closes #234, closes #193

## Changes

| File | Change |
|------|--------|
| `packages/ingest/src/edges/stem.ts` | New: lightweight suffix-stripping utility (20 suffixes, zero deps) |
| `packages/ingest/src/edges/edge-validator.ts` | Modified: Gate 7 stemmed matching + 2/3 threshold, `owner/repo` placeholder |
| `packages/search/src/normalize-source.ts` | New: repo URL normalizer |
| `packages/search/src/edge-resolution.ts` | Modified: normalization + `conceptEdges` in stats |
| `packages/search/src/trace/{indexing,resolution}.ts` | Modified: normalization in trace engine |
| `packages/search/src/eval/edge-resolution-evaluator.ts` | Modified: `adjustedResolutionRate` metric |
| `packages/ingest/src/edges/llm-prompt.ts` | Modified: `owner/repo` → `acme-corp/web-api` in few-shot examples |
| `packages/cli/src/{serve,commands/unresolved-edges}.ts` | Modified: `conceptEdges` display + division-by-zero guards |
| `apps/web/src/types.ts` | Modified: `conceptEdges?: number` on `EdgesResponse` |

## Test plan

- [x] 973 tests pass (80 test files), up from 900
- [x] 73 new test cases across 4 new test files
- [x] `edge-validator.test.ts`: all 8 gates + downgrade logic (31 tests)
- [x] `stem.test.ts`: suffix stripping with edge cases (29 tests)
- [x] `normalize-source.test.ts`: URL normalization variants (14 tests)
- [x] `edge-resolution-evaluator.test.ts`: concept edge stats + URL resolution (2 new tests)
- [x] Lint clean (biome)