### PR TITLE
fix(autoresearch): bump LLM timeouts + WTFOC_LLM_TIMEOUT_MS env

### DIFF
--- a/scripts/autoresearch/analyze-and-propose-patch.ts
+++ b/scripts/autoresearch/analyze-and-propose-patch.ts
@@ -259,7 +259,11 @@ export async function analyzeAndProposePatch(
 	const apiKey =
 		input.llmApiKey ?? process.env.WTFOC_PATCH_LLM_API_KEY ?? process.env.WTFOC_ANALYSIS_LLM_API_KEY ?? "";
 	const fetchFn = input.fetchFn ?? fetch;
-	const timeoutMs = input.timeoutMs ?? 90_000;
+	const envTimeout = process.env.WTFOC_LLM_TIMEOUT_MS
+		? Number.parseInt(process.env.WTFOC_LLM_TIMEOUT_MS, 10)
+		: undefined;
+	const timeoutMs =
+		input.timeoutMs ?? (envTimeout && Number.isFinite(envTimeout) ? envTimeout : 600_000);
 	const repoRoot = input.repoRoot ?? defaultRepoRoot();
 	const curatedPaths =
 		input.curatedFiles ??

--- a/scripts/autoresearch/analyze-and-propose.ts
+++ b/scripts/autoresearch/analyze-and-propose.ts
@@ -141,7 +141,11 @@ export async function analyzeAndPropose(
 	const model = input.llmModel ?? process.env.WTFOC_ANALYSIS_LLM_MODEL ?? DEFAULT_LLM_MODEL;
 	const apiKey = input.llmApiKey ?? process.env.WTFOC_ANALYSIS_LLM_API_KEY ?? "";
 	const fetchFn = input.fetchFn ?? fetch;
-	const timeoutMs = input.timeoutMs ?? 60_000;
+	const envTimeout = process.env.WTFOC_LLM_TIMEOUT_MS
+		? Number.parseInt(process.env.WTFOC_LLM_TIMEOUT_MS, 10)
+		: undefined;
+	const timeoutMs =
+		input.timeoutMs ?? (envTimeout && Number.isFinite(envTimeout) ? envTimeout : 300_000);
 
 	const userPrompt = buildUserPrompt({
 		matrixName: input.matrixName,


### PR DESCRIPTION
## Summary

Validated against the homelab vllm during the merge of #339. AEON-class reasoning models spend significant budget on internal chain-of-thought before emitting `message.content`. The previous 60s analyze / 90s patch defaults aborted live homelab calls before the model finished reasoning.

Observed during validation:
\`\`\`
\"LLM unavailable: This operation was aborted\"
\`\`\`

## Changes

- \`analyze-and-propose.ts\`: default 60s → 300s (5min)
- \`analyze-and-propose-patch.ts\`: default 90s → 600s (10min)
- Both honor \`WTFOC_LLM_TIMEOUT_MS\` env override

## Validation

After this fix, ran \`autonomous-loop.ts\` against a synthetic finding on the homelab:
- ✅ \`chat→chat\` mode-switch
- ✅ analyzeAndPropose returned (no abort)
- ✅ Planner fallback fired correctly when LLM emitted no \`## Proposal\` block
- ✅ \`chat→rerank-gpu\` mode-switch
- ✅ Materialize sweep ran on both corpora
- ✅ decide() correctly rejected (anti-overfit floor working)
- ✅ tried.jsonl row written

## Test plan

- [x] \`pnpm exec vitest run scripts/autoresearch/analyze-and-propose.test.ts scripts/autoresearch/analyze-and-propose-patch.test.ts\` — 24/24 still pass
- [x] Live homelab e2e validation (above)