### PR TITLE
fix(search): rerank pool-preservation + 2K-char per-candidate context (refs #313)

### DIFF
--- a/docs/autoresearch/audits/2026-04-30-rerank-pipeline-collapse.md
+++ b/docs/autoresearch/audits/2026-04-30-rerank-pipeline-collapse.md
@@ -1,0 +1,143 @@
+# Rerank pipeline pool-collapse audit (2026-04-30)
+
+Read-only investigation into why `LlmReranker` regressed quality −17pp on `noar_div` (qwen36-27b-aeon) in Phase 3 Stage 1. Cross-reviewer convergence (gemini+cursor+codex, 2026-04-30) flagged H1 (pre-trim before diversity-enforce) as the dominant root cause. This audit confirms H1 quantitatively from existing report data — no new sweep runs.
+
+## TL;DR
+
+The reranker is doing its primary job correctly (lifting recall@10 +0.02) and structurally breaking a different invariant the scoring rubric requires (source-type diversity, average **−1.7** distinct types per passing query, **−32%**). Net effect: 26 queries flip pass→fail, 0 queries flip fail→pass.
+
+This is **not a model-quality verdict** on `qwen36-27b-aeon`. It is a pipeline-order bug: rerank trims `fetchK = topK*10` candidates down to `topK` BEFORE `diversityEnforce` gets a chance to operate on the wider pool.
+
+## Reports compared
+
+Same axes (autoRoute=false, diversityEnforce=true), same corpus (`filoz-ecosystem-2026-04-v12`), same fixture (v1.9.0, 157 queries), same paraphrase setting (off). Only difference: reranker.
+
+| run | reranker | overall | portable | demo | recall@10 | passingAvg distinctSourceTypes |
+|---|---|---|---|---|---|---|
+| `noar_div_rrOff` (no rerank, killed sweep) | off | 57% | 46% | 100% | 0.701 | **5.36** |
+| `noar_div_rrLlm-qwen36-27b-aeon` (smoke) | qwen | **40%** ↓ | **40%** ↓ | 100% | **0.722** ↑ | **3.66** ↓ |
+
+Recall@10 went UP. Pass rate went DOWN. Source-type diversity collapsed.
+
+## Per-query flip analysis (157 paired queries)
+
+| outcome | count |
+|---|---|
+| both passed | 61 |
+| both failed | 70 |
+| **passed without rerank, FAILED with rerank** | **26** |
+| failed without rerank, passed with rerank | **0** |
+| skipped (either side) | 4 |
+
+**The reranker recovered zero queries and damaged 26.** Pure damage on the `passed` rubric.
+
+## The 26 flipped queries — distinct-source-type collapse
+
+Every query that flipped pass→fail lost source-type diversity. Mean drop: **−2.2 distinct source types** (range −1 to −4).
+
+| drop | n queries |
+|---|---|
+| −1 | 5 |
+| −2 | 13 |
+| −3 | 6 |
+| −4 | 2 |
+
+Full per-query data:
+
+| id | category | src_no_rerank | src_qwen | src_drop | docs_no | docs_qwen | recall_no | recall_qwen |
+|---|---|---|---|---|---|---|---|---|
+| `cov-11` | coverage | 6 | 5 | **−1** | 11 | 9 | — | — |
+| `cov-16` | coverage | 5 | 1 | **−4** | 9 | 7 | — | — |
+| `cov-19` | coverage | 6 | 3 | **−3** | 11 | 9 | — | — |
+| `cov-6` | coverage | 5 | 3 | **−2** | 12 | 8 | 0.50 | 0.00 |
+| `cov-7` | coverage | 5 | 3 | **−2** | 12 | 11 | 0.33 | 0.33 |
+| `cs-13` | cross-source | 6 | 4 | **−2** | 11 | 10 | — | — |
+| `cs-16` | cross-source | 6 | 5 | **−1** | 18 | 18 | — | — |
+| `cs-17` | cross-source | 6 | 5 | **−1** | 14 | 14 | — | — |
+| `cs-18` | cross-source | 6 | 4 | **−2** | 14 | 12 | — | — |
+| `cs-19` | cross-source | 6 | 3 | **−3** | 9 | 7 | — | — |
+| `cs-6` | cross-source | 6 | 4 | **−2** | 16 | 16 | 1.00 | 1.00 |
+| `fl-12` | file-level | 5 | 3 | **−2** | 13 | 12 | — | — |
+| `fl-6` | file-level | 5 | 3 | **−2** | 14 | 15 | — | — |
+| `syn-22` | synthesis | 6 | 5 | **−1** | 21 | 21 | — | — |
+| `syn-24` | synthesis | 6 | 3 | **−3** | 13 | 13 | — | — |
+| `syn-4` | synthesis | 6 | 4 | **−2** | 11 | 10 | — | — |
+| `syn-6` | synthesis | 6 | 4 | **−2** | 23 | 20 | 0.50 | 0.50 |
+| `syn-7` | synthesis | 6 | 3 | **−3** | 14 | 12 | **0.50** | **1.00 ↑** |
+| `syn-9` | synthesis | 5 | 3 | **−2** | 8 | 8 | — | — |
+| `wl-11` | work-lineage | 6 | 4 | **−2** | 10 | 9 | — | — |
+| `wl-14` | work-lineage | 6 | 4 | **−2** | 13 | 10 | — | — |
+| `wl-17` | work-lineage | 6 | 4 | **−2** | 17 | 16 | — | — |
+| `wl-19` | work-lineage | 6 | 5 | **−1** | 10 | 10 | — | — |
+| `wl-20` | work-lineage | 6 | 3 | **−3** | 11 | 9 | — | — |
+| `wl-21` | work-lineage | 6 | 2 | **−4** | 11 | 8 | — | — |
+| `wl-23` | work-lineage | 6 | 3 | **−3** | 10 | 7 | — | — |
+
+### The cleanest single-query proof
+
+**`syn-7`**:
+- recall@10: 0.50 → **1.00** (reranker found the gold-supporting docs)
+- distinctSourceTypes: 6 → **3** (reranker stripped half the source-type variety)
+- canonical: passed → **failed**
+
+The reranker found the right canonical-file paths AND simultaneously removed the cross-source supporting evidence the scoring rubric requires. `syn-7` is a synthesis-tier query (cross-cutting question that benefits from multi-source corroboration). The reranker promoted lexically-similar same-source candidates to the top-K, even though the gold canonical paths were lower-scoring.
+
+## Categories most affected
+
+| category | flipped pass→fail |
+|---|---|
+| work-lineage | 7 (wl-11, 14, 17, 19, 20, 21, 23) |
+| synthesis | 6 (syn-4, 6, 7, 9, 22, 24) |
+| cross-source | 6 (cs-6, 13, 16, 17, 18, 19) |
+| coverage | 5 (cov-6, 7, 11, 16, 19) |
+| file-level | 2 (fl-6, fl-12) |
+
+The categories hit hardest are exactly the ones that *require* multi-source evidence by design. cs-* (cross-source) and syn-* (synthesis) are explicit multi-source queries; wl-* (work-lineage) traces commit/PR/issue chains across source types; cov-* (coverage) requires breadth across the corpus.
+
+## Why this is happening — code path
+
+`packages/search/src/query.ts:144-181`:
+
+1. `fetchK = topK * 3` (default) or `topK * 10` (when `diversityEnforce` is on).
+2. `vectorIndex.search(queryVector, fetchK)` returns the wide pool.
+3. `reranker.rerank(...)` is called with `{ topN: topK }` — **the reranker pre-trims the pool to topK before returning** (line 178).
+4. Line 187 filter: `rerankedScores.has(m.entry.storageId)` drops every candidate not in the trimmed top-K.
+5. `diversityEnforce` (line 240) runs on the remaining ~topK candidates — but the reranker already homogenized the pool. The diversity rescue has nothing to rescue from.
+
+Same pattern in `packages/search/src/trace/trace.ts:269` for trace-stage rerank: `topN: maxTotal` pre-trims before any downstream selector.
+
+## Why the reranker prompt is also part of the problem
+
+`packages/search/src/rerankers/llm.ts:25-30` (system prompt):
+
+```
+You are a relevance scoring assistant. Given a search query and a list of candidate documents,
+score each candidate's relevance to the query on a scale of 0.0 to 1.0.
+...
+Score 1.0 = perfectly relevant, 0.0 = completely irrelevant.
+```
+
+The prompt:
+- Pointwise scoring (each candidate independently, no comparison)
+- Pure relevance objective — no source-type, no diversity, no structural signal
+- Sees `c.text.slice(0, 400)` per candidate (line 62) — ~80 tokens, far less than the embedder sees
+
+A diversity-aware prompt with comparative ranking would change the scoring behavior even if the pre-trim bug were unfixed. But the pre-trim bug eliminates the diversity-enforce safety net entirely; prompt work alone cannot recover it.
+
+## Verdict
+
+The Stage 1 conclusion **"reranker doesn't help"** is correct as a *production decision under the current pipeline*. It is **not a fair verdict on qwen36-27b-aeon as a reranker model**. The reranker's behavior is consistent with a model correctly executing a misframed task in a structurally broken pipeline.
+
+## Recommended next steps
+
+1. **Fix H1**: in `query.ts` and `trace.ts`, pass `topN: fetchK` (or omit the `topN` parameter) to `reranker.rerank()`. Let `diversityEnforce` operate on the full reranked pool.
+2. **Fix H5**: bump `c.text.slice(0, 400)` → `slice(0, 2000)` in `llm.ts` so the reranker has comparable context to what the embedder used.
+3. **Targeted small rerun**: 10-20 queries (mix of the 26 flipped queries + already-saturated controls) on raw-vllm post-fix. ~30-45 min instead of 7.35 hr.
+4. **Only if (1)+(2)+(3) recovers quality**: redesign the prompt for comparative ranking with diversity awareness ([#313](https://github.com/SgtPooki/wtfoc/issues/313)).
+5. **Defer**: graph/edge audit, model swap. Both are downstream of fixing the structural bug.
+
+## Artifacts
+
+- Per-query flip data: `/tmp/flipped-queries.json` (session-scoped — 26 row JSON array, key fields: id, category, distinctSourceTypes before/after, distinctDocs before/after, recallAtK before/after)
+- No-rerank report: `/var/folders/.../wtfoc-sweep-D8klz3/noar_div_rrOff-filoz-ecosystem-2026-04-v12.json` (session-scoped temp, may GC)
+- Qwen rerank report: `~/.wtfoc/autoresearch/raw-vllm-rerank-smoke.json` (persistent)

--- a/packages/search/src/query.test.ts
+++ b/packages/search/src/query.test.ts
@@ -365,4 +365,77 @@ describe("query", () => {
 			expect(result.results[0]?.sourceType).toBe("code");
 		});
 	});
+
+	describe("rerank pool-preservation contract (#311 audit)", () => {
+		// Phase 3 audit (docs/autoresearch/audits/2026-04-30-rerank-pipeline-collapse.md)
+		// found that pre-trimming the reranker output to `topK` collapsed
+		// the diverse candidate pool that `diversityEnforce` was meant to
+		// rescue from. These tests lock in the contract: when a reranker
+		// is wired in, query.ts MUST forward the full pre-rerank pool to
+		// it (no `topN` pre-trim) so downstream selectors see the full
+		// re-scored pool.
+
+		function makeRecordingReranker() {
+			const calls: Array<{
+				candidates: { id: string; text: string }[];
+				topN: number | undefined;
+			}> = [];
+			const reranker = {
+				async rerank(
+					_query: string,
+					candidates: { id: string; text: string }[],
+					options?: { topN?: number; signal?: AbortSignal },
+				) {
+					calls.push({ candidates: [...candidates], topN: options?.topN });
+					return candidates.map((c, i) => ({ id: c.id, score: candidates.length - i }));
+				},
+			};
+			return { reranker, calls };
+		}
+
+		it("forwards the full fetchK pool to the reranker (NOT pre-trimmed to topK)", async () => {
+			// Seed 30 entries so fetchK = topK * 3 = 30 (no diversity boost).
+			const entries = Array.from({ length: 30 }, (_, i) =>
+				makeEntry(`e${i}`, [1 - i * 0.01, i * 0.01, 0]),
+			);
+			const index = await seedIndex(...entries);
+			const { reranker, calls } = makeRecordingReranker();
+
+			await query("upload", embedder, index, { topK: 10, reranker });
+
+			expect(calls).toHaveLength(1);
+			// fetchK = topK * 3 = 30 when reranker is on (line 144 of query.ts)
+			expect(calls[0]?.candidates.length).toBeGreaterThanOrEqual(30);
+			// Critically: topN must NOT be set, so the reranker returns all
+			// scored candidates and downstream selectors see the full pool.
+			expect(calls[0]?.topN).toBeUndefined();
+		});
+
+		it("with diversityEnforce, forwards fetchK = topK * 10 candidates to reranker", async () => {
+			// Build 60 entries spanning multiple source types so the wider
+			// diversity-enforce fetch pool is meaningful.
+			const types = ["code", "markdown", "github-pr", "github-issue", "slack-message"];
+			const entries = Array.from({ length: 60 }, (_, i) =>
+				makeEntry(`e${i}`, [1 - i * 0.01, i * 0.01, 0], {
+					sourceType: types[i % types.length] ?? "code",
+				}),
+			);
+			const index = await seedIndex(...entries);
+			const { reranker, calls } = makeRecordingReranker();
+
+			await query("upload", embedder, index, {
+				topK: 5,
+				reranker,
+				diversityEnforce: { minScoreRatio: 0.65 },
+			});
+
+			expect(calls).toHaveLength(1);
+			// With diversityEnforce, fetchK = topK * 10 = 50 (line 161 of query.ts).
+			// Reranker MUST see at least the full diversity-widened pool, not
+			// just topK. Phase 3 measured a −17pp regression when this was
+			// pre-trimmed.
+			expect(calls[0]?.candidates.length).toBeGreaterThanOrEqual(50);
+			expect(calls[0]?.topN).toBeUndefined();
+		});
+	});
 });

--- a/packages/search/src/query.ts
+++ b/packages/search/src/query.ts
@@ -169,13 +169,20 @@ export async function query(
 
 	if (reranker && matches.length > 0) {
 		options?.signal?.throwIfAborted();
+		// Do NOT pass `topN: topK` here — that pre-trims the candidate
+		// pool to topK before downstream `diversityEnforce` operates on
+		// it. The whole point of `fetchK = topK * 10` (line 161) was to
+		// give diversity-enforce a wide pool to rescue source types
+		// from. Phase 3 measured a −17pp regression because the rerank
+		// trim collapsed the diverse pool back to a single source-type
+		// cluster. See `docs/autoresearch/audits/2026-04-30-rerank-pipeline-collapse.md`.
 		const reranked = await reranker.rerank(
 			queryText,
 			matches.map((match) => ({
 				id: match.entry.storageId,
 				text: match.entry.metadata.content ?? "",
 			})),
-			{ topN: topK, signal: options?.signal },
+			{ signal: options?.signal },
 		);
 		if (reranked.length > 0) {
 			rerankedScores = new Map(reranked.map((result) => [result.id, result.score]));

--- a/packages/search/src/rerankers/llm.ts
+++ b/packages/search/src/rerankers/llm.ts
@@ -55,11 +55,21 @@ export class LlmReranker implements Reranker {
 		if (candidates.length === 0) return [];
 		options?.signal?.throwIfAborted();
 
+		// Per-candidate context window: 2000 chars (~500 tokens). Up from
+		// the original 400 chars (~80 tokens) — Phase 3 audit found the
+		// 400-char window left the reranker LESS-informed than the
+		// embedder it was meant to refine, since bge-base-en-v1.5
+		// embeds the full ~512-token chunk while the reranker was
+		// scoring on the first 100 tokens. See
+		// `docs/autoresearch/audits/2026-04-30-rerank-pipeline-collapse.md`.
+		const PER_CANDIDATE_CHAR_LIMIT = 2000;
 		const userMessage = [
 			`Query: ${query}`,
 			"",
 			"Candidates:",
-			...candidates.map((c, i) => `[${i + 1}] id="${c.id}"\n${c.text.slice(0, 400)}`),
+			...candidates.map(
+				(c, i) => `[${i + 1}] id="${c.id}"\n${c.text.slice(0, PER_CANDIDATE_CHAR_LIMIT)}`,
+			),
 		].join("\n");
 
 		const headers: Record<string, string> = { "Content-Type": "application/json" };

--- a/packages/search/src/trace/trace.ts
+++ b/packages/search/src/trace/trace.ts
@@ -260,13 +260,18 @@ export async function trace(
 
 	if (options?.reranker && seeds.length > 0) {
 		options.signal?.throwIfAborted();
+		// Do NOT pass `topN: maxTotal` — diversity-enforce already ran
+		// at line 254 to produce a balanced `seeds` pool. Pre-trimming
+		// the rerank output back to maxTotal undoes that diversity by
+		// promoting same-source-type candidates that score highest on
+		// pure relevance. See `docs/autoresearch/audits/2026-04-30-rerank-pipeline-collapse.md`.
 		const reranked = await options.reranker.rerank(
 			query,
 			seeds.map((seed) => ({
 				id: seed.entry.id,
 				text: seed.entry.metadata.content ?? "",
 			})),
-			{ topN: maxTotal, signal: options.signal },
+			{ signal: options.signal },
 		);
 		if (reranked.length > 0) {
 			const scoreMap = new Map<string, number>(reranked.map((r) => [r.id, r.score]));


### PR DESCRIPTION
Two structural fixes in the search package, flagged by the cross-reviewer audit ([\`docs/autoresearch/audits/2026-04-30-rerank-pipeline-collapse.md\`](https://github.com/SgtPooki/wtfoc/blob/fix/313-rerank-pool-preservation/docs/autoresearch/audits/2026-04-30-rerank-pipeline-collapse.md)) — backed by quantitative evidence that closes the Phase 3 reranker mystery.

## Summary

- **H1 — pool preservation**: \`query.ts\` and \`trace/trace.ts\` no longer pass \`topN: topK\` (or \`topN: maxTotal\`) to \`reranker.rerank()\`. The pre-trim collapsed the diverse candidate pool that \`diversityEnforce\` was meant to operate on.
- **H5 — context window**: \`LlmReranker\` bumped per-candidate text from \`slice(0, 400)\` (~80 tokens) to \`slice(0, 2000)\` (~500 tokens). 400 chars left the reranker LESS-informed than the embedder it was meant to refine.
- **Tests**: pool-preservation contract locked in. Recording-reranker fake asserts \`query()\` forwards \`fetchK\` candidates (NOT \`topK\`) and never sets \`topN\` itself.

## Why now

Phase 3 Stage 1 measured \`qwen36-27b-aeon\` reranking \`noar_div\` at **−17pp overall** vs no-rerank baseline. Cross-reviewer audit (gemini+cursor+codex parallel pass, 2026-04-30) converged on H1 as the dominant root cause. Per-query analysis confirmed: 26 queries flipped pass→fail when rerank was added, **0** flipped fail→pass; the 26 flipped queries lost a mean of −2.2 distinct source types (range −1 to −4). recall@10 went UP +0.02 — the reranker IS finding gold-supporting docs but stripping the cross-source evidence the scoring rubric requires.

The Stage 1 finding "reranker doesn't help" was a correct *production decision* under the broken pipeline, but NOT a fair verdict on the model. With this fix, [#313](https://github.com/SgtPooki/wtfoc/issues/313) (LlmReranker prompt audit) and [#319](https://github.com/SgtPooki/wtfoc/issues/319) (BGE-reranker deploy) can run a fair comparison.

## Test plan

- [x] \`pnpm test\` — 1464 passing + 1 skipped (was 1462 + 1; +2 new contract tests)
- [x] \`pnpm -r build\` — clean
- [x] \`pnpm lint:fix\` — clean
- [ ] **Targeted small-fixture rerun on \`noar_div_rrLlm-qwen\`** post-fix — pending [#320](https://github.com/SgtPooki/wtfoc/issues/320) (\`WTFOC_QUERY_FILTER\`) landing for fast iteration. Or run via BGE-reranker once [#319](https://github.com/SgtPooki/wtfoc/issues/319) lands.
- [ ] **Full smoke rerun** to verify lift recovery — gated on the targeted rerun showing positive signal.

## Notes

- Pre-v1: breaking change to the implicit contract between \`query.ts\` / \`trace/trace.ts\` and \`Reranker\` impls. All in-tree rerankers (\`bge\`, \`cohere\`, \`llm\`, \`passthrough\`) handle the omitted-\`topN\` case correctly — \`LlmReranker\` returns the full scored list when \`topN\` is unset (line 111 of \`llm.ts\`); \`BgeReranker\` passes \`top_n: undefined\` to the sidecar which returns all scored candidates; \`CohereReranker\` defaults \`top_n: candidates.length\`; \`PassthroughReranker\` returns input unchanged.
- Audit doc + this fix together close the action items from the 2026-04-30 cross-reviewer pass on the Phase 3 reranker conclusion.

## Related

- [#311](https://github.com/SgtPooki/wtfoc/issues/311) — autoresearch loop (closed via #317)
- [#313](https://github.com/SgtPooki/wtfoc/issues/313) — LlmReranker prompt audit
- [#319](https://github.com/SgtPooki/wtfoc/issues/319) — BGE-reranker-v2-m3 cross-encoder deploy
- [#320](https://github.com/SgtPooki/wtfoc/issues/320) — \`WTFOC_QUERY_FILTER\` env var (next step's enabler)