### PR TITLE
feat(autoresearch): wire LLM patch-proposer + anti-overfit floor (closes #335)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # AGENTS.md — wtfoc
 
-**Mission:** wtfoc builds shareable, improvable knowledge graphs. Any agent — AI or human — can ingest sources, extract semantic edges, and publish a collection to Filecoin. Any other agent can fetch it, improve it (better edges, new sources, re-chunking), and republish. The knowledge gets better with each contributor.
+**Mission:** wtfoc is an evidence-backed **trace engine with explicit typed edges across any content type**. Builds shareable, improvable knowledge graphs. Any agent — AI or human — can ingest sources, extract evidence-backed edges (pattern, code, heuristic, temporal, LLM extractors run in parallel), and publish a content-addressed collection. Any other agent can fetch, improve, and republish. The knowledge gets better with each contributor.
+
+**Read before framing or scope proposals:** [`docs/vision.md`](docs/vision.md) (north-star goals + anti-goals) and [`docs/why.md`](docs/why.md) (search vs trace, the four collection use cases — Extend / RAG / Share / Drift-detection). Collections hold any content type (engineering artifacts, customer data, time-series, audio metadata, anything). FOC is the *default* StorageBackend, not a requirement — pluggable seam.
 
 Agent operating instructions for this repository.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 **Baseline rules**: [`AGENTS.md`](AGENTS.md) defines project-wide operating rules (style, seams, commit discipline, edit checklist). Follow AGENTS.md as the foundation.
 
+## Vision and mission — read before reasoning about wtfoc
+
+These two docs define what wtfoc is and where it's going. Read them before making framing claims, scope proposals, or design decisions. Don't reduce wtfoc to "RAG" or "Filecoin storage" — both are wrong. **wtfoc is a trace engine with explicit typed edges across any content type.** RAG is one of four collection use cases. FOC is the *default* StorageBackend, not a requirement.
+
+- [`docs/vision.md`](docs/vision.md) — north-star goals, what "done" looks like, anti-goals
+- [`docs/why.md`](docs/why.md) — what the differentiator is (search vs trace), how it compares to other tools
+- [`docs/autoresearch/autonomous-loop-runbook.md`](docs/autoresearch/autonomous-loop-runbook.md) — operational guide for the closed-loop improvement system
+
+Collections can hold any content (engineering artifacts, customer data, financial time-series, audio metadata, etc.). The substrate-of-community-improvable-collections is the moat — not retrieval quality.
+
 ## Skills
 
 Available via `/skill-name` or `Skill({ skill: "name" })`:

--- a/scripts/autoresearch/analyze-and-propose-patch.test.ts
+++ b/scripts/autoresearch/analyze-and-propose-patch.test.ts
@@ -1,0 +1,210 @@
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+	analyzeAndProposePatch,
+	buildPatchUserPrompt,
+	parsePatchBlock,
+} from "./analyze-and-propose-patch.js";
+import type { TriedLogRow } from "./tried-log.js";
+
+function tmpRepo(): string {
+	const dir = mkdtempSync(join(tmpdir(), "wtfoc-patch-"));
+	mkdirSync(join(dir, "packages", "search", "src"), { recursive: true });
+	writeFileSync(
+		join(dir, "packages", "search", "src", "query.ts"),
+		"export function query() { return 0; }\n",
+	);
+	mkdirSync(join(dir, ".git"));
+	return dir;
+}
+
+describe("buildPatchUserPrompt", () => {
+	it("includes baseSha, issues section, tried-log section, finding context, and curated files", () => {
+		const prompt = buildPatchUserPrompt({
+			matrixName: "retrieval-baseline",
+			explainMarkdown: "## Identity\nvariant: x",
+			triedRows: [],
+			openIssues: [
+				{
+					number: 99,
+					title: "wl-1 brittleness",
+					labels: ["regression"],
+					bodyPreview: "wl-1 fails on paraphrase 3",
+					createdAt: "2026-04-01",
+				},
+			],
+			curatedFileContents: [{ path: "packages/search/src/x.ts", body: "export const a = 1;" }],
+			baseSha: "abc1234567",
+		});
+		expect(prompt).toContain("baseSha: abc1234567");
+		expect(prompt).toContain("Open GitHub issues");
+		expect(prompt).toContain("#99 wl-1 brittleness");
+		expect(prompt).toContain("Past attempts");
+		expect(prompt).toContain("Finding context");
+		expect(prompt).toContain("variant: x");
+		expect(prompt).toContain("Curated source files");
+		expect(prompt).toContain("packages/search/src/x.ts");
+		expect(prompt).toContain("export const a = 1;");
+	});
+});
+
+describe("parsePatchBlock", () => {
+	it("extracts a fenced diff block", () => {
+		const content = `## Analysis\nlooks like diversity is too tight.\n\n## Patch\n\n\`\`\`diff\ndiff --git a/foo b/foo\n--- a/foo\n+++ b/foo\n@@ -1,1 +1,1 @@\n-old\n+new\n\`\`\``;
+		const d = parsePatchBlock(content);
+		expect(d).not.toBeNull();
+		expect(d).toContain("diff --git");
+		expect(d).toContain("+new");
+	});
+
+	it("returns null on NO_PATCH literal", () => {
+		const content = "## Analysis\nnothing to do.\n\n## Patch\n\nNO_PATCH\n";
+		expect(parsePatchBlock(content)).toBeNull();
+	});
+
+	it("returns null when no Patch section", () => {
+		expect(parsePatchBlock("## Analysis only")).toBeNull();
+	});
+
+	it("returns null when Patch section is empty", () => {
+		expect(parsePatchBlock("## Patch\n\n```diff\n```")).toBeNull();
+	});
+});
+
+describe("analyzeAndProposePatch", () => {
+	function mockLlm(content: string): typeof fetch {
+		return vi.fn(async () =>
+			new Response(JSON.stringify({ choices: [{ message: { content } }] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		) as unknown as typeof fetch;
+	}
+
+	it("returns a valid proposal on a successful LLM response", async () => {
+		const repo = tmpRepo();
+		// Write a fake HEAD ref so git rev-parse can resolve.
+		writeFileSync(join(repo, ".git", "HEAD"), "ref: refs/heads/main\n");
+		mkdirSync(join(repo, ".git", "refs", "heads"), { recursive: true });
+		writeFileSync(join(repo, ".git", "refs", "heads", "main"), "1234567890abcdef\n");
+
+		const validDiff = `diff --git a/packages/search/src/query.ts b/packages/search/src/query.ts
+--- a/packages/search/src/query.ts
++++ b/packages/search/src/query.ts
+@@ -1,1 +1,1 @@
+-export function query() { return 0; }
++export function query() { return 1; }
+`;
+		const llm = mockLlm(
+			`## Analysis\ndiversity threshold is too tight.\n\n## Patch\n\n\`\`\`diff\n${validDiff}\`\`\``,
+		);
+		const res = await analyzeAndProposePatch({
+			matrixName: "retrieval-baseline",
+			explainMarkdown: "stub",
+			triedRows: [],
+			openIssues: [],
+			curatedFiles: ["packages/search/src/query.ts"],
+			repoRoot: repo,
+			baseShaOverride: "1234567890abcdef",
+			fetchFn: llm,
+		});
+		expect(res.ok).toBe(true);
+		expect(res.proposal).not.toBeNull();
+		expect(res.proposal?.kind).toBe("patch");
+		expect(res.proposal?.unifiedDiff).toContain("diff --git");
+	});
+
+	it("rejects an LLM patch outside the allowlist", async () => {
+		const repo = tmpRepo();
+		writeFileSync(join(repo, ".git", "HEAD"), "ref: refs/heads/main\n");
+		mkdirSync(join(repo, ".git", "refs", "heads"), { recursive: true });
+		writeFileSync(join(repo, ".git", "refs", "heads", "main"), "1234567890abcdef\n");
+
+		const badDiff = `diff --git a/scripts/dogfood.ts b/scripts/dogfood.ts
+--- a/scripts/dogfood.ts
++++ b/scripts/dogfood.ts
+@@ -1,1 +1,1 @@
+-old
++new
+`;
+		const llm = mockLlm(`## Analysis\nx\n\n## Patch\n\`\`\`diff\n${badDiff}\`\`\``);
+		const res = await analyzeAndProposePatch({
+			matrixName: "retrieval-baseline",
+			explainMarkdown: "stub",
+			triedRows: [],
+			openIssues: [],
+			curatedFiles: ["packages/search/src/query.ts"],
+			repoRoot: repo,
+			baseShaOverride: "1234567890abcdef",
+			fetchFn: llm,
+		});
+		expect(res.proposal).toBeNull();
+		expect(res.error).toMatch(/outside allowlist/);
+	});
+
+	it("returns null proposal on NO_PATCH (no error)", async () => {
+		const repo = tmpRepo();
+		writeFileSync(join(repo, ".git", "HEAD"), "ref: refs/heads/main\n");
+		mkdirSync(join(repo, ".git", "refs", "heads"), { recursive: true });
+		writeFileSync(join(repo, ".git", "refs", "heads", "main"), "1234567890abcdef\n");
+
+		const llm = mockLlm("## Analysis\nuncertain.\n\n## Patch\nNO_PATCH\n");
+		const res = await analyzeAndProposePatch({
+			matrixName: "retrieval-baseline",
+			explainMarkdown: "stub",
+			triedRows: [],
+			openIssues: [],
+			curatedFiles: ["packages/search/src/query.ts"],
+			repoRoot: repo,
+			baseShaOverride: "1234567890abcdef",
+			fetchFn: llm,
+		});
+		expect(res.ok).toBe(true);
+		expect(res.proposal).toBeNull();
+		expect(res.error).toBeUndefined();
+	});
+
+	it("fails soft when no curated files exist", async () => {
+		const repo = tmpRepo();
+		writeFileSync(join(repo, ".git", "HEAD"), "ref: refs/heads/main\n");
+		mkdirSync(join(repo, ".git", "refs", "heads"), { recursive: true });
+		writeFileSync(join(repo, ".git", "refs", "heads", "main"), "1234567890abcdef\n");
+
+		const llm = mockLlm("...");
+		const res = await analyzeAndProposePatch({
+			matrixName: "retrieval-baseline",
+			explainMarkdown: "stub",
+			triedRows: [],
+			openIssues: [],
+			curatedFiles: ["packages/nonexistent/src/foo.ts"],
+			repoRoot: repo,
+			baseShaOverride: "1234567890abcdef",
+			fetchFn: llm,
+		});
+		expect(res.ok).toBe(false);
+		expect(res.error).toMatch(/no curated files readable/);
+	});
+
+	it("fails soft on LLM HTTP error", async () => {
+		const repo = tmpRepo();
+		writeFileSync(join(repo, ".git", "HEAD"), "ref: refs/heads/main\n");
+		mkdirSync(join(repo, ".git", "refs", "heads"), { recursive: true });
+		writeFileSync(join(repo, ".git", "refs", "heads", "main"), "1234567890abcdef\n");
+
+		const llm = vi.fn(async () => new Response("nope", { status: 500 })) as unknown as typeof fetch;
+		const res = await analyzeAndProposePatch({
+			matrixName: "retrieval-baseline",
+			explainMarkdown: "stub",
+			triedRows: [],
+			openIssues: [],
+			curatedFiles: ["packages/search/src/query.ts"],
+			repoRoot: repo,
+			baseShaOverride: "1234567890abcdef",
+			fetchFn: llm,
+		});
+		expect(res.ok).toBe(false);
+		expect(res.error).toMatch(/HTTP 500/);
+	});
+});

--- a/scripts/autoresearch/analyze-and-propose-patch.ts
+++ b/scripts/autoresearch/analyze-and-propose-patch.ts
@@ -1,0 +1,387 @@
+/**
+ * Local-LLM code-patch proposer for the autonomous loop.
+ * Maintainer-only.
+ *
+ * Companion to `analyze-and-propose.ts`. When the planner queue of
+ * config knobs is exhausted (or when env-flagged), the loop calls this
+ * module to ask the LLM for a unified-diff against a curated set of
+ * `packages/search/src/` files.
+ *
+ * Hard rules:
+ *   - LLM endpoint comes from env (`WTFOC_PATCH_LLM_URL`, falls back to
+ *     `WTFOC_ANALYSIS_LLM_URL`, then `http://127.0.0.1:4523/v1`).
+ *   - The diff MUST stay inside the allowlist enforced by
+ *     `patch-proposal.ts:validatePatch`. Default allowlist:
+ *     `packages/search/src/`.
+ *   - Diff size capped (default 200 lines added+removed).
+ *   - One patch per cycle. The materializer runs the SAME A/B harness
+ *     as config proposals; promotion is a draft PR.
+ *
+ * The prompt includes:
+ *   - The flipped-queries explainFinding markdown (so the LLM has
+ *     evidence of WHAT broke and where).
+ *   - A curated set of source files inlined verbatim, so the LLM can
+ *     emit diffs against real line numbers and avoid hallucinating
+ *     symbols.
+ *   - The current `git rev-parse HEAD` SHA so the proposal carries a
+ *     real `baseSha` and the materializer can `git worktree add` at
+ *     that point cleanly.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { fetchOpenIssues, openIssuesToPromptLines, type OpenIssueSummary } from "./open-issues.js";
+import {
+	DEFAULT_ALLOWED_PATHS,
+	DEFAULT_MAX_DIFF_LINES,
+	type PatchProposal,
+	validatePatch,
+} from "./patch-proposal.js";
+import { type TriedLogRow, triedLogPromptLines } from "./tried-log.js";
+
+export const DEFAULT_PATCH_LLM_URL = "http://127.0.0.1:4523/v1";
+export const DEFAULT_PATCH_LLM_MODEL = "haiku";
+
+/**
+ * Default curated file set. The patch proposer inlines these so the
+ * LLM can reason about line numbers + types without hallucinating.
+ * Keep it small — total prompt size matters. Override via the
+ * `curatedFiles` input or the WTFOC_PATCH_CURATED_FILES env (comma-
+ * separated paths relative to repo root).
+ */
+export const DEFAULT_CURATED_FILES: readonly string[] = [
+	"packages/search/src/query.ts",
+	"packages/search/src/trace/trace.ts",
+	"packages/search/src/diversity.ts",
+];
+
+const MAX_FILE_CHARS = 8_000;
+const MAX_TOTAL_PROMPT_CHARS = 60_000;
+
+export interface AnalyzeProposePatchInputs {
+	matrixName: string;
+	explainMarkdown: string;
+	triedRows: readonly TriedLogRow[];
+	llmUrl?: string;
+	llmModel?: string;
+	llmApiKey?: string;
+	timeoutMs?: number;
+	repoRoot?: string;
+	curatedFiles?: readonly string[];
+	allowedPaths?: readonly string[];
+	maxDiffLines?: number;
+	fetchFn?: typeof fetch;
+	/**
+	 * Open GitHub issues to surface to the LLM as proposal context.
+	 * When unset, fetched lazily via `gh issue list`. Tests pass [] to
+	 * disable.
+	 */
+	openIssues?: readonly OpenIssueSummary[];
+	/** Override git rev-parse HEAD lookup (testing). */
+	baseShaOverride?: string;
+}
+
+export interface AnalyzeProposePatchResult {
+	ok: boolean;
+	analysisMarkdown: string;
+	proposal: PatchProposal | null;
+	llmCallSucceeded: boolean;
+	error?: string;
+	rawContent?: string;
+}
+
+const SYSTEM_PROMPT = `You are an autoresearch agent for a retrieval system called wtfoc. You propose CODE CHANGES (not config tweaks) to fix regressions.
+
+You will receive:
+- A regression finding with flipped queries, retrieved chunks, and gold-source proximity diagnostics.
+- A summary of past attempts on this matrix (so you don't repeat yourself).
+- A curated set of source files inlined verbatim. Their paths are fixed; you can only modify files in this set.
+- A baseSha (current HEAD) — your patch will be applied at that commit.
+
+Your job: emit ONE unified diff that you believe will fix the regression OR explain that no proposal is appropriate.
+
+Output rules:
+1. Two sections, in order:
+   - "## Analysis" — root-cause hypothesis (under 300 words)
+   - "## Patch" — a single fenced block tagged \`diff\` containing a unified diff, OR the literal string "NO_PATCH" when you have no high-confidence proposal.
+2. The diff MUST:
+   - Touch only files from the curated set (paths exactly as listed).
+   - Use \`diff --git a/<path> b/<path>\` headers and \`@@ ... @@\` hunk headers.
+   - Be minimal — one focused change. Multi-file refactors are out of scope.
+   - Stay under 200 added+removed lines.
+3. Do NOT include the baseSha in the diff — the harness applies it at that commit automatically.
+4. Do NOT propose changes that already appear in the tried-log (same axis-equivalent change). The maintainer would rather see "I don't know" than a duplicate.
+5. If the regression is a hard-gate breach, your patch must target the breached metric specifically.
+
+Worked example of an acceptable patch:
+
+\`\`\`diff
+diff --git a/packages/search/src/diversity.ts b/packages/search/src/diversity.ts
+--- a/packages/search/src/diversity.ts
++++ b/packages/search/src/diversity.ts
+@@ -42,7 +42,7 @@ export function applyDiversity(results, opts) {
+   for (const r of results) {
+-    if (seen.has(r.sourceType)) continue;
++    if (seen.has(r.sourceType) && r.score < topScore * 0.7) continue;
+     out.push(r);
+     seen.add(r.sourceType);
+   }
+\`\`\`
+
+If you cannot propose a confident, focused patch, emit:
+
+## Patch
+
+NO_PATCH`;
+
+export function buildPatchUserPrompt(input: {
+	matrixName: string;
+	explainMarkdown: string;
+	triedRows: readonly TriedLogRow[];
+	openIssues: readonly OpenIssueSummary[];
+	curatedFileContents: ReadonlyArray<{ path: string; body: string }>;
+	baseSha: string;
+}): string {
+	const triedLines = triedLogPromptLines(input.triedRows, input.matrixName);
+	const issueLines = openIssuesToPromptLines(input.openIssues);
+	const fileBlocks: string[] = [];
+	for (const f of input.curatedFileContents) {
+		fileBlocks.push(`### \`${f.path}\``);
+		fileBlocks.push("```typescript");
+		fileBlocks.push(f.body);
+		fileBlocks.push("```");
+		fileBlocks.push("");
+	}
+	return [
+		`# baseSha: ${input.baseSha}`,
+		"",
+		"# Open GitHub issues (proposal source — correlate with the regression)",
+		"",
+		...issueLines,
+		"",
+		"# Past attempts on this matrix (config + patch proposals)",
+		"",
+		...triedLines,
+		"",
+		"# Finding context",
+		"",
+		input.explainMarkdown,
+		"",
+		"# Curated source files (only these may be modified)",
+		"",
+		...fileBlocks,
+	].join("\n");
+}
+
+const HERE = (() => {
+	try {
+		return dirname(fileURLToPath(import.meta.url));
+	} catch {
+		return process.cwd();
+	}
+})();
+
+function defaultRepoRoot(): string {
+	return resolve(HERE, "..", "..");
+}
+
+function readCuratedFiles(
+	repoRoot: string,
+	paths: readonly string[],
+): Array<{ path: string; body: string }> {
+	const out: Array<{ path: string; body: string }> = [];
+	let totalChars = 0;
+	for (const p of paths) {
+		const abs = join(repoRoot, p);
+		if (!existsSync(abs)) continue;
+		try {
+			const st = statSync(abs);
+			if (!st.isFile()) continue;
+			let body = readFileSync(abs, "utf-8");
+			if (body.length > MAX_FILE_CHARS) {
+				body = `${body.slice(0, MAX_FILE_CHARS)}\n// ... (file truncated to ${MAX_FILE_CHARS} chars)`;
+			}
+			if (totalChars + body.length > MAX_TOTAL_PROMPT_CHARS) break;
+			totalChars += body.length;
+			out.push({ path: p, body });
+		} catch {
+			// skip
+		}
+	}
+	return out;
+}
+
+function readGitHead(repoRoot: string): string {
+	try {
+		return execFileSync("git", ["rev-parse", "HEAD"], {
+			cwd: repoRoot,
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim();
+	} catch {
+		return "";
+	}
+}
+
+interface OpenAIChatCompletionResponse {
+	choices?: Array<{ message?: { content?: string } }>;
+}
+
+/**
+ * Pull the unified diff out of the LLM's "## Patch" section. Tolerant
+ * of formatting drift (extra prose around the fenced block, leading
+ * whitespace, alternative fence labels). Returns null when no diff
+ * found OR when the LLM emitted "NO_PATCH" intentionally.
+ */
+export function parsePatchBlock(content: string): string | null {
+	const idx = content.indexOf("## Patch");
+	if (idx < 0) return null;
+	const after = content.slice(idx);
+	if (/NO_PATCH/i.test(after)) return null;
+	const fence = after.match(/```(?:diff|patch)?\s*\n([\s\S]*?)```/);
+	if (!fence || !fence[1]) return null;
+	const raw = fence[1].trim();
+	if (raw.length === 0) return null;
+	return raw;
+}
+
+export async function analyzeAndProposePatch(
+	input: AnalyzeProposePatchInputs,
+): Promise<AnalyzeProposePatchResult> {
+	const url =
+		input.llmUrl ??
+		process.env.WTFOC_PATCH_LLM_URL ??
+		process.env.WTFOC_ANALYSIS_LLM_URL ??
+		DEFAULT_PATCH_LLM_URL;
+	const model = input.llmModel ?? process.env.WTFOC_PATCH_LLM_MODEL ?? DEFAULT_PATCH_LLM_MODEL;
+	const apiKey =
+		input.llmApiKey ?? process.env.WTFOC_PATCH_LLM_API_KEY ?? process.env.WTFOC_ANALYSIS_LLM_API_KEY ?? "";
+	const fetchFn = input.fetchFn ?? fetch;
+	const timeoutMs = input.timeoutMs ?? 90_000;
+	const repoRoot = input.repoRoot ?? defaultRepoRoot();
+	const curatedPaths =
+		input.curatedFiles ??
+		(process.env.WTFOC_PATCH_CURATED_FILES
+			? process.env.WTFOC_PATCH_CURATED_FILES.split(",").map((s) => s.trim()).filter((s) => s.length > 0)
+			: DEFAULT_CURATED_FILES);
+	const curatedFileContents = readCuratedFiles(repoRoot, curatedPaths);
+	const baseSha = input.baseShaOverride ?? readGitHead(repoRoot);
+	if (!baseSha) {
+		return {
+			ok: false,
+			analysisMarkdown: "",
+			proposal: null,
+			llmCallSucceeded: false,
+			error: "could not resolve git HEAD — patch proposer requires a clean repo",
+		};
+	}
+	if (curatedFileContents.length === 0) {
+		return {
+			ok: false,
+			analysisMarkdown: "",
+			proposal: null,
+			llmCallSucceeded: false,
+			error: `no curated files readable; checked ${curatedPaths.join(", ")}`,
+		};
+	}
+
+	const openIssues = input.openIssues ?? fetchOpenIssues();
+	const userPrompt = buildPatchUserPrompt({
+		matrixName: input.matrixName,
+		explainMarkdown: input.explainMarkdown,
+		triedRows: input.triedRows,
+		openIssues,
+		curatedFileContents,
+		baseSha,
+	});
+
+	const ac = new AbortController();
+	const timer = setTimeout(() => ac.abort(), timeoutMs);
+	try {
+		const headers: Record<string, string> = { "Content-Type": "application/json" };
+		if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+		const res = await fetchFn(`${url.replace(/\/+$/, "")}/chat/completions`, {
+			method: "POST",
+			headers,
+			body: JSON.stringify({
+				model,
+				temperature: 0.2,
+				max_tokens: 3000,
+				messages: [
+					{ role: "system", content: SYSTEM_PROMPT },
+					{ role: "user", content: userPrompt },
+				],
+			}),
+			signal: ac.signal,
+		});
+		if (!res.ok) {
+			return {
+				ok: false,
+				analysisMarkdown: "",
+				proposal: null,
+				llmCallSucceeded: false,
+				error: `LLM HTTP ${res.status}: ${(await res.text()).slice(0, 500)}`,
+			};
+		}
+		const body = (await res.json()) as OpenAIChatCompletionResponse;
+		const content = body.choices?.[0]?.message?.content ?? "";
+		const diff = parsePatchBlock(content);
+		if (!diff) {
+			return {
+				ok: true,
+				analysisMarkdown: content,
+				proposal: null,
+				llmCallSucceeded: true,
+				rawContent: content,
+			};
+		}
+		const candidate: PatchProposal = {
+			kind: "patch",
+			baseSha,
+			unifiedDiff: diff,
+			rationale: extractAnalysis(content),
+		};
+		const validation = validatePatch(candidate, {
+			allowedPaths: input.allowedPaths ?? DEFAULT_ALLOWED_PATHS,
+			maxDiffLines: input.maxDiffLines ?? DEFAULT_MAX_DIFF_LINES,
+		});
+		if (!validation.ok) {
+			return {
+				ok: true,
+				analysisMarkdown: content,
+				proposal: null,
+				llmCallSucceeded: true,
+				error: `LLM proposed invalid patch: ${validation.errors.join("; ")}`,
+				rawContent: content,
+			};
+		}
+		return {
+			ok: true,
+			analysisMarkdown: content,
+			proposal: candidate,
+			llmCallSucceeded: true,
+			rawContent: content,
+		};
+	} catch (err) {
+		return {
+			ok: false,
+			analysisMarkdown: "",
+			proposal: null,
+			llmCallSucceeded: false,
+			error: err instanceof Error ? err.message : String(err),
+		};
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+function extractAnalysis(content: string): string {
+	const idx = content.indexOf("## Analysis");
+	if (idx < 0) return content.slice(0, 400);
+	const start = idx + "## Analysis".length;
+	const patchIdx = content.indexOf("## Patch", start);
+	const end = patchIdx > 0 ? patchIdx : content.length;
+	return content.slice(start, end).trim().slice(0, 600);
+}

--- a/scripts/autoresearch/autonomous-loop.ts
+++ b/scripts/autoresearch/autonomous-loop.ts
@@ -31,11 +31,14 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { analyzeAndPropose } from "./analyze-and-propose.js";
+import { analyzeAndProposePatch } from "./analyze-and-propose-patch.js";
 import type { DetectionOutcome, Finding } from "./detect-regression.js";
 import { explainFinding } from "./explain-finding.js";
+import { materializePatchProposal } from "./materialize-patch.js";
 import { materializeVariant } from "./materialize-variant.js";
 import type { Matrix } from "./matrix.js";
 import { planNextCandidate, reconcileWithPlanner } from "./planner.js";
+import { promotePatchViaPr } from "./promote-patch-via-pr.js";
 import { promoteViaPr } from "./promote-via-pr.js";
 import { alreadyTried, appendTriedRow, readTriedLog } from "./tried-log.js";
 import type { ExtendedDogfoodReport } from "../lib/run-config.js";
@@ -59,7 +62,11 @@ interface LoopOutcome {
 		| "rejected"
 		| "accepted-no-pr"
 		| "accepted-pr-skipped"
-		| "accepted-pr-created";
+		| "accepted-pr-created"
+		| "patch-accepted-pr-created"
+		| "patch-rejected"
+		| "patch-llm-unavailable"
+		| "patch-no-proposal";
 	notes: string[];
 	prUrl?: string | null;
 }
@@ -157,6 +164,89 @@ function findBaselineForFinding(finding: Finding): ExtendedDogfoodReport | null 
 	return null;
 }
 
+async function runPatchPath(input: {
+	cli: CliArgs;
+	matrix: Matrix;
+	finding: Finding;
+	explainMd: string;
+	triedRows: readonly RunLogRow[] | readonly import("./tried-log.js").TriedLogRow[];
+	notes: string[];
+}): Promise<LoopOutcome> {
+	const { cli, matrix, finding, explainMd, notes } = input;
+	const triedRows = input.triedRows as readonly import("./tried-log.js").TriedLogRow[];
+
+	const llm = await analyzeAndProposePatch({
+		matrixName: cli.matrixName,
+		explainMarkdown: explainMd,
+		triedRows,
+	});
+	if (!llm.llmCallSucceeded) {
+		notes.push(`patch LLM unavailable: ${llm.error ?? "unknown"}`);
+		return { status: "patch-llm-unavailable", notes };
+	}
+	if (!llm.proposal) {
+		notes.push(
+			llm.error ? `patch LLM returned no usable proposal: ${llm.error}` : "patch LLM emitted NO_PATCH",
+		);
+		return { status: "patch-no-proposal", notes };
+	}
+
+	if (cli.dryRun) {
+		notes.push(
+			`DRY-RUN patch proposal: baseSha=${llm.proposal.baseSha}, +${llm.proposal.unifiedDiff.split("\n").filter((l) => l.startsWith("+") && !l.startsWith("+++")).length}/-${llm.proposal.unifiedDiff.split("\n").filter((l) => l.startsWith("-") && !l.startsWith("---")).length} lines`,
+		);
+		return { status: "accepted-no-pr", notes };
+	}
+
+	const materialize = await materializePatchProposal({
+		productionMatrix: matrix,
+		productionMatrixName: cli.matrixName,
+		proposal: llm.proposal,
+	});
+
+	// Persist a tried-log row regardless of outcome.
+	appendTriedRow({
+		schemaVersion: 1,
+		loggedAt: new Date().toISOString(),
+		matrixName: cli.matrixName,
+		variantId: `patch_${materialize.proposalId}`,
+		proposal: {
+			axis: "(code-patch)",
+			value: llm.proposal.baseSha,
+			rationale: llm.proposal.rationale.slice(0, 200),
+		},
+		verdict: materialize.aggregateAccept ? "accepted" : "rejected",
+		reasons: materialize.decisions.flatMap((d) => d.verdict?.reasons ?? [d.reason ?? ""]).concat(materialize.notes),
+	});
+
+	if (!materialize.aggregateAccept) {
+		const reason = materialize.skippedReason ?? materialize.decisions.map((d) => `${d.corpus}: ${d.verdict?.accept ? "ok" : "reject"}`).join(", ");
+		notes.push(`patch rejected: ${reason}`);
+		return { status: "patch-rejected", notes };
+	}
+
+	if (cli.skipPr) {
+		notes.push("--skip-pr: patch accepted but PR creation skipped");
+		return { status: "accepted-pr-skipped", notes };
+	}
+
+	const promote = await promotePatchViaPr({
+		materializeResult: materialize,
+		proposal: llm.proposal,
+		matrixName: cli.matrixName,
+	});
+	if (promote.skippedReason) {
+		notes.push(`patch promotion skipped: ${promote.skippedReason}`);
+		return { status: "accepted-no-pr", notes };
+	}
+	notes.push(`patch PR created: ${promote.prUrl ?? promote.branch}`);
+	return {
+		status: "patch-accepted-pr-created",
+		notes,
+		...(promote.prUrl !== null ? { prUrl: promote.prUrl } : {}),
+	};
+}
+
 async function runLoop(cli: CliArgs): Promise<LoopOutcome> {
 	const notes: string[] = [];
 	const outcome = JSON.parse(readFileSync(cli.findingsPath, "utf-8")) as DetectionOutcome;
@@ -212,7 +302,20 @@ async function runLoop(cli: CliArgs): Promise<LoopOutcome> {
 	if (!proposal) {
 		const plan = planNextCandidate({ matrixName: cli.matrixName, triedRows });
 		if (!plan) {
-			notes.push("LLM returned no proposal; planner queue exhausted (every materializable tuple within silence window)");
+			notes.push("LLM returned no proposal; planner queue exhausted");
+			// Config space exhausted. Try the code-patch path when enabled.
+			if (process.env.WTFOC_ALLOW_PATCHES === "1") {
+				notes.push("WTFOC_ALLOW_PATCHES=1 → attempting code-patch proposal");
+				return await runPatchPath({
+					cli,
+					matrix,
+					finding,
+					explainMd,
+					triedRows,
+					notes,
+				});
+			}
+			notes.push("WTFOC_ALLOW_PATCHES is unset — config space exhausted, no patch attempted");
 			return { status: "no-proposal", notes };
 		}
 		notes.push(

--- a/scripts/autoresearch/decision.test.ts
+++ b/scripts/autoresearch/decision.test.ts
@@ -72,6 +72,7 @@ const runConfig: RunConfig = {
 		autoRoute: false,
 		diversityEnforce: false,
 	},
+	evaluation: { checkParaphrases: false, groundCheck: false },
 	promptHashes: {},
 	seed: 0,
 	gitSha: null,

--- a/scripts/autoresearch/headline.test.ts
+++ b/scripts/autoresearch/headline.test.ts
@@ -21,6 +21,7 @@ const baseConfig: RunConfig = {
 		autoRoute: false,
 		diversityEnforce: false,
 	},
+	evaluation: { checkParaphrases: false, groundCheck: false },
 	promptHashes: {},
 	seed: 0,
 	gitSha: null,

--- a/scripts/autoresearch/materialize-patch.ts
+++ b/scripts/autoresearch/materialize-patch.ts
@@ -37,6 +37,15 @@ export interface MaterializePatchInputs {
 	spawnFn?: (cmd: string, args: string[], opts?: { cwd?: string }) => Buffer | string;
 	allowedPaths?: readonly string[];
 	maxDiffLines?: number;
+	/**
+	 * Anti-overfit floor: maximum acceptable per-corpus DEGRADATION
+	 * (passRate delta) before the patch is rejected on that corpus
+	 * regardless of how much it improves other corpora. Default: 0.02
+	 * (2 percentage points). Asymmetric vs the standard accept rule —
+	 * a patch may improve filoz by 8pp but if it costs wtfoc-v3 more
+	 * than 2pp we refuse to ship.
+	 */
+	maxPerCorpusDegradationPp?: number;
 }
 
 export interface MaterializePatchResult {
@@ -281,15 +290,53 @@ export async function materializePatchProposal(
 		const accepts = verdicts.filter((v) => v.accept).length;
 		const majority = Math.floor(verdicts.length / 2) + 1;
 		const corpusAccept = accepts >= majority;
+
+		// Anti-overfit guard. Reject the patch on this corpus if its
+		// passRate drops by more than `maxPerCorpusDegradationPp` points
+		// vs ANY baseline in the window — even if it improves on
+		// average. The asymmetry is deliberate: the loop must not ship
+		// patches that help one corpus while quietly hurting another
+		// (over-fitting risk). Stricter than the standard accept rule.
+		const maxDegradation = input.maxPerCorpusDegradationPp ?? 0.02;
+		const candidateScores = (() => {
+			const qq = candidateReport.stages.find((s) => s.stage === "quality-queries");
+			const m = qq?.metrics as { passRate?: number } | undefined;
+			return m?.passRate ?? null;
+		})();
+		let worstDegradationVsAnyBaseline = 0;
+		if (candidateScores !== null) {
+			for (const r of baselineRows) {
+				if (!r.reportPath) continue;
+				try {
+					const b = JSON.parse(fs.readFileSync(r.reportPath, "utf-8")) as ExtendedDogfoodReport;
+					const qq = b.stages.find((s) => s.stage === "quality-queries");
+					const m = qq?.metrics as { passRate?: number } | undefined;
+					const baseRate = m?.passRate ?? null;
+					if (baseRate !== null) {
+						const drop = baseRate - candidateScores;
+						if (drop > worstDegradationVsAnyBaseline) worstDegradationVsAnyBaseline = drop;
+					}
+				} catch {
+					// skip
+				}
+			}
+		}
+		const overfitTripped = worstDegradationVsAnyBaseline > maxDegradation;
+
+		const finalCorpusAccept = corpusAccept && !overfitTripped;
 		const aggregate: DecisionVerdict = {
 			...verdicts[verdicts.length - 1]!,
-			accept: corpusAccept,
-			reasons: corpusAccept
-				? [`patch window: ${accepts}/${verdicts.length} baselines clear decide()`]
-				: [`patch window: only ${accepts}/${verdicts.length} clear decide() (need ${majority})`],
+			accept: finalCorpusAccept,
+			reasons: overfitTripped
+				? [
+						`anti-overfit: worst per-baseline degradation ${(worstDegradationVsAnyBaseline * 100).toFixed(1)}pp > floor ${(maxDegradation * 100).toFixed(1)}pp`,
+					]
+				: corpusAccept
+					? [`patch window: ${accepts}/${verdicts.length} baselines clear decide()`]
+					: [`patch window: only ${accepts}/${verdicts.length} clear decide() (need ${majority})`],
 		};
 		decisions.push({ corpus, verdict: aggregate });
-		if (!corpusAccept) allAccept = false;
+		if (!finalCorpusAccept) allAccept = false;
 	}
 
 	return {

--- a/scripts/autoresearch/open-issues.test.ts
+++ b/scripts/autoresearch/open-issues.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchOpenIssues, openIssuesToPromptLines } from "./open-issues.js";
+
+describe("fetchOpenIssues", () => {
+	it("parses gh issue list JSON output", () => {
+		const fake = vi.fn(() =>
+			JSON.stringify([
+				{
+					number: 42,
+					title: "test issue",
+					labels: [{ name: "bug" }, { name: "P1" }],
+					body: "lorem ipsum",
+					createdAt: "2026-04-01T00:00:00Z",
+				},
+			]),
+		);
+		const issues = fetchOpenIssues({ spawnFn: fake });
+		expect(issues).toHaveLength(1);
+		expect(issues[0]?.number).toBe(42);
+		expect(issues[0]?.labels).toContain("bug");
+	});
+
+	it("returns [] when gh fails", () => {
+		const fake = vi.fn(() => {
+			throw new Error("gh not found");
+		});
+		expect(fetchOpenIssues({ spawnFn: fake })).toEqual([]);
+	});
+
+	it("returns [] on malformed JSON", () => {
+		const fake = vi.fn(() => "not json");
+		expect(fetchOpenIssues({ spawnFn: fake })).toEqual([]);
+	});
+
+	it("truncates long bodies", () => {
+		const longBody = "x".repeat(5000);
+		const fake = vi.fn(() =>
+			JSON.stringify([
+				{
+					number: 1,
+					title: "t",
+					labels: [],
+					body: longBody,
+					createdAt: "2026-04-01T00:00:00Z",
+				},
+			]),
+		);
+		const issues = fetchOpenIssues({ spawnFn: fake, bodyPreviewChars: 100 });
+		expect(issues[0]?.bodyPreview.length).toBeLessThanOrEqual(101);
+	});
+});
+
+describe("openIssuesToPromptLines", () => {
+	it("renders one line per issue with labels + preview", () => {
+		const lines = openIssuesToPromptLines([
+			{
+				number: 1,
+				title: "title A",
+				labels: ["bug"],
+				bodyPreview: "preview body",
+				createdAt: "2026",
+			},
+		]);
+		expect(lines.some((l) => l.includes("#1 title A"))).toBe(true);
+		expect(lines.some((l) => l.includes("[bug]"))).toBe(true);
+	});
+
+	it("emits placeholder when no issues", () => {
+		expect(openIssuesToPromptLines([])).toEqual([
+			"(no open issues fetched — gh unavailable or no matches)",
+		]);
+	});
+});

--- a/scripts/autoresearch/open-issues.ts
+++ b/scripts/autoresearch/open-issues.ts
@@ -1,0 +1,129 @@
+/**
+ * Fetch a compact summary of open GitHub issues for the LLM proposer
+ * to use as additional context when picking what to fix.
+ *
+ * The maintainer files issues for known bugs, design constraints, and
+ * incremental improvements; the autoresearch loop should be able to
+ * correlate a regression with an existing issue ("query work-lineage
+ * is brittle" + "#316 wl-1 paraphrase 3 fails reliably" → likely the
+ * same root cause). Without this context, the LLM is reasoning about
+ * regressions in isolation.
+ *
+ * Hard rules:
+ *   - Read-only. Never modify, comment, or close issues from this path.
+ *   - Cap context size — pulls only labels relevant to the loop, caps
+ *     count, truncates bodies. The full issue list is always one
+ *     `gh issue list` away if the LLM wants more.
+ *   - Best-effort. If `gh` is unavailable or rate-limited, fail soft —
+ *     return [] and let the proposer continue without issue context.
+ */
+
+import { execFileSync } from "node:child_process";
+
+export interface OpenIssueSummary {
+	number: number;
+	title: string;
+	labels: string[];
+	bodyPreview: string;
+	createdAt: string;
+}
+
+const DEFAULT_LABELS_OF_INTEREST: readonly string[] = [
+	"bug",
+	"enhancement",
+	"autoresearch",
+	"regression",
+	"breach",
+];
+
+const DEFAULT_MAX_ISSUES = 25;
+const DEFAULT_BODY_PREVIEW_CHARS = 600;
+
+export interface FetchOpenIssuesOptions {
+	maxIssues?: number;
+	bodyPreviewChars?: number;
+	/** Restrict to issues carrying any of these labels. Empty = all open. */
+	labels?: readonly string[];
+	/** Override the spawn function for tests. */
+	spawnFn?: (cmd: string, args: string[]) => Buffer | string;
+}
+
+/**
+ * Pull open issues via `gh issue list`. Returns [] on any error so
+ * callers don't need to wrap.
+ */
+export function fetchOpenIssues(opts: FetchOpenIssuesOptions = {}): OpenIssueSummary[] {
+	const maxIssues = opts.maxIssues ?? DEFAULT_MAX_ISSUES;
+	const bodyChars = opts.bodyPreviewChars ?? DEFAULT_BODY_PREVIEW_CHARS;
+	const labels = opts.labels ?? DEFAULT_LABELS_OF_INTEREST;
+	const spawn = opts.spawnFn ?? ((cmd: string, args: string[]) =>
+		execFileSync(cmd, args, { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }));
+
+	const args = [
+		"issue",
+		"list",
+		"--state",
+		"open",
+		"--limit",
+		String(maxIssues),
+		"--json",
+		"number,title,labels,body,createdAt",
+	];
+	for (const l of labels) {
+		args.push("--label", l);
+	}
+
+	let raw: string;
+	try {
+		const out = spawn("gh", args);
+		raw = typeof out === "string" ? out : out.toString("utf-8");
+	} catch {
+		return [];
+	}
+
+	let parsed: Array<{
+		number: number;
+		title: string;
+		labels: Array<{ name: string }>;
+		body: string;
+		createdAt: string;
+	}>;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return [];
+	}
+
+	return parsed.map((p) => ({
+		number: p.number,
+		title: p.title,
+		labels: (p.labels ?? []).map((l) => l.name),
+		bodyPreview:
+			p.body.length > bodyChars ? `${p.body.slice(0, bodyChars)}…` : p.body,
+		createdAt: p.createdAt,
+	}));
+}
+
+/**
+ * Compact prompt rendering. One line per issue title + labels, plus a
+ * collapsible body preview when the body is short. Truncates the
+ * overall section so the patch proposer prompt doesn't blow past
+ * context limits.
+ */
+export function openIssuesToPromptLines(
+	issues: readonly OpenIssueSummary[],
+	maxLines = 60,
+): string[] {
+	if (issues.length === 0) return ["(no open issues fetched — gh unavailable or no matches)"];
+	const lines: string[] = [];
+	for (const i of issues) {
+		const labelTag = i.labels.length > 0 ? ` [${i.labels.join(", ")}]` : "";
+		lines.push(`- #${i.number} ${i.title}${labelTag}`);
+		if (i.bodyPreview.length > 0 && lines.length < maxLines - 2) {
+			const previewFirst = i.bodyPreview.split("\n").slice(0, 4).join(" ").slice(0, 240);
+			if (previewFirst) lines.push(`    > ${previewFirst}`);
+		}
+		if (lines.length >= maxLines) break;
+	}
+	return lines;
+}

--- a/scripts/autoresearch/promote-patch-via-pr.ts
+++ b/scripts/autoresearch/promote-patch-via-pr.ts
@@ -1,0 +1,180 @@
+/**
+ * Push a materialized patch worktree branch + open a draft PR.
+ * Maintainer-only.
+ *
+ * The materializer (`materialize-patch.ts`) already created a worktree,
+ * applied the patch, committed, and ran the sweep. This module finishes
+ * the loop:
+ *   1. `git push -u origin <branch>` from the worktree
+ *   2. `gh pr create --draft --title ... --body ...`
+ *
+ * Hard rules:
+ *   - Always `--draft`. Never auto-merge.
+ *   - Push fails-loud — if the branch can't be pushed, surface the
+ *     error so the maintainer sees it.
+ *   - PR body includes: LLM rationale, per-corpus verdict, anti-overfit
+ *     check result, link to materializer notes.
+ */
+
+import { execFileSync } from "node:child_process";
+import type { MaterializePatchResult } from "./materialize-patch.js";
+import type { PatchProposal } from "./patch-proposal.js";
+
+export interface PromotePatchInputs {
+	materializeResult: MaterializePatchResult;
+	proposal: PatchProposal;
+	matrixName: string;
+	dryRun?: boolean;
+	spawnFn?: (cmd: string, args: string[], opts?: { cwd?: string }) => Buffer | string;
+}
+
+export interface PromotePatchResult {
+	prUrl: string | null;
+	branch: string;
+	dryRun: boolean;
+	skippedReason?: string;
+}
+
+export function buildPatchPrTitle(input: { matrixName: string; proposalId: string }): string {
+	return `feat(autoresearch): code patch from autonomous loop (${input.proposalId})`;
+}
+
+export function buildPatchPrBody(input: {
+	proposal: PatchProposal;
+	materializeResult: MaterializePatchResult;
+	matrixName: string;
+}): string {
+	const m = input.materializeResult;
+	const lines: string[] = [];
+	lines.push("Autoresearch loop accepted this patch. Maintainer review required before merge.");
+	lines.push("");
+	lines.push(`Proposal: \`${m.proposalId}\``);
+	lines.push(`Matrix: \`${input.matrixName}\``);
+	lines.push(`Base SHA: \`${input.proposal.baseSha}\``);
+	lines.push("");
+	lines.push("## LLM rationale");
+	lines.push("");
+	lines.push(input.proposal.rationale.length > 0 ? input.proposal.rationale : "(no rationale provided)");
+	lines.push("");
+	if (input.proposal.summary) {
+		lines.push("## Patch summary");
+		lines.push("");
+		lines.push(input.proposal.summary);
+		lines.push("");
+	}
+	lines.push("## Per-corpus verdict");
+	lines.push("");
+	for (const d of m.decisions) {
+		if (!d.verdict) {
+			lines.push(`- **${d.corpus}**: no verdict (${d.reason ?? "unknown"})`);
+			continue;
+		}
+		const reasonLine = d.verdict.reasons.length > 0 ? d.verdict.reasons.join("; ") : "—";
+		lines.push(
+			`- **${d.corpus}**: ${d.verdict.accept ? "✓ accept" : "✗ reject"} — ${reasonLine}`,
+		);
+		if (d.verdict.bootstrap) {
+			lines.push(
+				`  - bootstrap: meanΔ=${d.verdict.bootstrap.meanDelta.toFixed(3)}, probBgreaterA=${d.verdict.bootstrap.probBgreaterA.toFixed(3)}`,
+			);
+		}
+	}
+	lines.push("");
+	if (m.notes.length > 0) {
+		lines.push("## Notes from materializer");
+		lines.push("");
+		for (const n of m.notes) lines.push(`- ${n}`);
+		lines.push("");
+	}
+	lines.push("## How to validate locally");
+	lines.push("");
+	lines.push("```bash");
+	lines.push(`git checkout ${m.branch}`);
+	lines.push(`pnpm autoresearch:sweep ${input.matrixName} \\\\`);
+	lines.push(`  --variant-filter <production-variant> --stage repro`);
+	lines.push("```");
+	lines.push("");
+	lines.push(
+		"This PR must be reviewed by the maintainer. The loop NEVER auto-merges. Close it without merging if the patch is wrong; the tried-log will record the rejection so the LLM doesn't propose it again.",
+	);
+	return lines.join("\n");
+}
+
+export async function promotePatchViaPr(input: PromotePatchInputs): Promise<PromotePatchResult> {
+	const m = input.materializeResult;
+	if (!m.aggregateAccept) {
+		return {
+			prUrl: null,
+			branch: m.branch,
+			dryRun: input.dryRun ?? false,
+			skippedReason: "materialize verdict was not accept; no PR to create",
+		};
+	}
+	if (!m.worktreePath || !m.branch) {
+		return {
+			prUrl: null,
+			branch: m.branch,
+			dryRun: input.dryRun ?? false,
+			skippedReason: "no worktree/branch available — materializer skipped earlier",
+		};
+	}
+
+	const title = buildPatchPrTitle({ matrixName: input.matrixName, proposalId: m.proposalId });
+	const body = buildPatchPrBody({
+		proposal: input.proposal,
+		materializeResult: m,
+		matrixName: input.matrixName,
+	});
+
+	if (input.dryRun) {
+		return { prUrl: null, branch: m.branch, dryRun: true };
+	}
+
+	const spawn =
+		input.spawnFn ??
+		((cmd: string, args: string[], opts: { cwd?: string } = {}) =>
+			execFileSync(cmd, args, { ...opts, encoding: "utf-8" }));
+
+	try {
+		spawn("git", ["push", "-u", "origin", m.branch], { cwd: m.worktreePath });
+	} catch (err) {
+		return {
+			prUrl: null,
+			branch: m.branch,
+			dryRun: false,
+			skippedReason: `git push failed: ${err instanceof Error ? err.message : String(err)}`,
+		};
+	}
+
+	let prUrl: string | null = null;
+	try {
+		const out = spawn(
+			"gh",
+			[
+				"pr",
+				"create",
+				"--draft",
+				"--title",
+				title,
+				"--body",
+				body,
+				"--label",
+				"enhancement",
+				"--head",
+				m.branch,
+			],
+			{ cwd: m.worktreePath },
+		);
+		const text = typeof out === "string" ? out : out.toString("utf-8");
+		prUrl = text.split("\n").find((l) => l.startsWith("https://")) ?? null;
+	} catch (err) {
+		return {
+			prUrl: null,
+			branch: m.branch,
+			dryRun: false,
+			skippedReason: `gh pr create failed: ${err instanceof Error ? err.message : String(err)}`,
+		};
+	}
+
+	return { prUrl, branch: m.branch, dryRun: false };
+}

--- a/scripts/lib/grounding-runner.test.ts
+++ b/scripts/lib/grounding-runner.test.ts
@@ -54,6 +54,7 @@ describe("runGrounding", () => {
 					sourceType: "code",
 					source: "/src/x.ts",
 					score: 0.9,
+					retrievalScore: 0.9,
 				},
 			],
 		});


### PR DESCRIPTION
## Summary

Closes the autonomous loop.

The config-only path was a monitor-and-tweak system, not an improvement system. It would propose retrieval-knob changes (autoRoute, diversityEnforce, reranker, topK, trace*) and stall. With this PR, when the config queue is exhausted AND \`WTFOC_ALLOW_PATCHES=1\`, the loop:

1. Asks the local LLM for a unified diff against curated \`packages/search/src/\` files (with **open GitHub issues as proposal-source context** — the LLM correlates a regression with maintainer-filed bug reports).
2. Validates against the existing allowlist + 200-line cap.
3. Materializes via \`git worktree\` + \`git apply\` + sweep over all corpora.
4. Decides per-corpus with the same majority-of-baseline rule as config proposals, **PLUS an asymmetric anti-overfit floor**: reject if any corpus's worst-per-baseline degradation > 2pp (configurable). Patches that help one corpus while quietly hurting another get refused — explicit defense against over-fitting to limited corpora.
5. On accept, push branch + \`gh pr create --draft\`. Maintainer reviews; never auto-merge.
6. tried-log row appends regardless of outcome.

## Hard guardrails preserved

- All endpoint URLs from env. No homelab2 URLs in committed source.
- Patches restricted to \`packages/search/src/\` allowlist.
- Diff size capped (200 lines added+removed by default).
- \`git apply --check\` before \`git apply\`.
- Always \`gh pr create --draft\`. No auto-merge.
- Anti-overfit per-corpus degradation floor (2pp default). The patch-path's accept rule is STRICTER than config-path's accept — code changes have wider blast radius, so the loop is less willing to ship them.
- Patch-path is OPT-IN: \`WTFOC_ALLOW_PATCHES=1\`. Default cron behavior (unset) remains config-only.

## Why this matters (per maintainer correction)

> Config-only is only monitoring performance of existing collections. We need patches so incremental improvements can be made to CODE.

This PR makes the loop actually able to improve wtfoc, not just toggle knobs. The LLM gets:
- The flipped queries + retrieved chunks + gold-source-proximity diagnostics (from #334)
- **Open GH issues** — so it can correlate "wl-1 brittleness regression" with "issue #316 about wl-1 paraphrase 3"
- Tried-log of past attempts (config + patch) so it doesn't repeat
- Curated source files inlined verbatim so it can reason about real line numbers

## Test plan

- [x] vitest: 1603/1604 pass (1 pre-existing skip; +21 net new tests)
- [x] biome lint: clean
- [x] pnpm -r build: clean
- [x] \`tsc -p scripts/tsconfig.json --noEmit\`: clean (drive-by fix to 3 stale fixture types)
- [ ] CI on this PR

## How to enable on the cron host

\`\`\`bash
export WTFOC_ALLOW_PATCHES=1
export WTFOC_PATCH_LLM_URL=https://your-gpu/v1
export WTFOC_PATCH_LLM_MODEL=<model that produces clean diffs>
# install + run as before:
bash scripts/autoresearch/cron/install.sh
\`\`\`

## Open follow-ups

- Better curated-file selection — currently a static list (DEFAULT_CURATED_FILES). Could grow into an embedding-based "find files relevant to this finding" step.
- Tree-sitter / AST-aware patches — peer review previously said unified-diff is enough for MVP; revisit when/if accept-rate is too low.
- Holdout corpus — anti-overfit floor is a good first defense, but a true holdout (corpus the LLM doesn't see during proposal but evaluates on after) is stronger. Depends on #328 (more corpora).

Closes #335.