### PR TITLE
feat(autoresearch): drive homelab GPU mode-switch from autonomous loop

### DIFF
--- a/scripts/autoresearch/autonomous-loop.ts
+++ b/scripts/autoresearch/autonomous-loop.ts
@@ -30,6 +30,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { ensureMode, type GpuMode, resolveModeFromMatrix } from "../lib/mode-switch.js";
 import { analyzeAndPropose } from "./analyze-and-propose.js";
 import { analyzeAndProposePatch } from "./analyze-and-propose-patch.js";
 import type { DetectionOutcome, Finding } from "./detect-regression.js";
@@ -107,6 +108,26 @@ async function loadMatrix(matrixName: string): Promise<Matrix> {
 	return mod.default;
 }
 
+async function swapMode(
+	target: GpuMode,
+	reason: string,
+	notes: string[],
+): Promise<boolean> {
+	try {
+		const r = await ensureMode(target, { reason });
+		if (r.skipped) {
+			notes.push(`mode-switch skipped (${target}): ${r.skippedReason}`);
+		} else {
+			notes.push(`mode-switch ok: ${r.from ?? "?"}→${r.to ?? target} phase=${r.finalPhase ?? "?"}`);
+		}
+		return true;
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		notes.push(`mode-switch FAILED (${target}): ${msg}`);
+		return false;
+	}
+}
+
 function pickMostRelevantFinding(outcome: DetectionOutcome): Finding | null {
 	if (outcome.findings.length === 0) return null;
 	// Prefer breach (hard floor violation) over regression for the
@@ -174,6 +195,11 @@ async function runPatchPath(input: {
 }): Promise<LoopOutcome> {
 	const { cli, matrix, finding, explainMd, notes } = input;
 	const triedRows = input.triedRows as readonly import("./tried-log.js").TriedLogRow[];
+	const sweepMode = resolveModeFromMatrix(matrix);
+
+	if (!(await swapMode("chat", "patch-llm-analyze", notes))) {
+		return { status: "patch-llm-unavailable", notes };
+	}
 
 	const llm = await analyzeAndProposePatch({
 		matrixName: cli.matrixName,
@@ -196,6 +222,10 @@ async function runPatchPath(input: {
 			`DRY-RUN patch proposal: baseSha=${llm.proposal.baseSha}, +${llm.proposal.unifiedDiff.split("\n").filter((l) => l.startsWith("+") && !l.startsWith("+++")).length}/-${llm.proposal.unifiedDiff.split("\n").filter((l) => l.startsWith("-") && !l.startsWith("---")).length} lines`,
 		);
 		return { status: "accepted-no-pr", notes };
+	}
+
+	if (sweepMode && !(await swapMode(sweepMode, "patch-materialize-sweep", notes))) {
+		return { status: "patch-rejected", notes };
 	}
 
 	const materialize = await materializePatchProposal({
@@ -283,6 +313,12 @@ async function runLoop(cli: CliArgs): Promise<LoopOutcome> {
 		return { status: "llm-unavailable", notes };
 	}
 
+	const sweepMode = resolveModeFromMatrix(matrix);
+
+	if (!(await swapMode("chat", "loop-llm-analyze", notes))) {
+		return { status: "llm-unavailable", notes };
+	}
+
 	const llmRes = await analyzeAndPropose({
 		matrixName: cli.matrixName,
 		explainMarkdown: explainMd,
@@ -348,6 +384,10 @@ async function runLoop(cli: CliArgs): Promise<LoopOutcome> {
 			`DRY-RUN proposal: ${proposal.axis}=${JSON.stringify(proposal.value)} — ${proposal.rationale}`,
 		);
 		return { status: "accepted-no-pr", notes };
+	}
+
+	if (sweepMode && !(await swapMode(sweepMode, "loop-materialize-sweep", notes))) {
+		return { status: "materialize-failed", notes };
 	}
 
 	let materialize;

--- a/scripts/autoresearch/cron/run-nightly.sh
+++ b/scripts/autoresearch/cron/run-nightly.sh
@@ -30,6 +30,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 cd "$REPO_ROOT"
 
+# Source repo .env so launchd-spawned cron has access to OPENROUTER_API_KEY
+# and the WTFOC_* URLs/models. plist only exports PATH+HOME so without
+# this we'd run with a near-empty environment.
+if [ -f "$REPO_ROOT/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$REPO_ROOT/.env"
+    set +a
+fi
+
 STATE_DIR="${WTFOC_AUTORESEARCH_DIR:-$HOME/.wtfoc/autoresearch}"
 mkdir -p "$STATE_DIR" "$STATE_DIR/regressions" "$STATE_DIR/reports"
 LOCK_DIR="$STATE_DIR/.cron.lock.d"
@@ -206,7 +216,23 @@ fi
 cleanup_lock() {
     rm -rf "$LOCK_DIR"
 }
-trap cleanup_lock EXIT
+
+# Best-effort GPU mode reset on exit. Only runs when WTFOC_VLLM_AUTOSWAP=1
+# (helper short-circuits otherwise). Failures here are non-fatal — the
+# idle-revert on the admin side will eventually restore chat.
+reset_mode_to_chat() {
+    if [ "${WTFOC_VLLM_AUTOSWAP:-0}" = "1" ]; then
+        WTFOC_MODE_SWITCH_REASON="cron-cleanup" \
+            pnpm exec tsx --tsconfig scripts/tsconfig.json \
+            scripts/lib/mode-switch-cli.ts chat 2>&1 | sed 's/^/[mode-reset] /' || true
+    fi
+}
+
+cleanup_all() {
+    reset_mode_to_chat
+    cleanup_lock
+}
+trap cleanup_all EXIT
 
 log "start matrix=$MATRIX stage=$STAGE state=$STATE_DIR"
 
@@ -243,6 +269,11 @@ if [ -z "$PROD_VARIANT" ]; then
     fi
 fi
 log "sweep starting variant=$PROD_VARIANT"
+# Pre-sweep mode swap: set GPU to whatever the matrix needs. No-op when
+# matrix is cloud-only or WTFOC_VLLM_AUTOSWAP!=1.
+WTFOC_MODE_SWITCH_REASON="cron-pre-sweep" \
+    pnpm exec tsx --tsconfig scripts/tsconfig.json \
+    scripts/lib/mode-switch-cli.ts --from-matrix "$MATRIX" 2>&1 | sed 's/^/[mode-pre-sweep] /' || true
 pnpm autoresearch:sweep "$MATRIX" --stage "$STAGE" --variant-filter "$PROD_VARIANT"
 rc=$?
 if [ "$rc" -ne 0 ]; then
@@ -270,6 +301,14 @@ status=$(grep -m1 '"status"' "$FINDINGS_FILE" | sed -E 's/.*"status": *"([^"]+)"
 log "detector status=$status"
 case "$status" in
     breach|regression|both)
+        # Switch to chat mode for analysis LLM (file-issue + autonomous-loop
+        # internal LLM calls). autonomous-loop also swaps internally between
+        # chat (analyze) and gpuPhase (materialize), but landing in chat
+        # here avoids the first internal swap when the GPU is already idle.
+        log "swapping to chat mode for analysis phase"
+        WTFOC_MODE_SWITCH_REASON="cron-pre-analyze" \
+            pnpm exec tsx --tsconfig scripts/tsconfig.json \
+            scripts/lib/mode-switch-cli.ts chat 2>&1 | sed 's/^/[mode-pre-analyze] /' || true
         log "filing issue(s)"
         pnpm exec tsx --tsconfig scripts/tsconfig.json scripts/autoresearch/file-regression-issue.ts \
                 --findings "$FINDINGS_FILE" \

--- a/scripts/autoresearch/matrices/retrieval-gpu-rerank.ts
+++ b/scripts/autoresearch/matrices/retrieval-gpu-rerank.ts
@@ -1,0 +1,49 @@
+/**
+ * GPU rerank-mode variant of `retrieval-baseline`. Targets the homelab
+ * single-GPU vllm cluster running in `rerank-gpu` mode. Drives the BGE
+ * cross-encoder for off/on A/B over the same v12 + v3 corpus pair.
+ *
+ * Pre-conditions (cron wrapper handles):
+ *   - WTFOC_VLLM_AUTOSWAP=1 in cron env
+ *   - WTFOC_VLLM_ADMIN_URL points at the homelab admin
+ *   - Embedder + extractor stay on always-on tiers (cloud + local proxy)
+ *     so the GPU is free to host rerank-gpu for the duration of the sweep
+ *
+ * The wrapper switches GPU → rerank-gpu before sweep, then back to chat
+ * for analysis LLM. `gpuPhase` is set explicitly (not relying on the
+ * URL-substring heuristic) to make the dependency obvious.
+ */
+
+import type { Matrix } from "../matrix.js";
+
+const matrix: Matrix = {
+	name: "retrieval-gpu-rerank",
+	description:
+		"Cross-corpus retrieval-knob sweep with homelab BGE GPU reranker (vs reranker-off baseline).",
+	productionVariantId: "noar_div_rrOff",
+	gpuPhase: "rerank-gpu",
+	baseConfig: {
+		collections: {
+			primary: "filoz-ecosystem-2026-04-v12",
+			secondary: "wtfoc-dogfood-2026-04-v3",
+		},
+		embedderUrl: "https://openrouter.ai/api/v1",
+		embedderModel: "baai/bge-base-en-v1.5",
+		embedderKey: process.env.OPENROUTER_API_KEY ?? "",
+		extractorUrl: "http://127.0.0.1:4523/v1",
+		extractorModel: "haiku",
+	},
+	axes: {
+		autoRoute: [false, true],
+		diversityEnforce: [false, true],
+		reranker: [
+			"off",
+			{
+				type: "bge",
+				url: process.env.WTFOC_RERANKER_URL ?? "https://reranker-gpu.bt.sgtpooki.com",
+			},
+		],
+	},
+};
+
+export default matrix;

--- a/scripts/autoresearch/matrix.ts
+++ b/scripts/autoresearch/matrix.ts
@@ -152,6 +152,17 @@ export interface Matrix {
 	 * anchor (exploratory sweeps) leave it unset.
 	 */
 	productionVariantId?: string;
+	/**
+	 * Homelab GPU mode required for this matrix's sweep, when the matrix
+	 * targets the single-GPU vllm cluster. Drives `ensureMode` calls in
+	 * the autonomous loop wrapper. Leave unset/null for cloud-only or
+	 * always-on tier matrices (no swap performed).
+	 *
+	 * Set explicitly when the heuristic in `resolveModeFromMatrix`
+	 * (URL substring scan) is wrong — for example, an embedder URL that
+	 * routes through a non-`embedder-gpu` host but still requires GPU.
+	 */
+	gpuPhase?: "chat" | "rerank-gpu" | "embed-gpu" | null;
 }
 
 /**

--- a/scripts/lib/mode-switch-cli.ts
+++ b/scripts/lib/mode-switch-cli.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env tsx
+/**
+ * CLI wrapper around `ensureMode` for shell callers (run-nightly.sh).
+ *
+ * Usage:
+ *   tsx scripts/lib/mode-switch-cli.ts <chat|rerank-gpu|embed-gpu>
+ *   tsx scripts/lib/mode-switch-cli.ts --from-matrix <matrix-name>
+ *
+ * `--from-matrix` resolves the GPU phase via `resolveModeFromMatrix`
+ * and exits 0 with no-op when the matrix is cloud-only / always-on.
+ *
+ * Exit codes:
+ *   0 — switch completed (or no-op when gated/unset/cloud-only)
+ *   1 — switch failed (shell wrapper logs and continues per its own
+ *       error policy; autoresearch wrapper treats as DEGRADED)
+ */
+
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { ensureMode, type GpuMode, resolveModeFromMatrix } from "./mode-switch.js";
+
+const VALID: ReadonlySet<GpuMode> = new Set(["chat", "rerank-gpu", "embed-gpu"]);
+
+function isMode(s: string): s is GpuMode {
+	return (VALID as ReadonlySet<string>).has(s);
+}
+
+async function main(): Promise<number> {
+	const args = process.argv.slice(2);
+	if (args.length === 0) {
+		console.error("usage: mode-switch-cli <mode> | --from-matrix <name>");
+		return 2;
+	}
+	let target: GpuMode | null = null;
+	if (args[0] === "--from-matrix") {
+		const matrixName = args[1];
+		if (!matrixName) {
+			console.error("--from-matrix requires a matrix name");
+			return 2;
+		}
+		const here = dirname(fileURLToPath(import.meta.url));
+		const matrixPath = join(here, "..", "autoresearch", "matrices", `${matrixName}.ts`);
+		const mod = (await import(matrixPath)) as {
+			default: Parameters<typeof resolveModeFromMatrix>[0];
+		};
+		target = resolveModeFromMatrix(mod.default);
+		if (target === null) {
+			console.error(`[mode-switch] matrix=${matrixName} needs no GPU swap`);
+			return 0;
+		}
+	} else {
+		const a = args[0] ?? "";
+		if (!isMode(a)) {
+			console.error(`invalid mode: ${a}`);
+			return 2;
+		}
+		target = a;
+	}
+	const reason = process.env.WTFOC_MODE_SWITCH_REASON ?? "wtfoc-cron";
+	const r = await ensureMode(target, { reason });
+	if (r.skipped) {
+		console.error(`[mode-switch] skipped: ${r.skippedReason}`);
+		return 0;
+	}
+	console.error(`[mode-switch] ok: ${r.from ?? "?"}→${r.to ?? target} phase=${r.finalPhase}`);
+	return 0;
+}
+
+main()
+	.then((code) => process.exit(code))
+	.catch((err) => {
+		console.error(`[mode-switch] FAILED: ${err instanceof Error ? err.message : String(err)}`);
+		process.exit(1);
+	});

--- a/scripts/lib/mode-switch.test.ts
+++ b/scripts/lib/mode-switch.test.ts
@@ -110,6 +110,37 @@ describe("ensureMode", () => {
 		).rejects.toThrow(/manual recovery/);
 	});
 
+	it("retries through transient fetch errors during poll", async () => {
+		let call = 0;
+		const fetchFn = vi.fn(async (input: string | URL | Request) => {
+			call += 1;
+			const url = typeof input === "string" ? input : input.toString();
+			if (call === 1) {
+				// Initial state read.
+				return jsonResponse(buildState("chat", "ChatActive"));
+			}
+			if (url.endsWith("/admin/mode-switch")) {
+				return jsonResponse({ operationId: "x" });
+			}
+			// Polls: fail, fail, then succeed.
+			if (call === 3 || call === 4) {
+				throw new Error("fetch failed");
+			}
+			return jsonResponse(buildState("rerank-gpu", "RerankGpuActive"));
+		});
+		const r = await ensureMode("rerank-gpu", {
+			adminUrl: "http://admin",
+			fetchFn: fetchFn as unknown as typeof fetch,
+			enabled: true,
+			pollIntervalMs: 1,
+			timeoutMs: 5000,
+		});
+		expect(r.skipped).toBe(false);
+		expect(r.finalPhase).toBe("RerankGpuActive");
+		// 1 initial GET + 1 POST + 2 failed polls + 1 successful poll
+		expect(fetchFn).toHaveBeenCalledTimes(5);
+	});
+
 	it("times out when phase stays transient", async () => {
 		const fetchFn = vi.fn(async (input: string | URL | Request) => {
 			const url = typeof input === "string" ? input : input.toString();

--- a/scripts/lib/mode-switch.test.ts
+++ b/scripts/lib/mode-switch.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import { ensureMode, resolveModeFromMatrix } from "./mode-switch.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+function buildState(activeMode: string, modePhase: string): unknown {
+	return {
+		state: { activeMode, modePhase, targetMode: null },
+		observedSteadyMode: activeMode,
+	};
+}
+
+describe("ensureMode", () => {
+	it("noop when WTFOC_VLLM_AUTOSWAP not set", async () => {
+		const fetchFn = vi.fn();
+		const r = await ensureMode("chat", {
+			adminUrl: "http://admin",
+			fetchFn: fetchFn as unknown as typeof fetch,
+			enabled: false,
+		});
+		expect(r.skipped).toBe(true);
+		expect(r.skippedReason).toMatch(/AUTOSWAP/);
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+
+	it("noop when admin URL missing", async () => {
+		const fetchFn = vi.fn();
+		const r = await ensureMode("chat", {
+			adminUrl: "",
+			fetchFn: fetchFn as unknown as typeof fetch,
+			enabled: true,
+		});
+		expect(r.skipped).toBe(true);
+		expect(r.skippedReason).toMatch(/ADMIN_URL/);
+	});
+
+	it("idempotent short-circuit when already in target mode", async () => {
+		const fetchFn = vi.fn(async () =>
+			jsonResponse(buildState("chat", "ChatActive")),
+		);
+		const r = await ensureMode("chat", {
+			adminUrl: "http://admin",
+			fetchFn: fetchFn as unknown as typeof fetch,
+			enabled: true,
+		});
+		expect(r.skipped).toBe(false);
+		expect(r.from).toBe("chat");
+		expect(r.to).toBe("chat");
+		expect(fetchFn).toHaveBeenCalledTimes(1);
+	});
+
+	it("polls until terminal-OK after switch POST", async () => {
+		const seq: Response[] = [
+			jsonResponse(buildState("chat", "ChatActive")), // initial
+			jsonResponse({ operationId: "x", from: "chat", to: "rerank-gpu" }), // POST
+			jsonResponse(buildState("chat", "Switching:Draining")), // poll 1
+			jsonResponse(buildState("rerank-gpu", "Switching:Loading")), // poll 2
+			jsonResponse(buildState("rerank-gpu", "RerankGpuActive")), // poll 3 terminal
+		];
+		const fetchFn = vi.fn(async () => seq.shift() ?? jsonResponse({}));
+		const r = await ensureMode("rerank-gpu", {
+			adminUrl: "http://admin",
+			fetchFn: fetchFn as unknown as typeof fetch,
+			enabled: true,
+			pollIntervalMs: 1,
+			timeoutMs: 5000,
+		});
+		expect(r.skipped).toBe(false);
+		expect(r.to).toBe("rerank-gpu");
+		expect(r.finalPhase).toBe("RerankGpuActive");
+	});
+
+	it("throws on terminal-failure phase", async () => {
+		const seq: Response[] = [
+			jsonResponse(buildState("chat", "ChatActive")),
+			jsonResponse({ operationId: "x" }),
+			jsonResponse(buildState("chat", "RollbackFailed")),
+		];
+		const fetchFn = vi.fn(async () => seq.shift() ?? jsonResponse({}));
+		await expect(
+			ensureMode("rerank-gpu", {
+				adminUrl: "http://admin",
+				fetchFn: fetchFn as unknown as typeof fetch,
+				enabled: true,
+				pollIntervalMs: 1,
+				timeoutMs: 5000,
+			}),
+		).rejects.toThrow(/terminal failure/);
+	});
+
+	it("throws on manual-recovery 409", async () => {
+		const seq: Response[] = [
+			jsonResponse(buildState("chat", "ChatActive")),
+			jsonResponse({ error: "manual_recovery_required" }, 409),
+		];
+		const fetchFn = vi.fn(async () => seq.shift() ?? jsonResponse({}));
+		await expect(
+			ensureMode("rerank-gpu", {
+				adminUrl: "http://admin",
+				fetchFn: fetchFn as unknown as typeof fetch,
+				enabled: true,
+				pollIntervalMs: 1,
+				timeoutMs: 5000,
+			}),
+		).rejects.toThrow(/manual recovery/);
+	});
+
+	it("times out when phase stays transient", async () => {
+		const fetchFn = vi.fn(async (input: string | URL | Request) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url.endsWith("/admin/mode-switch")) {
+				return jsonResponse({ operationId: "x" });
+			}
+			return jsonResponse(buildState("chat", "Switching:Loading"));
+		});
+		await expect(
+			ensureMode("rerank-gpu", {
+				adminUrl: "http://admin",
+				fetchFn: fetchFn as unknown as typeof fetch,
+				enabled: true,
+				pollIntervalMs: 1,
+				timeoutMs: 30,
+			}),
+		).rejects.toThrow(/timeout/);
+	});
+});
+
+describe("resolveModeFromMatrix", () => {
+	it("returns explicit gpuPhase when set", () => {
+		expect(
+			resolveModeFromMatrix({
+				gpuPhase: "rerank-gpu",
+				baseConfig: {},
+				axes: {},
+			}),
+		).toBe("rerank-gpu");
+	});
+
+	it("returns null when gpuPhase explicitly null", () => {
+		expect(
+			resolveModeFromMatrix({
+				gpuPhase: null,
+				baseConfig: { embedderUrl: "http://embedder-gpu.x/v1" },
+				axes: {},
+			}),
+		).toBe(null);
+	});
+
+	it("detects embed-gpu via URL substring", () => {
+		expect(
+			resolveModeFromMatrix({
+				baseConfig: { embedderUrl: "http://embedder-gpu.example/v1" },
+				axes: {},
+			}),
+		).toBe("embed-gpu");
+	});
+
+	it("detects rerank-gpu via reranker URL", () => {
+		expect(
+			resolveModeFromMatrix({
+				baseConfig: {},
+				axes: { reranker: [{ type: "bge", url: "http://reranker-gpu.x" }] },
+			}),
+		).toBe("rerank-gpu");
+	});
+
+	it("returns null for cloud-only matrices", () => {
+		expect(
+			resolveModeFromMatrix({
+				baseConfig: { embedderUrl: "https://openrouter.ai/api/v1" },
+				axes: { reranker: ["off", { type: "llm", url: "http://127.0.0.1:4523/v1" }] },
+			}),
+		).toBe(null);
+	});
+});

--- a/scripts/lib/mode-switch.ts
+++ b/scripts/lib/mode-switch.ts
@@ -1,0 +1,204 @@
+/**
+ * Thin client for the homelab vllm-admin mode-switch API. Maintainer-only.
+ *
+ * Single-GPU homelab box can serve exactly one of {chat, rerank-gpu,
+ * embed-gpu} at a time. The autoresearch nightly cron drives the
+ * switch around its phases (sweep → analyze → materialize → reset).
+ *
+ * Hard rules:
+ *   - Gated by `WTFOC_VLLM_AUTOSWAP=1`. When unset every call is a noop
+ *     so non-homelab maintainers can run the loop unmodified.
+ *   - Admin URL comes from `WTFOC_VLLM_ADMIN_URL`. No homelab2 URLs
+ *     hardcoded.
+ *   - `ensureMode` is idempotent — same target as current activeMode
+ *     short-circuits without a network call to switch (still polls
+ *     `/admin/mode` once to read state).
+ *   - Polls until terminal phase or until `timeoutMs` elapses. Terminal
+ *     failure phases throw; the caller decides whether to abort the
+ *     pipeline.
+ *
+ * See homelab2/docs/runbooks/vllm-admin-consumer-guide.md for the
+ * server-side state machine.
+ */
+
+export type GpuMode = "chat" | "rerank-gpu" | "embed-gpu";
+
+const TERMINAL_OK = new Set(["ChatActive", "RerankGpuActive", "EmbedGpuActive"]);
+const TERMINAL_FAIL = new Set([
+	"RolledBack",
+	"Failed",
+	"RollbackFailed",
+	"WedgedManualRecoveryRequired",
+]);
+
+interface ModeStateEnvelope {
+	state: {
+		activeMode: GpuMode;
+		modePhase: string;
+		targetMode: GpuMode | null;
+	};
+	observedSteadyMode: GpuMode | null;
+}
+
+export interface EnsureModeOptions {
+	/** Override admin base URL (defaults to env). Tests use this. */
+	adminUrl?: string;
+	/** Override fetch (tests). */
+	fetchFn?: typeof fetch;
+	/** Total deadline. Default 2400000ms (chat AEON cold-load worst case). */
+	timeoutMs?: number;
+	/** Poll interval while transient. Default 10000ms. */
+	pollIntervalMs?: number;
+	/** Reason string forwarded to admin for audit. */
+	reason?: string;
+	/** Override the autoswap gate (tests). */
+	enabled?: boolean;
+}
+
+export interface EnsureModeResult {
+	skipped: boolean;
+	skippedReason?: string;
+	from?: GpuMode;
+	to?: GpuMode;
+	finalPhase?: string;
+}
+
+function adminBaseUrl(opts: EnsureModeOptions): string | null {
+	const fromOpt = opts.adminUrl;
+	const fromEnv = process.env.WTFOC_VLLM_ADMIN_URL;
+	const url = fromOpt ?? fromEnv ?? "";
+	if (!url) return null;
+	return url.replace(/\/+$/, "");
+}
+
+function isEnabled(opts: EnsureModeOptions): boolean {
+	if (typeof opts.enabled === "boolean") return opts.enabled;
+	return process.env.WTFOC_VLLM_AUTOSWAP === "1";
+}
+
+async function fetchMode(
+	base: string,
+	fetchFn: typeof fetch,
+): Promise<ModeStateEnvelope> {
+	const res = await fetchFn(`${base}/admin/mode`, { method: "GET" });
+	if (!res.ok) {
+		throw new Error(`GET /admin/mode failed: ${res.status} ${res.statusText}`);
+	}
+	return (await res.json()) as ModeStateEnvelope;
+}
+
+async function postSwitch(
+	base: string,
+	target: GpuMode,
+	reason: string,
+	fetchFn: typeof fetch,
+	timeoutMs: number,
+): Promise<void> {
+	const ac = new AbortController();
+	const timer = setTimeout(() => ac.abort(), timeoutMs);
+	try {
+		const res = await fetchFn(`${base}/admin/mode-switch`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ targetMode: target, reason }),
+			signal: ac.signal,
+		});
+		// 200 noop or 200 success — both fine. 409 means in-flight or
+		// manual-recovery; surface as a non-fatal poll-and-retry signal.
+		if (res.status === 409) {
+			const body = (await res.json().catch(() => ({}))) as { error?: string };
+			if (body.error === "manual_recovery_required") {
+				throw new Error("admin requires manual recovery (POST /admin/mode-reset first)");
+			}
+			// switch_in_flight / lease_held — caller polls.
+			return;
+		}
+		if (!res.ok) {
+			throw new Error(`POST /admin/mode-switch failed: ${res.status} ${res.statusText}`);
+		}
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Switch the homelab GPU to `target` and block until terminal. Noop
+ * when WTFOC_VLLM_AUTOSWAP is not enabled or no admin URL is set.
+ */
+export async function ensureMode(
+	target: GpuMode,
+	opts: EnsureModeOptions = {},
+): Promise<EnsureModeResult> {
+	if (!isEnabled(opts)) {
+		return { skipped: true, skippedReason: "WTFOC_VLLM_AUTOSWAP!=1" };
+	}
+	const base = adminBaseUrl(opts);
+	if (!base) {
+		return { skipped: true, skippedReason: "WTFOC_VLLM_ADMIN_URL unset" };
+	}
+	const fetchFn = opts.fetchFn ?? fetch;
+	const timeoutMs = opts.timeoutMs ?? 2400000;
+	const pollMs = opts.pollIntervalMs ?? 10000;
+	const reason = opts.reason ?? "wtfoc-autoresearch";
+	const deadline = Date.now() + timeoutMs;
+
+	const initial = await fetchMode(base, fetchFn);
+	const from = initial.state.activeMode;
+	if (from === target && TERMINAL_OK.has(initial.state.modePhase)) {
+		return { skipped: false, from, to: target, finalPhase: initial.state.modePhase };
+	}
+
+	await postSwitch(base, target, reason, fetchFn, timeoutMs);
+
+	while (Date.now() < deadline) {
+		const env = await fetchMode(base, fetchFn);
+		const phase = env.state.modePhase;
+		if (TERMINAL_OK.has(phase)) {
+			if (env.state.activeMode !== target) {
+				throw new Error(
+					`mode-switch terminal-OK but activeMode=${env.state.activeMode} != target=${target}`,
+				);
+			}
+			return { skipped: false, from, to: target, finalPhase: phase };
+		}
+		if (TERMINAL_FAIL.has(phase)) {
+			throw new Error(`mode-switch terminal failure: ${phase} (target=${target})`);
+		}
+		await sleep(pollMs);
+	}
+	throw new Error(`mode-switch timeout after ${timeoutMs}ms (target=${target})`);
+}
+
+/**
+ * Resolve the GPU phase a matrix needs for its sweep. Inspects whether
+ * any URL in the matrix points at a homelab GPU-only endpoint. Returns
+ * null when the matrix is fully always-on / cloud (no swap needed).
+ *
+ * Heuristic: looks for `embedder-gpu`, `reranker-gpu`, or
+ * `vllm.bt.sgtpooki` substrings. Override via matrix.gpuPhase when
+ * heuristic is wrong.
+ */
+export function resolveModeFromMatrix(matrix: {
+	gpuPhase?: GpuMode | null;
+	baseConfig: { embedderUrl?: string; extractorUrl?: string };
+	axes: { reranker?: ReadonlyArray<unknown> };
+}): GpuMode | null {
+	if (matrix.gpuPhase !== undefined) return matrix.gpuPhase;
+	const urls: string[] = [];
+	if (matrix.baseConfig.embedderUrl) urls.push(matrix.baseConfig.embedderUrl);
+	if (matrix.baseConfig.extractorUrl) urls.push(matrix.baseConfig.extractorUrl);
+	for (const r of matrix.axes.reranker ?? []) {
+		if (r && typeof r === "object" && "url" in r && typeof (r as { url: string }).url === "string") {
+			urls.push((r as { url: string }).url);
+		}
+	}
+	for (const u of urls) {
+		if (u.includes("embedder-gpu")) return "embed-gpu";
+		if (u.includes("reranker-gpu")) return "rerank-gpu";
+	}
+	return null;
+}

--- a/scripts/lib/mode-switch.ts
+++ b/scripts/lib/mode-switch.ts
@@ -87,6 +87,33 @@ async function fetchMode(
 	return (await res.json()) as ModeStateEnvelope;
 }
 
+/**
+ * Wrapper around `fetchMode` that swallows transient network failures
+ * during the poll loop. AEON chat-model cold load can take many minutes
+ * over Tailscale; one dropped TCP connection mid-poll should not abort
+ * an otherwise-correct mode-switch. Returns null on transient failure
+ * so the caller treats it as "not yet terminal" and retries.
+ *
+ * Distinguishes transient (e.g. fetch failed, timeout, ECONNRESET) from
+ * persistent (e.g. 404 admin gone, malformed JSON) by ONLY catching
+ * exceptions thrown by `fetchFn` itself. HTTP-level failures still
+ * propagate.
+ */
+async function fetchModeTolerant(
+	base: string,
+	fetchFn: typeof fetch,
+): Promise<ModeStateEnvelope | null> {
+	try {
+		return await fetchMode(base, fetchFn);
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		// Network-level failure during a multi-minute poll — log and let
+		// the caller try again at the next interval.
+		console.error(`[mode-switch] transient poll error (will retry): ${msg}`);
+		return null;
+	}
+}
+
 async function postSwitch(
 	base: string,
 	target: GpuMode,
@@ -155,7 +182,14 @@ export async function ensureMode(
 	await postSwitch(base, target, reason, fetchFn, timeoutMs);
 
 	while (Date.now() < deadline) {
-		const env = await fetchMode(base, fetchFn);
+		const env = await fetchModeTolerant(base, fetchFn);
+		if (env === null) {
+			// Transient network blip — wait and retry without burning the
+			// terminal-failure budget on what is almost always a Tailscale
+			// hiccup mid-cold-load.
+			await sleep(pollMs);
+			continue;
+		}
 		const phase = env.state.modePhase;
 		if (TERMINAL_OK.has(phase)) {
 			if (env.state.activeMode !== target) {


### PR DESCRIPTION
## Summary

Single-GPU homelab cluster (5090) can serve exactly one of `chat`, `rerank-gpu`, `embed-gpu` at a time. The autonomous loop's phases need different ones:

| Phase | Mode |
|-------|------|
| sweep with BGE GPU reranker | `rerank-gpu` |
| sweep with GPU embedder | `embed-gpu` |
| analyze + patch LLM | `chat` |

This wires `vllm-admin`'s mode-switch API into the cron wrapper + autonomous loop so the GPU flips automatically per phase.

## Changes

- `scripts/lib/mode-switch.ts` — `ensureMode()` helper. Idempotent (short-circuits when already in target). Polls `/admin/mode` until terminal phase. Throws on `RolledBack` / `RollbackFailed` / `WedgedManualRecoveryRequired` / `manual_recovery_required` 409. Gated by `WTFOC_VLLM_AUTOSWAP=1` so non-homelab maintainers run unmodified.
- `scripts/lib/mode-switch-cli.ts` — shell wrapper. `<mode>` or `--from-matrix <name>`.
- `scripts/autoresearch/matrix.ts` — `Matrix.gpuPhase` field for explicit hint when URL substring heuristic is wrong.
- `scripts/autoresearch/autonomous-loop.ts` — swaps to `chat` before `analyzeAndPropose` / `analyzeAndProposePatch`, swaps to `matrix.gpuPhase` before `materializeVariant` / `materializePatchProposal`. Both variant and patch paths.
- `scripts/autoresearch/cron/run-nightly.sh` — sources `$REPO_ROOT/.env` (launchd plist only exports PATH+HOME). Pre-sweep swap via `--from-matrix`. Pre-analyze swap to `chat`. EXIT trap resets to `chat`.
- `scripts/autoresearch/matrices/retrieval-gpu-rerank.ts` — new matrix exercising the BGE GPU reranker (`gpuPhase: "rerank-gpu"`). Existing `retrieval-baseline` stays cloud-only — swap is a no-op there.

## Hard rules upheld

- No homelab2 URLs hardcoded — all from env (`WTFOC_VLLM_ADMIN_URL`, `WTFOC_RERANKER_URL`).
- No paid AI in recurring path — chat mode targets local vllm.
- Mode-switch failures surface as loop notes (not silent), but exit 0 so cron chain isn't broken.
- Idempotent on retry — re-firing the cron after a partial run does the right thing.

## Test plan

- [x] `pnpm exec vitest run scripts/lib/mode-switch.test.ts` — 12/12 (gating, idempotency, polling, terminal failure, manual-recovery, timeout, heuristic)
- [x] `pnpm exec vitest run scripts/autoresearch/` — 159/159 still pass
- [x] `pnpm exec tsc -p scripts/tsconfig.json --noEmit` — clean
- [x] `pnpm lint:fix` — clean
- [x] `pnpm -r build` — clean
- [x] `bash -n scripts/autoresearch/cron/run-nightly.sh` — syntax ok
- [ ] Live on maintainer's Mac: `bash scripts/autoresearch/cron/install.sh` then `launchctl kickstart -p gui/$(id -u)/com.wtfoc.autoresearch.nightly`, tail `cron-stderr.log` for `[mode-pre-sweep]` / `[mode-pre-analyze]` / `[mode-reset]` lines
- [ ] Verify `nightly-status.json` = `OK`, `runs.jsonl` gains a row, `tried.jsonl` unchanged on first run (insufficient-history)