### PR TITLE
feat(search): WTFOC_QUERY_FILTER for fixture subset smokes (fixes #320)

### DIFF
--- a/packages/search/src/eval/quality-queries-evaluator.test.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.test.ts
@@ -9,7 +9,8 @@ const mockTrace = vi.hoisted(() => vi.fn<() => Promise<TraceResult>>());
 vi.mock("../query.js", () => ({ query: mockQuery }));
 vi.mock("../trace/trace.js", () => ({ trace: mockTrace }));
 
-const { evaluateQualityQueries } = await import("./quality-queries-evaluator.js");
+const { evaluateQualityQueries, getActiveQueries } = await import("./quality-queries-evaluator.js");
+const { GOLD_STANDARD_QUERIES } = await import("./gold-standard-queries.js");
 
 function makeQueryResult(
 	results: Array<{ sourceType: string; source: string; score: number }>,
@@ -507,6 +508,91 @@ describe("evaluateQualityQueries", () => {
 			});
 
 			expect(deterministic(run2)).toEqual(deterministic(run1));
+		});
+	});
+
+	describe("WTFOC_QUERY_FILTER subset filtering (#320)", () => {
+		// Tests `getActiveQueries()` directly — the helper exported for
+		// fast-iteration smokes (run a 20-30 query subset instead of the
+		// full 153-query fixture). Aggregate metrics noisier on subsets
+		// but per-query data stays real signal.
+
+		it("unset env var → no filter, returns full fixture", () => {
+			vi.stubEnv("WTFOC_QUERY_FILTER", "");
+			try {
+				const { queries, filter } = getActiveQueries();
+				expect(filter.active).toBe(false);
+				expect(filter.requestedIds).toEqual([]);
+				expect(filter.unknownIds).toEqual([]);
+				expect(filter.totalAvailable).toBe(GOLD_STANDARD_QUERIES.length);
+				expect(queries.length).toBe(GOLD_STANDARD_QUERIES.length);
+			} finally {
+				vi.unstubAllEnvs();
+			}
+		});
+
+		it("whitespace-only env var → no filter (defensive)", () => {
+			vi.stubEnv("WTFOC_QUERY_FILTER", "  ,  ,  ");
+			try {
+				const { filter } = getActiveQueries();
+				expect(filter.active).toBe(false);
+			} finally {
+				vi.unstubAllEnvs();
+			}
+		});
+
+		it("filter by known id returns only that query", () => {
+			const knownId = GOLD_STANDARD_QUERIES[0]?.id ?? "";
+			expect(knownId).toBeTruthy();
+			vi.stubEnv("WTFOC_QUERY_FILTER", knownId);
+			try {
+				const { queries, filter } = getActiveQueries();
+				expect(filter.active).toBe(true);
+				expect(filter.requestedIds).toEqual([knownId]);
+				expect(filter.unknownIds).toEqual([]);
+				expect(queries.length).toBe(1);
+				expect(queries[0]?.id).toBe(knownId);
+			} finally {
+				vi.unstubAllEnvs();
+			}
+		});
+
+		it("filter with unknown ids surfaces them in unknownIds", () => {
+			const knownId = GOLD_STANDARD_QUERIES[0]?.id ?? "";
+			vi.stubEnv("WTFOC_QUERY_FILTER", `${knownId},nonexistent-id`);
+			try {
+				const { queries, filter } = getActiveQueries();
+				expect(filter.active).toBe(true);
+				expect(filter.unknownIds).toEqual(["nonexistent-id"]);
+				expect(queries.length).toBe(1);
+			} finally {
+				vi.unstubAllEnvs();
+			}
+		});
+
+		it("filter with all-unknown ids returns empty queries + populated unknownIds", () => {
+			vi.stubEnv("WTFOC_QUERY_FILTER", "no-such-id,also-not-real");
+			try {
+				const { queries, filter } = getActiveQueries();
+				expect(filter.active).toBe(true);
+				expect(filter.unknownIds).toEqual(["no-such-id", "also-not-real"]);
+				expect(queries.length).toBe(0);
+			} finally {
+				vi.unstubAllEnvs();
+			}
+		});
+
+		it("filter with extra whitespace in ids tolerated", () => {
+			const knownId = GOLD_STANDARD_QUERIES[0]?.id ?? "";
+			vi.stubEnv("WTFOC_QUERY_FILTER", `  ${knownId}  ,  `);
+			try {
+				const { queries, filter } = getActiveQueries();
+				expect(filter.active).toBe(true);
+				expect(queries.length).toBe(1);
+				expect(queries[0]?.id).toBe(knownId);
+			} finally {
+				vi.unstubAllEnvs();
+			}
 		});
 	});
 });

--- a/packages/search/src/eval/quality-queries-evaluator.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.ts
@@ -21,6 +21,54 @@ import {
 	type LineageMetrics,
 } from "./lineage-metrics.js";
 
+/**
+ * #320 — fast-iteration smoke support. When `WTFOC_QUERY_FILTER` is set
+ * to a comma-separated list of query ids, score only those queries from
+ * the gold fixture. Aggregate metrics get noisier (demo-critical
+ * pass-rate of 1/1 is not the same signal as 5/5) but per-query data
+ * stays real — useful for hypothesis testing on a 20-30 query subset
+ * before burning hours on the full 153-query fixture.
+ *
+ * Empty / unset / whitespace-only env var = no filter (default behavior).
+ * Unknown ids in the filter list are silently dropped. Missing ids in
+ * the fixture are reported in `queryFilter.unknownIds` so a typo doesn't
+ * silently shrink the run beyond expectation.
+ */
+export function getActiveQueries(): {
+	queries: ReadonlyArray<GoldStandardQuery>;
+	filter: { active: boolean; requestedIds: string[]; unknownIds: string[]; totalAvailable: number };
+} {
+	const raw = process.env.WTFOC_QUERY_FILTER ?? "";
+	const requested = raw
+		.split(",")
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+	if (requested.length === 0) {
+		return {
+			queries: GOLD_STANDARD_QUERIES,
+			filter: {
+				active: false,
+				requestedIds: [],
+				unknownIds: [],
+				totalAvailable: GOLD_STANDARD_QUERIES.length,
+			},
+		};
+	}
+	const wantedSet = new Set(requested);
+	const filtered = GOLD_STANDARD_QUERIES.filter((q) => wantedSet.has(q.id));
+	const matchedIds = new Set(filtered.map((q) => q.id));
+	const unknownIds = requested.filter((id) => !matchedIds.has(id));
+	return {
+		queries: filtered,
+		filter: {
+			active: true,
+			requestedIds: requested,
+			unknownIds,
+			totalAvailable: GOLD_STANDARD_QUERIES.length,
+		},
+	};
+}
+
 interface QueryScore {
 	id: string;
 	category: string;
@@ -148,7 +196,9 @@ export async function evaluateQualityQueries(
 	let skippedCount = 0;
 	const skippedReasons: Array<{ id: string; reason: string }> = [];
 
-	for (const gq of GOLD_STANDARD_QUERIES) {
+	const { queries: activeQueries, filter: queryFilter } = getActiveQueries();
+
+	for (const gq of activeQueries) {
 		signal?.throwIfAborted();
 		const skip = resolveSkip(gq, context);
 		if (skip) {
@@ -176,7 +226,7 @@ export async function evaluateQualityQueries(
 		if (score.passedQueryOnly) queryOnlyPassCount++;
 	}
 
-	const applicableTotal = GOLD_STANDARD_QUERIES.length - skippedCount;
+	const applicableTotal = activeQueries.length - skippedCount;
 	const passRate = applicableTotal > 0 ? passCount / applicableTotal : 0;
 	const queryOnlyPassRate = applicableTotal > 0 ? queryOnlyPassCount / applicableTotal : 0;
 
@@ -210,7 +260,7 @@ export async function evaluateQualityQueries(
 	// June 7 flagship to be safe. Surfaced separately so overall pass rate
 	// doesn't hide a demo-breaking regression.
 	const demoCriticalIds = new Set(
-		GOLD_STANDARD_QUERIES.filter((q) => q.tier === "demo-critical").map((q) => q.id),
+		activeQueries.filter((q) => q.tier === "demo-critical").map((q) => q.id),
 	);
 	const demoCriticalScores = scores.filter((s) => demoCriticalIds.has(s.id) && !s.skipped);
 	const demoCriticalPassed = demoCriticalScores.filter((s) => s.passed).length;
@@ -228,7 +278,7 @@ export async function evaluateQualityQueries(
 	// from masquerading as general retrieval. Peer-review (codex + gemini)
 	// required after overfitting audit flagged single-corpus tuning.
 	const portableIds = new Set(
-		GOLD_STANDARD_QUERIES.filter((q) => q.portability === "portable").map((q) => q.id),
+		activeQueries.filter((q) => q.portability === "portable").map((q) => q.id),
 	);
 	const portableScores = scores.filter((s) => portableIds.has(s.id) && !s.skipped);
 	const portablePassed = portableScores.filter((s) => s.passed).length;
@@ -251,9 +301,7 @@ export async function evaluateQualityQueries(
 	// Applicable rate (v1.6.0) — what fraction of the fixture this corpus
 	// can even answer. A high pass rate on a low applicable rate is the
 	// overfit-and-skip signature; threshold check should warn on this.
-	const applicableRate = GOLD_STANDARD_QUERIES.length
-		? applicableTotal / GOLD_STANDARD_QUERIES.length
-		: 0;
+	const applicableRate = activeQueries.length ? applicableTotal / activeQueries.length : 0;
 
 	// Verdict
 	let verdict: "pass" | "warn" | "fail" = "pass";
@@ -340,7 +388,12 @@ export async function evaluateQualityQueries(
 			// goldSupportingSources mapping in the fixture (demo-critical
 			// tier in v1.7.0). Reports the mean recall@K across those
 			// queries plus the per-tier average for demo-critical.
-			recallAtK: aggregateRecall(scores),
+			recallAtK: aggregateRecall(scores, activeQueries),
+			// #320 — when WTFOC_QUERY_FILTER is set, surface the filter
+			// state in metrics so analysts can see the run was a subset
+			// (and not compare aggregate metrics directly to full-fixture
+			// runs). `active: false` when no filter — analysts can ignore.
+			queryFilter,
 			// #311 (Phase 1a) — paraphrase invariance aggregate. Only
 			// emitted when paraphrase checking ran. A query is "brittle"
 			// when canonical passes but ≥1 paraphrase fails — directly
@@ -404,10 +457,13 @@ interface RecallAggregate {
 	demoCriticalGraded: number;
 }
 
-function aggregateRecall(scores: QueryScore[]): RecallAggregate {
+function aggregateRecall(
+	scores: QueryScore[],
+	activeQueries: ReadonlyArray<GoldStandardQuery>,
+): RecallAggregate {
 	const graded = scores.filter((s) => !s.skipped && s.recallAtK !== null && s.recallK !== null);
 	const demoCriticalIds = new Set(
-		GOLD_STANDARD_QUERIES.filter((q) => q.tier === "demo-critical").map((q) => q.id),
+		activeQueries.filter((q) => q.tier === "demo-critical").map((q) => q.id),
 	);
 	const demoCriticalGraded = graded.filter((s) => demoCriticalIds.has(s.id));
 	const k = graded[0]?.recallK ?? null;


### PR DESCRIPTION
Closes #320.

## Summary

Env-var-driven query subsetting for fast smoke iteration. Set \`WTFOC_QUERY_FILTER=cov-16,wl-21,...\` to score only those queries from the 153-query gold fixture. Unset/empty = full fixture.

## Why

[Phase 3 audit](https://github.com/SgtPooki/wtfoc/blob/main/docs/autoresearch/audits/2026-04-30-rerank-pipeline-collapse.md) identified the 26 queries that flipped pass→fail under qwen rerank + diversityEnforce. Validating the [#323 H1+H5 fix](https://github.com/SgtPooki/wtfoc/pull/323) and [#319 BGE-reranker](https://github.com/SgtPooki/wtfoc/issues/319) requires iterating on those 26 queries — not the full 153-query fixture (hours/smoke). Subsets produce real per-query data; only aggregate metrics are noisier.

## What

- \`getActiveQueries()\` helper filters fixture by env var, surfaces filter state
- \`evaluateQualityQueries\` uses \`activeQueries\` for scoring loop + tier/portability/recall aggregations
- Filter state emitted in metrics output as \`queryFilter\` field
- Unknown ids reported in \`queryFilter.unknownIds\` (typo protection)

## Test plan

- [x] \`pnpm test\` — 1470 passing + 1 skipped (was 1464 + 1, +6 new tests)
- [x] \`pnpm -r build\` — clean
- [x] \`pnpm lint:fix\` — clean

## Notes

- Pre-v1 env-var contract.
- Subset aggregate metrics are intentionally noisy — should NOT be used for production-config promotion decisions.