### PR TITLE
docs(agents): point CLAUDE.md + AGENTS.md at vision.md/why.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # AGENTS.md — wtfoc
 
-**Mission:** wtfoc builds shareable, improvable knowledge graphs. Any agent — AI or human — can ingest sources, extract semantic edges, and publish a collection to Filecoin. Any other agent can fetch it, improve it (better edges, new sources, re-chunking), and republish. The knowledge gets better with each contributor.
+**Mission:** wtfoc is an evidence-backed **trace engine with explicit typed edges across any content type**. Builds shareable, improvable knowledge graphs. Any agent — AI or human — can ingest sources, extract evidence-backed edges (pattern, code, heuristic, temporal, LLM extractors run in parallel), and publish a content-addressed collection. Any other agent can fetch, improve, and republish. The knowledge gets better with each contributor.
+
+**Read before framing or scope proposals:** [`docs/vision.md`](docs/vision.md) (north-star goals + anti-goals) and [`docs/why.md`](docs/why.md) (search vs trace, the four collection use cases — Extend / RAG / Share / Drift-detection). Collections hold any content type (engineering artifacts, customer data, time-series, audio metadata, anything). FOC is the *default* StorageBackend, not a requirement — pluggable seam.
 
 Agent operating instructions for this repository.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 **Baseline rules**: [`AGENTS.md`](AGENTS.md) defines project-wide operating rules (style, seams, commit discipline, edit checklist). Follow AGENTS.md as the foundation.
 
+## Vision and mission — read before reasoning about wtfoc
+
+These two docs define what wtfoc is and where it's going. Read them before making framing claims, scope proposals, or design decisions. Don't reduce wtfoc to "RAG" or "Filecoin storage" — both are wrong. **wtfoc is a trace engine with explicit typed edges across any content type.** RAG is one of four collection use cases. FOC is the *default* StorageBackend, not a requirement.
+
+- [`docs/vision.md`](docs/vision.md) — north-star goals, what "done" looks like, anti-goals
+- [`docs/why.md`](docs/why.md) — what the differentiator is (search vs trace), how it compares to other tools
+- [`docs/autoresearch/autonomous-loop-runbook.md`](docs/autoresearch/autonomous-loop-runbook.md) — operational guide for the closed-loop improvement system
+
+Collections can hold any content (engineering artifacts, customer data, financial time-series, audio metadata, etc.). The substrate-of-community-improvable-collections is the moat — not retrieval quality.
+
 ## Skills
 
 Available via `/skill-name` or `Skill({ skill: "name" })`:


### PR DESCRIPTION
Auto-loads authoritative wtfoc framing into every agent session. Eliminates having to repeat 'wtfoc is a trace engine, NOT a RAG, NOT FOC-only' in every conversation.

Both CLAUDE.md and AGENTS.md now:
- Lead with the trace-engine framing
- Note that collections can hold any content type
- Note that RAG is one of four use cases (Extend / RAG / Share / Drift)
- Note that FOC is the default StorageBackend, not a requirement
- Point at docs/vision.md, docs/why.md, and docs/autoresearch/autonomous-loop-runbook.md

No code changes. CI should be a no-op (lint+build+test all pass; nothing in source touched).