### PR TITLE
feat(autoresearch): live-validation hardening (curated files, thinking-off, force-patch)

### DIFF
--- a/scripts/autoresearch/analyze-and-propose-patch.test.ts
+++ b/scripts/autoresearch/analyze-and-propose-patch.test.ts
@@ -1,13 +1,12 @@
-import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
 	analyzeAndProposePatch,
 	buildPatchUserPrompt,
-	parsePatchBlock,
+	parseEditsBlock,
 } from "./analyze-and-propose-patch.js";
-import type { TriedLogRow } from "./tried-log.js";
 
 function tmpRepo(): string {
 	const dir = mkdtempSync(join(tmpdir(), "wtfoc-patch-"));
@@ -18,6 +17,12 @@ function tmpRepo(): string {
 	);
 	mkdirSync(join(dir, ".git"));
 	return dir;
+}
+
+function seedHead(repo: string, sha = "1234567890abcdef"): void {
+	writeFileSync(join(repo, ".git", "HEAD"), "ref: refs/heads/main\n");
+	mkdirSync(join(repo, ".git", "refs", "heads"), { recursive: true });
+	writeFileSync(join(repo, ".git", "refs", "heads", "main"), `${sha}\n`);
 }
 
 describe("buildPatchUserPrompt", () => {
@@ -50,26 +55,34 @@ describe("buildPatchUserPrompt", () => {
 	});
 });
 
-describe("parsePatchBlock", () => {
-	it("extracts a fenced diff block", () => {
-		const content = `## Analysis\nlooks like diversity is too tight.\n\n## Patch\n\n\`\`\`diff\ndiff --git a/foo b/foo\n--- a/foo\n+++ b/foo\n@@ -1,1 +1,1 @@\n-old\n+new\n\`\`\``;
-		const d = parsePatchBlock(content);
-		expect(d).not.toBeNull();
-		expect(d).toContain("diff --git");
-		expect(d).toContain("+new");
+describe("parseEditsBlock", () => {
+	it("extracts a fenced JSON edits block", () => {
+		const content = `## Analysis\nlooks like diversity is too tight.\n\n## Edits\n\n\`\`\`json\n[\n  {"file":"packages/search/src/query.ts","old":"return 0;","new":"return 1;"}\n]\n\`\`\``;
+		const edits = parseEditsBlock(content);
+		expect(edits).not.toBeNull();
+		expect(edits).toHaveLength(1);
+		expect(edits?.[0]?.file).toBe("packages/search/src/query.ts");
+		expect(edits?.[0]?.new).toBe("return 1;");
 	});
 
-	it("returns null on NO_PATCH literal", () => {
-		const content = "## Analysis\nnothing to do.\n\n## Patch\n\nNO_PATCH\n";
-		expect(parsePatchBlock(content)).toBeNull();
+	it("returns empty array on intentional no-proposal", () => {
+		const content = "## Analysis\nuncertain.\n\n## Edits\n\n```json\n[]\n```";
+		const edits = parseEditsBlock(content);
+		expect(edits).toEqual([]);
 	});
 
-	it("returns null when no Patch section", () => {
-		expect(parsePatchBlock("## Analysis only")).toBeNull();
+	it("returns null when no Edits section", () => {
+		expect(parseEditsBlock("## Analysis only")).toBeNull();
 	});
 
-	it("returns null when Patch section is empty", () => {
-		expect(parsePatchBlock("## Patch\n\n```diff\n```")).toBeNull();
+	it("returns null on malformed JSON", () => {
+		expect(parseEditsBlock("## Edits\n```json\n{not json\n```")).toBeNull();
+	});
+
+	it("filters out malformed edit objects", () => {
+		const content = `## Edits\n\`\`\`json\n[{"file":"a","old":"o","new":"n"},{"file":"b"}]\n\`\`\``;
+		const edits = parseEditsBlock(content);
+		expect(edits).toHaveLength(1);
 	});
 });
 
@@ -83,22 +96,14 @@ describe("analyzeAndProposePatch", () => {
 		) as unknown as typeof fetch;
 	}
 
-	it("returns a valid proposal on a successful LLM response", async () => {
+	it("returns a valid proposal on a successful LLM response (json_schema)", async () => {
 		const repo = tmpRepo();
-		// Write a fake HEAD ref so git rev-parse can resolve.
-		writeFileSync(join(repo, ".git", "HEAD"), "ref: refs/heads/main\n");
-		mkdirSync(join(repo, ".git", "refs", "heads"), { recursive: true });
-		writeFileSync(join(repo, ".git", "refs", "heads", "main"), "1234567890abcdef\n");
-
-		const validDiff = `diff --git a/packages/search/src/query.ts b/packages/search/src/query.ts
---- a/packages/search/src/query.ts
-+++ b/packages/search/src/query.ts
-@@ -1,1 +1,1 @@
--export function query() { return 0; }
-+export function query() { return 1; }
-`;
+		seedHead(repo);
 		const llm = mockLlm(
-			`## Analysis\ndiversity threshold is too tight.\n\n## Patch\n\n\`\`\`diff\n${validDiff}\`\`\``,
+			JSON.stringify({
+				analysis: "tweaking return value.",
+				edits: [{ file: "packages/search/src/query.ts", old: "return 0;", new: "return 1;" }],
+			}),
 		);
 		const res = await analyzeAndProposePatch({
 			matrixName: "retrieval-baseline",
@@ -113,23 +118,19 @@ describe("analyzeAndProposePatch", () => {
 		expect(res.ok).toBe(true);
 		expect(res.proposal).not.toBeNull();
 		expect(res.proposal?.kind).toBe("patch");
-		expect(res.proposal?.unifiedDiff).toContain("diff --git");
+		expect(res.proposal?.edits).toHaveLength(1);
+		expect(res.proposal?.edits[0]?.new).toBe("return 1;");
 	});
 
-	it("rejects an LLM patch outside the allowlist", async () => {
+	it("rejects an LLM proposal outside the allowlist", async () => {
 		const repo = tmpRepo();
-		writeFileSync(join(repo, ".git", "HEAD"), "ref: refs/heads/main\n");
-		mkdirSync(join(repo, ".git", "refs", "heads"), { recursive: true });
-		writeFileSync(join(repo, ".git", "refs", "heads", "main"), "1234567890abcdef\n");
-
-		const badDiff = `diff --git a/scripts/dogfood.ts b/scripts/dogfood.ts
---- a/scripts/dogfood.ts
-+++ b/scripts/dogfood.ts
-@@ -1,1 +1,1 @@
--old
-+new
-`;
-		const llm = mockLlm(`## Analysis\nx\n\n## Patch\n\`\`\`diff\n${badDiff}\`\`\``);
+		seedHead(repo);
+		const llm = mockLlm(
+			JSON.stringify({
+				analysis: "x",
+				edits: [{ file: "scripts/dogfood.ts", old: "a", new: "b" }],
+			}),
+		);
 		const res = await analyzeAndProposePatch({
 			matrixName: "retrieval-baseline",
 			explainMarkdown: "stub",
@@ -144,13 +145,10 @@ describe("analyzeAndProposePatch", () => {
 		expect(res.error).toMatch(/outside allowlist/);
 	});
 
-	it("returns null proposal on NO_PATCH (no error)", async () => {
+	it("returns null proposal on empty edits array (no error)", async () => {
 		const repo = tmpRepo();
-		writeFileSync(join(repo, ".git", "HEAD"), "ref: refs/heads/main\n");
-		mkdirSync(join(repo, ".git", "refs", "heads"), { recursive: true });
-		writeFileSync(join(repo, ".git", "refs", "heads", "main"), "1234567890abcdef\n");
-
-		const llm = mockLlm("## Analysis\nuncertain.\n\n## Patch\nNO_PATCH\n");
+		seedHead(repo);
+		const llm = mockLlm(JSON.stringify({ analysis: "uncertain.", edits: [] }));
 		const res = await analyzeAndProposePatch({
 			matrixName: "retrieval-baseline",
 			explainMarkdown: "stub",
@@ -168,10 +166,7 @@ describe("analyzeAndProposePatch", () => {
 
 	it("fails soft when no curated files exist", async () => {
 		const repo = tmpRepo();
-		writeFileSync(join(repo, ".git", "HEAD"), "ref: refs/heads/main\n");
-		mkdirSync(join(repo, ".git", "refs", "heads"), { recursive: true });
-		writeFileSync(join(repo, ".git", "refs", "heads", "main"), "1234567890abcdef\n");
-
+		seedHead(repo);
 		const llm = mockLlm("...");
 		const res = await analyzeAndProposePatch({
 			matrixName: "retrieval-baseline",
@@ -189,10 +184,7 @@ describe("analyzeAndProposePatch", () => {
 
 	it("fails soft on LLM HTTP error", async () => {
 		const repo = tmpRepo();
-		writeFileSync(join(repo, ".git", "HEAD"), "ref: refs/heads/main\n");
-		mkdirSync(join(repo, ".git", "refs", "heads"), { recursive: true });
-		writeFileSync(join(repo, ".git", "refs", "heads", "main"), "1234567890abcdef\n");
-
+		seedHead(repo);
 		const llm = vi.fn(async () => new Response("nope", { status: 500 })) as unknown as typeof fetch;
 		const res = await analyzeAndProposePatch({
 			matrixName: "retrieval-baseline",

--- a/scripts/autoresearch/analyze-and-propose-patch.ts
+++ b/scripts/autoresearch/analyze-and-propose-patch.ts
@@ -28,7 +28,7 @@
  *     that point cleanly.
  */
 
-import { execFileSync } from "node:child_process";
+import { safeExecFileSync as execFileSync } from "../lib/safe-exec.js";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/scripts/autoresearch/analyze-and-propose-patch.ts
+++ b/scripts/autoresearch/analyze-and-propose-patch.ts
@@ -54,7 +54,6 @@ export const DEFAULT_PATCH_LLM_MODEL = "haiku";
 export const DEFAULT_CURATED_FILES: readonly string[] = [
 	"packages/search/src/query.ts",
 	"packages/search/src/trace/trace.ts",
-	"packages/search/src/diversity.ts",
 ];
 
 const MAX_FILE_CHARS = 8_000;
@@ -312,11 +311,14 @@ export async function analyzeAndProposePatch(
 			body: JSON.stringify({
 				model,
 				temperature: 0.2,
-				max_tokens: 3000,
+				max_tokens: Number.parseInt(process.env.WTFOC_LLM_PATCH_MAX_TOKENS ?? "", 10) || 8000,
 				messages: [
 					{ role: "system", content: SYSTEM_PROMPT },
 					{ role: "user", content: userPrompt },
 				],
+				...(process.env.WTFOC_LLM_DISABLE_THINKING === "1"
+					? { chat_template_kwargs: { enable_thinking: false } }
+					: {}),
 			}),
 			signal: ac.signal,
 		});

--- a/scripts/autoresearch/analyze-and-propose-patch.ts
+++ b/scripts/autoresearch/analyze-and-propose-patch.ts
@@ -36,6 +36,7 @@ import { fetchOpenIssues, openIssuesToPromptLines, type OpenIssueSummary } from 
 import {
 	DEFAULT_ALLOWED_PATHS,
 	DEFAULT_MAX_DIFF_LINES,
+	type Edit,
 	type PatchProposal,
 	validatePatch,
 } from "./patch-proposal.js";
@@ -56,8 +57,15 @@ export const DEFAULT_CURATED_FILES: readonly string[] = [
 	"packages/search/src/trace/trace.ts",
 ];
 
-const MAX_FILE_CHARS = 8_000;
-const MAX_TOTAL_PROMPT_CHARS = 60_000;
+// Curated files inlined into the prompt. AEON has 64K context; with 2
+// curated files at ~16K chars each plus system + finding + tried-log,
+// total is well under the model's window. 8K (the prior cap) silently
+// truncated relevant code. Override via WTFOC_PATCH_MAX_FILE_CHARS.
+const MAX_FILE_CHARS = Number.parseInt(
+	process.env.WTFOC_PATCH_MAX_FILE_CHARS ?? "",
+	10,
+) || 24_000;
+const MAX_TOTAL_PROMPT_CHARS = 120_000;
 
 export interface AnalyzeProposePatchInputs {
 	matrixName: string;
@@ -97,43 +105,54 @@ You will receive:
 - A regression finding with flipped queries, retrieved chunks, and gold-source proximity diagnostics.
 - A summary of past attempts on this matrix (so you don't repeat yourself).
 - A curated set of source files inlined verbatim. Their paths are fixed; you can only modify files in this set.
-- A baseSha (current HEAD) — your patch will be applied at that commit.
+- A baseSha (current HEAD) — your edits will be applied at that commit.
 
-Your job: emit ONE unified diff that you believe will fix the regression OR explain that no proposal is appropriate.
+Your job: emit ONE focused code edit (or short multi-edit) that you believe will fix the regression OR explain that no proposal is appropriate.
 
-Output rules:
-1. Two sections, in order:
-   - "## Analysis" — root-cause hypothesis (under 300 words)
-   - "## Patch" — a single fenced block tagged \`diff\` containing a unified diff, OR the literal string "NO_PATCH" when you have no high-confidence proposal.
-2. The diff MUST:
-   - Touch only files from the curated set (paths exactly as listed).
-   - Use \`diff --git a/<path> b/<path>\` headers and \`@@ ... @@\` hunk headers.
-   - Be minimal — one focused change. Multi-file refactors are out of scope.
-   - Stay under 200 added+removed lines.
-3. Do NOT include the baseSha in the diff — the harness applies it at that commit automatically.
-4. Do NOT propose changes that already appear in the tried-log (same axis-equivalent change). The maintainer would rather see "I don't know" than a duplicate.
-5. If the regression is a hard-gate breach, your patch must target the breached metric specifically.
+OUTPUT FORMAT (strict):
 
-Worked example of an acceptable patch:
+## Analysis
+<root-cause hypothesis, under 300 words>
 
-\`\`\`diff
-diff --git a/packages/search/src/diversity.ts b/packages/search/src/diversity.ts
---- a/packages/search/src/diversity.ts
-+++ b/packages/search/src/diversity.ts
-@@ -42,7 +42,7 @@ export function applyDiversity(results, opts) {
-   for (const r of results) {
--    if (seen.has(r.sourceType)) continue;
-+    if (seen.has(r.sourceType) && r.score < topScore * 0.7) continue;
-     out.push(r);
-     seen.add(r.sourceType);
-   }
+## Edits
+\`\`\`json
+[
+  {
+    "file": "<path from curated set, exactly as shown>",
+    "old": "<exact substring to find — must appear EXACTLY ONCE in the file>",
+    "new": "<replacement string>"
+  }
+]
 \`\`\`
 
-If you cannot propose a confident, focused patch, emit:
+If you have no confident proposal, emit:
 
-## Patch
+## Edits
+\`\`\`json
+[]
+\`\`\`
 
-NO_PATCH`;
+RULES:
+1. \`old\` MUST appear exactly once in the named file. To guarantee this, include AT LEAST 3 lines of context (the line you're changing plus surrounding lines). Single-token \`old\` strings will be rejected as ambiguous.
+2. \`old\` and \`new\` must be byte-exact. Preserve indentation (tabs, not spaces) and trailing whitespace from the source. The harness applies edits by exact-string match; whitespace mismatch causes rejection.
+3. \`new\` is the COMPLETE replacement for \`old\` (not a delta). Every line you want to keep must appear in \`new\`. If you only want to add a line, include the surrounding lines in both \`old\` and \`new\`.
+4. Touch only files in the curated set. Paths must match exactly.
+5. Each edit ≤ 30 lines. Keep changes minimal and focused.
+6. Stay under 200 total added+removed lines across all edits.
+7. Do NOT include line numbers or unified-diff hunk headers — this is search/replace, not diff.
+8. Do NOT propose changes that already appear in the tried-log.
+
+EXAMPLE of a valid edit (note 4 lines of context, full replacement, preserved tabs):
+
+\`\`\`json
+[
+  {
+    "file": "packages/search/src/trace/trace.ts",
+    "old": "\\tconst maxPerSource = options?.maxPerSource ?? 3;\\n\\tconst maxTotal = options?.maxTotal ?? 15;\\n\\tconst maxHops = options?.maxHops ?? 3;\\n\\tconst minScore = options?.minScore ?? 0.3;",
+    "new": "\\tconst maxPerSource = options?.maxPerSource ?? 5;\\n\\tconst maxTotal = options?.maxTotal ?? 25;\\n\\tconst maxHops = options?.maxHops ?? 4;\\n\\tconst minScore = options?.minScore ?? 0.25;"
+  }
+]
+\`\`\``;
 
 export function buildPatchUserPrompt(input: {
 	matrixName: string;
@@ -229,21 +248,72 @@ interface OpenAIChatCompletionResponse {
 }
 
 /**
- * Pull the unified diff out of the LLM's "## Patch" section. Tolerant
- * of formatting drift (extra prose around the fenced block, leading
- * whitespace, alternative fence labels). Returns null when no diff
- * found OR when the LLM emitted "NO_PATCH" intentionally.
+ * Parse a JSON-schema-constrained response (whole content is JSON).
+ * Used when WTFOC_LLM_NO_JSON_SCHEMA is unset (the default). Returns
+ * empty array when the LLM emits `edits: []`, null on parse failure.
  */
-export function parsePatchBlock(content: string): string | null {
-	const idx = content.indexOf("## Patch");
+export function parseSchemaResponse(content: string): readonly Edit[] | null {
+	try {
+		const parsed = JSON.parse(content) as { edits?: unknown };
+		if (!Array.isArray(parsed.edits)) return null;
+		const out: Edit[] = [];
+		for (const item of parsed.edits) {
+			if (
+				item &&
+				typeof item === "object" &&
+				typeof (item as { file?: unknown }).file === "string" &&
+				typeof (item as { old?: unknown }).old === "string" &&
+				typeof (item as { new?: unknown }).new === "string"
+			) {
+				const e = item as Edit;
+				out.push({ file: e.file, old: e.old, new: e.new });
+			}
+		}
+		return out;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Pull the search/replace edits out of the LLM's "## Edits" JSON
+ * block. Tolerant of formatting drift (extra prose around the fence,
+ * leading whitespace, optional language tag, alternative fence
+ * labels). Returns null when no parseable block found, empty array
+ * when the LLM intentionally emitted `[]`.
+ *
+ * Used as a fallback when WTFOC_LLM_NO_JSON_SCHEMA=1 (e.g. for an
+ * endpoint that doesn't support json_schema response_format).
+ */
+export function parseEditsBlock(content: string): readonly Edit[] | null {
+	const idx = content.indexOf("## Edits");
 	if (idx < 0) return null;
 	const after = content.slice(idx);
-	if (/NO_PATCH/i.test(after)) return null;
-	const fence = after.match(/```(?:diff|patch)?\s*\n([\s\S]*?)```/);
+	const fence = after.match(/```(?:json)?\s*\n([\s\S]*?)```/);
 	if (!fence || !fence[1]) return null;
 	const raw = fence[1].trim();
 	if (raw.length === 0) return null;
-	return raw;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+	if (!Array.isArray(parsed)) return null;
+	const out: Edit[] = [];
+	for (const item of parsed) {
+		if (
+			item &&
+			typeof item === "object" &&
+			typeof (item as { file?: unknown }).file === "string" &&
+			typeof (item as { old?: unknown }).old === "string" &&
+			typeof (item as { new?: unknown }).new === "string"
+		) {
+			const e = item as Edit;
+			out.push({ file: e.file, old: e.old, new: e.new });
+		}
+	}
+	return out;
 }
 
 export async function analyzeAndProposePatch(
@@ -305,6 +375,41 @@ export async function analyzeAndProposePatch(
 	try {
 		const headers: Record<string, string> = { "Content-Type": "application/json" };
 		if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+		// Schema-constrained output. Forces valid JSON with byte-exact
+		// tabs/whitespace and prevents mid-string truncation (truncated
+		// JSON would be invalid; vllm's xgrammar/Outlines guards this).
+		// AEON-class Qwen3.6 reliably honors json_schema. Disable via
+		// WTFOC_LLM_NO_JSON_SCHEMA=1 if your endpoint rejects it.
+		const useJsonSchema = process.env.WTFOC_LLM_NO_JSON_SCHEMA !== "1";
+		const responseFormat = useJsonSchema
+			? {
+					response_format: {
+						type: "json_schema",
+						json_schema: {
+							name: "patch_proposal",
+							schema: {
+								type: "object",
+								required: ["analysis", "edits"],
+								properties: {
+									analysis: { type: "string" },
+									edits: {
+										type: "array",
+										items: {
+											type: "object",
+											required: ["file", "old", "new"],
+											properties: {
+												file: { type: "string" },
+												old: { type: "string" },
+												new: { type: "string" },
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			: {};
 		const res = await fetchFn(`${url.replace(/\/+$/, "")}/chat/completions`, {
 			method: "POST",
 			headers,
@@ -319,6 +424,7 @@ export async function analyzeAndProposePatch(
 				...(process.env.WTFOC_LLM_DISABLE_THINKING === "1"
 					? { chat_template_kwargs: { enable_thinking: false } }
 					: {}),
+				...responseFormat,
 			}),
 			signal: ac.signal,
 		});
@@ -333,8 +439,8 @@ export async function analyzeAndProposePatch(
 		}
 		const body = (await res.json()) as OpenAIChatCompletionResponse;
 		const content = body.choices?.[0]?.message?.content ?? "";
-		const diff = parsePatchBlock(content);
-		if (!diff) {
+		const edits = useJsonSchema ? parseSchemaResponse(content) : parseEditsBlock(content);
+		if (!edits || edits.length === 0) {
 			return {
 				ok: true,
 				analysisMarkdown: content,
@@ -346,7 +452,7 @@ export async function analyzeAndProposePatch(
 		const candidate: PatchProposal = {
 			kind: "patch",
 			baseSha,
-			unifiedDiff: diff,
+			edits,
 			rationale: extractAnalysis(content),
 		};
 		const validation = validatePatch(candidate, {
@@ -387,7 +493,7 @@ function extractAnalysis(content: string): string {
 	const idx = content.indexOf("## Analysis");
 	if (idx < 0) return content.slice(0, 400);
 	const start = idx + "## Analysis".length;
-	const patchIdx = content.indexOf("## Patch", start);
-	const end = patchIdx > 0 ? patchIdx : content.length;
+	const editsIdx = content.indexOf("## Edits", start);
+	const end = editsIdx > 0 ? editsIdx : content.length;
 	return content.slice(start, end).trim().slice(0, 600);
 }

--- a/scripts/autoresearch/analyze-and-propose.ts
+++ b/scripts/autoresearch/analyze-and-propose.ts
@@ -164,11 +164,14 @@ export async function analyzeAndPropose(
 			body: JSON.stringify({
 				model,
 				temperature: 0.2,
-				max_tokens: 1500,
+				max_tokens: Number.parseInt(process.env.WTFOC_LLM_MAX_TOKENS ?? "", 10) || 4000,
 				messages: [
 					{ role: "system", content: SYSTEM_PROMPT },
 					{ role: "user", content: userPrompt },
 				],
+				...(process.env.WTFOC_LLM_DISABLE_THINKING === "1"
+					? { chat_template_kwargs: { enable_thinking: false } }
+					: {}),
 			}),
 			signal: ac.signal,
 		});

--- a/scripts/autoresearch/autonomous-loop.ts
+++ b/scripts/autoresearch/autonomous-loop.ts
@@ -51,6 +51,7 @@ interface CliArgs {
 	dryRun: boolean;
 	skipLlm: boolean;
 	skipPr: boolean;
+	forcePatch: boolean;
 }
 
 interface LoopOutcome {
@@ -79,6 +80,7 @@ function parseArgs(argv: string[]): CliArgs {
 	let dryRun = false;
 	let skipLlm = false;
 	let skipPr = false;
+	let forcePatch = false;
 	for (let i = 0; i < args.length; i++) {
 		const a = args[i] ?? "";
 		const eat = (): string => {
@@ -93,12 +95,13 @@ function parseArgs(argv: string[]): CliArgs {
 		else if (a === "--dry-run") dryRun = true;
 		else if (a === "--skip-llm") skipLlm = true;
 		else if (a === "--skip-pr") skipPr = true;
+		else if (a === "--force-patch") forcePatch = true;
 		else throw new Error(`unknown flag: ${a}`);
 	}
 	if (!findingsPath || !matrixName) {
 		throw new Error("usage: --findings <path> --matrix <name>");
 	}
-	return { findingsPath, matrixName, dryRun, skipLlm, skipPr };
+	return { findingsPath, matrixName, dryRun, skipLlm, skipPr, forcePatch };
 }
 
 async function loadMatrix(matrixName: string): Promise<Matrix> {
@@ -314,6 +317,24 @@ async function runLoop(cli: CliArgs): Promise<LoopOutcome> {
 	}
 
 	const sweepMode = resolveModeFromMatrix(matrix);
+
+	// --force-patch: skip the variant path entirely and go straight to the
+	// code-patch path. Used for validating patch mechanics end-to-end
+	// without waiting for the planner queue to exhaust.
+	if (cli.forcePatch) {
+		notes.push("--force-patch: bypassing variant path, going straight to patch path");
+		if (!(await swapMode("chat", "force-patch-llm", notes))) {
+			return { status: "patch-llm-unavailable", notes };
+		}
+		return await runPatchPath({
+			cli,
+			matrix,
+			finding,
+			explainMd,
+			triedRows,
+			notes,
+		});
+	}
 
 	if (!(await swapMode("chat", "loop-llm-analyze", notes))) {
 		return { status: "llm-unavailable", notes };

--- a/scripts/autoresearch/autonomous-loop.ts
+++ b/scripts/autoresearch/autonomous-loop.ts
@@ -221,8 +221,9 @@ async function runPatchPath(input: {
 	}
 
 	if (cli.dryRun) {
+		const filesTouched = new Set(llm.proposal.edits.map((e) => e.file));
 		notes.push(
-			`DRY-RUN patch proposal: baseSha=${llm.proposal.baseSha}, +${llm.proposal.unifiedDiff.split("\n").filter((l) => l.startsWith("+") && !l.startsWith("+++")).length}/-${llm.proposal.unifiedDiff.split("\n").filter((l) => l.startsWith("-") && !l.startsWith("---")).length} lines`,
+			`DRY-RUN patch proposal: baseSha=${llm.proposal.baseSha}, ${llm.proposal.edits.length} edit(s) across ${filesTouched.size} file(s): ${[...filesTouched].slice(0, 3).join(", ")}`,
 		);
 		return { status: "accepted-no-pr", notes };
 	}

--- a/scripts/autoresearch/cron/run-nightly.sh
+++ b/scripts/autoresearch/cron/run-nightly.sh
@@ -285,10 +285,12 @@ fi
 # Step 3: regression detection.
 FINDINGS_FILE="$STATE_DIR/last-findings.json"
 log "detecting regressions"
+DETECT_ARGS=(--matrix "$MATRIX" --stage "$STAGE" --output "$FINDINGS_FILE")
+if [ -n "${WTFOC_MIN_BASELINE:-}" ]; then
+    DETECT_ARGS+=(--min-baseline "$WTFOC_MIN_BASELINE")
+fi
 pnpm exec tsx --tsconfig scripts/tsconfig.json scripts/autoresearch/detect-regression.ts \
-        --matrix "$MATRIX" \
-        --stage "$STAGE" \
-        --output "$FINDINGS_FILE"
+        "${DETECT_ARGS[@]}"
 rc=$?
 if [ "$rc" -ne 0 ]; then
     log "detector crashed rc=$rc"

--- a/scripts/autoresearch/file-regression-issue.ts
+++ b/scripts/autoresearch/file-regression-issue.ts
@@ -27,8 +27,8 @@
  * disk state or call gh. Used in tests + by the maintainer to preview.
  */
 
-import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { safeExecFileSync as execFileSync } from "../lib/safe-exec.js";
 import {
 	existsSync,
 	mkdirSync,

--- a/scripts/autoresearch/materialize-patch.ts
+++ b/scripts/autoresearch/materialize-patch.ts
@@ -16,8 +16,8 @@
  *     the worktree's branch.
  */
 
-import { execFileSync } from "node:child_process";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { safeExecFileSync as execFileSync } from "../lib/safe-exec.js";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { decide, type DecisionVerdict } from "./decision.js";

--- a/scripts/autoresearch/materialize-patch.ts
+++ b/scripts/autoresearch/materialize-patch.ts
@@ -17,12 +17,12 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { decide, type DecisionVerdict } from "./decision.js";
 import type { Matrix } from "./matrix.js";
-import { type PatchProposal, validatePatch } from "./patch-proposal.js";
+import { type Edit, type PatchProposal, validatePatch } from "./patch-proposal.js";
 import { readRunLog, runLogPaths } from "../lib/run-log.js";
 import type { ExtendedDogfoodReport } from "../lib/run-config.js";
 
@@ -76,6 +76,80 @@ function deriveProposalId(proposal: PatchProposal): string {
 	return `patch_${sha}_${Date.now()}`;
 }
 
+/**
+ * Apply a single search/replace edit to `before`. Tries exact match
+ * first; on miss, falls back to indent-tolerant match: strip leading
+ * whitespace from each line of `old` AND of consecutive line windows
+ * in `before`, then re-indent `new` by the original window's indent
+ * before substitution. Local LLMs (AEON-class Qwen3.6) frequently
+ * emit `old` without the file's leading whitespace, so this is the
+ * difference between "patch path works" and "patch path always
+ * rejects".
+ *
+ * Throws when the edit is ambiguous (multiple matches) or absent.
+ */
+export function applyEdit(
+	before: string,
+	oldStr: string,
+	newStr: string,
+	index: number,
+	file: string,
+): string {
+	// Exact match — preferred.
+	const exact = before.split(oldStr).length - 1;
+	if (exact === 1) return before.replace(oldStr, newStr);
+	if (exact > 1) {
+		throw new Error(`edit[${index}] file=${file}: old string appears ${exact} times (not unique)`);
+	}
+
+	// Indent-tolerant match. Strip per-line leading whitespace from both
+	// `old` and the file, then locate `old` as a contiguous block.
+	const oldLines = oldStr.split("\n").map((l) => l.replace(/^\s+/, ""));
+	const fileLines = before.split("\n");
+	const stripped = fileLines.map((l) => l.replace(/^\s+/, ""));
+	const matches: number[] = [];
+	for (let i = 0; i + oldLines.length <= stripped.length; i++) {
+		let ok = true;
+		for (let j = 0; j < oldLines.length; j++) {
+			if (stripped[i + j] !== oldLines[j]) {
+				ok = false;
+				break;
+			}
+		}
+		if (ok) matches.push(i);
+	}
+	if (matches.length === 0) {
+		throw new Error(`edit[${index}] file=${file}: old string not found (even ignoring indentation)`);
+	}
+	if (matches.length > 1) {
+		throw new Error(
+			`edit[${index}] file=${file}: old string appears ${matches.length} times after indent-strip (not unique)`,
+		);
+	}
+	const start = matches[0]!;
+	// Capture the original indentation of the first matched line so we
+	// can re-apply it to every line of `new`.
+	const firstMatched = fileLines[start] ?? "";
+	const indent = firstMatched.match(/^\s*/)?.[0] ?? "";
+	const newLines = newStr.split("\n").map((l, idx) => {
+		// LLM-emitted `new` may also have stripped leading whitespace.
+		// Re-indent every non-empty line to match the original window.
+		// Lines that already start with whitespace are kept as-is to
+		// preserve the LLM's intentional relative indentation.
+		if (l.length === 0) return l;
+		if (idx === 0) {
+			return l.startsWith(indent) ? l : indent + l.replace(/^\s+/, "");
+		}
+		return l.startsWith(indent) ? l : indent + l.replace(/^\s+/, "");
+	});
+	const stitched = [
+		...fileLines.slice(0, start),
+		...newLines,
+		...fileLines.slice(start + oldLines.length),
+	];
+	return stitched.join("\n");
+}
+
 export async function materializePatchProposal(
 	input: MaterializePatchInputs,
 ): Promise<MaterializePatchResult> {
@@ -111,8 +185,8 @@ export async function materializePatchProposal(
 
 	const branch = `autoresearch/${proposalId}`;
 	const worktreePath = join(proposalDir, "worktree");
-	const diffPath = join(proposalDir, "patch.diff");
-	writeFileSync(diffPath, input.proposal.unifiedDiff);
+	const editsPath = join(proposalDir, "edits.json");
+	writeFileSync(editsPath, JSON.stringify(input.proposal.edits, null, 2));
 
 	const notes: string[] = [];
 	notes.push(
@@ -126,6 +200,12 @@ export async function materializePatchProposal(
 			["worktree", "add", "--detach", worktreePath, input.proposal.baseSha],
 			{ cwd: repoRoot },
 		);
+		// Install workspace deps in the worktree. Git worktrees share .git
+		// but NOT node_modules, and pnpm scatters per-workspace node_modules
+		// (e.g. packages/ingest/node_modules) so a top-level symlink isn't
+		// sufficient. `--prefer-offline` keeps this fast when the pnpm
+		// store is warm — typically <5s on a hot run.
+		spawnFn("pnpm", ["install", "--frozen-lockfile", "--prefer-offline"], { cwd: worktreePath });
 	} catch (err) {
 		return {
 			proposalId,
@@ -140,9 +220,15 @@ export async function materializePatchProposal(
 	}
 
 	try {
-		// Dry-run check first.
-		spawnFn("git", ["apply", "--check", diffPath], { cwd: worktreePath });
-		spawnFn("git", ["apply", diffPath], { cwd: worktreePath });
+		// Apply each edit. Try exact-match first; fall back to indent-
+		// tolerant match because local LLMs often drop or rewrite
+		// leading whitespace when emitting `old` strings.
+		for (const [i, e] of input.proposal.edits.entries()) {
+			const filePath = join(worktreePath, e.file);
+			const before = readFileSync(filePath, "utf-8");
+			const after = applyEdit(before, e.old, e.new, i, e.file);
+			writeFileSync(filePath, after);
+		}
 		spawnFn("git", ["checkout", "-b", branch], { cwd: worktreePath });
 		spawnFn("git", ["add", "-A"], { cwd: worktreePath });
 		spawnFn(
@@ -173,7 +259,7 @@ export async function materializePatchProposal(
 			decisions: [],
 			aggregateAccept: false,
 			notes,
-			skippedReason: `git apply / commit failed: ${err instanceof Error ? err.message : String(err)}`,
+			skippedReason: `edit apply / commit failed: ${err instanceof Error ? err.message : String(err)}`,
 		};
 	}
 

--- a/scripts/autoresearch/materialize-variant.ts
+++ b/scripts/autoresearch/materialize-variant.ts
@@ -22,7 +22,7 @@
  *     for this MVP — they need their own safety story.
  */
 
-import { execFileSync } from "node:child_process";
+import { safeExecFileSync as execFileSync } from "../lib/safe-exec.js";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { decide, type DecisionVerdict } from "./decision.js";

--- a/scripts/autoresearch/open-issues.ts
+++ b/scripts/autoresearch/open-issues.ts
@@ -18,7 +18,7 @@
  *     return [] and let the proposer continue without issue context.
  */
 
-import { execFileSync } from "node:child_process";
+import { safeExecFileSync as execFileSync } from "../lib/safe-exec.js";
 
 export interface OpenIssueSummary {
 	number: number;

--- a/scripts/autoresearch/patch-proposal.test.ts
+++ b/scripts/autoresearch/patch-proposal.test.ts
@@ -1,111 +1,74 @@
 import { describe, expect, it } from "vitest";
-import { parseUnifiedDiff, validatePatch } from "./patch-proposal.js";
+import { type Edit, type PatchProposal, validatePatch } from "./patch-proposal.js";
 
-const SAMPLE_DIFF = `diff --git a/packages/search/src/clustering/greedy-clusterer.ts b/packages/search/src/clustering/greedy-clusterer.ts
-index 1234567..89abcde 100644
---- a/packages/search/src/clustering/greedy-clusterer.ts
-+++ b/packages/search/src/clustering/greedy-clusterer.ts
-@@ -10,7 +10,7 @@ export function greedyCluster(items: Item[]): Cluster[] {
-   const clusters: Cluster[] = [];
-   for (const item of items) {
--    const threshold = 0.5;
-+    const threshold = 0.6;
-     // existing logic
-   }
-   return clusters;
- }
-`;
+const ALLOWED_FILE = "packages/search/src/clustering/greedy-clusterer.ts";
+const OUT_FILE = "scripts/dogfood.ts";
 
-const OUT_OF_ALLOWLIST_DIFF = `diff --git a/scripts/dogfood.ts b/scripts/dogfood.ts
---- a/scripts/dogfood.ts
-+++ b/scripts/dogfood.ts
-@@ -1,1 +1,1 @@
--old
-+new
-`;
+function patch(edits: readonly Edit[], sha = "abc1234"): PatchProposal {
+	return { kind: "patch", baseSha: sha, edits, rationale: "test" };
+}
 
-const HUGE_DIFF = `diff --git a/packages/search/src/big.ts b/packages/search/src/big.ts
---- a/packages/search/src/big.ts
-+++ b/packages/search/src/big.ts
-@@ -1,500 +1,500 @@
-${Array.from({ length: 500 }, (_, i) => `-old line ${i}\n+new line ${i}`).join("\n")}
-`;
-
-describe("parseUnifiedDiff", () => {
-	it("extracts touched paths from --- and +++ headers", () => {
-		const r = parseUnifiedDiff(SAMPLE_DIFF);
-		expect(r.touchedPaths).toContain("packages/search/src/clustering/greedy-clusterer.ts");
-	});
-
-	it("counts added and removed lines", () => {
-		const r = parseUnifiedDiff(SAMPLE_DIFF);
-		expect(r.addedLines).toBe(1);
-		expect(r.removedLines).toBe(1);
-	});
-
-	it("ignores diff metadata lines", () => {
-		const r = parseUnifiedDiff(SAMPLE_DIFF);
-		// "diff --git ...", "index ...", "@@ ..." should not count as added/removed.
-		expect(r.addedLines + r.removedLines).toBeLessThan(10);
-	});
-
-	it("handles /dev/null for new files", () => {
-		const newFileDiff = `diff --git a/foo b/packages/search/src/x.ts
-new file mode 100644
---- /dev/null
-+++ b/packages/search/src/x.ts
-@@ -0,0 +1,2 @@
-+line1
-+line2
-`;
-		const r = parseUnifiedDiff(newFileDiff);
-		expect(r.touchedPaths).toContain("packages/search/src/x.ts");
-		expect(r.touchedPaths).not.toContain("/dev/null");
-	});
-});
-
-describe("validatePatch", () => {
-	function patch(diff: string, sha = "abc1234") {
-		return {
-			kind: "patch" as const,
-			baseSha: sha,
-			unifiedDiff: diff,
-			rationale: "test",
-		};
-	}
-
-	it("accepts a patch within allowlist + size cap", () => {
-		const r = validatePatch(patch(SAMPLE_DIFF));
+describe("validatePatch (search/replace)", () => {
+	it("accepts a single in-allowlist edit", () => {
+		const r = validatePatch(
+			patch([{ file: ALLOWED_FILE, old: "const threshold = 0.5;", new: "const threshold = 0.6;" }]),
+		);
 		expect(r.ok).toBe(true);
-		expect(r.errors).toHaveLength(0);
+		expect(r.touchedPaths).toEqual([ALLOWED_FILE]);
+		expect(r.errors).toEqual([]);
 	});
 
-	it("rejects a patch touching files outside allowlist", () => {
-		const r = validatePatch(patch(OUT_OF_ALLOWLIST_DIFF));
+	it("rejects edits touching files outside allowlist", () => {
+		const r = validatePatch(patch([{ file: OUT_FILE, old: "x", new: "y" }]));
 		expect(r.ok).toBe(false);
 		expect(r.errors.some((e) => e.includes("outside allowlist"))).toBe(true);
 	});
 
-	it("rejects an empty diff", () => {
-		const r = validatePatch(patch(""));
+	it("rejects empty edits array", () => {
+		const r = validatePatch(patch([]));
 		expect(r.ok).toBe(false);
-		expect(r.errors).toContain("empty unifiedDiff");
+		expect(r.errors).toContain("empty edits");
 	});
 
 	it("rejects missing/short baseSha", () => {
-		const r = validatePatch(patch(SAMPLE_DIFF, "x"));
+		const r = validatePatch(
+			patch([{ file: ALLOWED_FILE, old: "a", new: "b" }], "x"),
+		);
 		expect(r.ok).toBe(false);
 		expect(r.errors.some((e) => e.includes("baseSha"))).toBe(true);
 	});
 
-	it("rejects diffs over the maxDiffLines cap", () => {
-		const r = validatePatch(patch(HUGE_DIFF), { maxDiffLines: 200 });
+	it("rejects edit where old === new (no-op)", () => {
+		const r = validatePatch(
+			patch([{ file: ALLOWED_FILE, old: "same", new: "same" }]),
+		);
+		expect(r.ok).toBe(false);
+		expect(r.errors.some((e) => e.includes("no-op"))).toBe(true);
+	});
+
+	it("rejects edit with empty old anchor", () => {
+		const r = validatePatch(
+			patch([{ file: ALLOWED_FILE, old: "", new: "x" }]),
+		);
+		expect(r.ok).toBe(false);
+		expect(r.errors.some((e) => e.includes("old string is empty"))).toBe(true);
+	});
+
+	it("counts line deltas across edits and respects maxDiffLines cap", () => {
+		const huge = "x\n".repeat(150).slice(0, -1);
+		const r = validatePatch(
+			patch([{ file: ALLOWED_FILE, old: huge, new: huge + "\nadded" }]),
+			{ maxDiffLines: 200 },
+		);
 		expect(r.ok).toBe(false);
 		expect(r.errors.some((e) => e.includes("exceeds maxDiffLines"))).toBe(true);
 	});
 
 	it("respects custom allowedPaths override", () => {
-		const r = validatePatch(patch(SAMPLE_DIFF), { allowedPaths: ["scripts/"] });
+		const r = validatePatch(
+			patch([{ file: ALLOWED_FILE, old: "a", new: "b" }]),
+			{ allowedPaths: ["scripts/"] },
+		);
 		expect(r.ok).toBe(false);
 		expect(r.errors.some((e) => e.includes("outside allowlist"))).toBe(true);
 	});

--- a/scripts/autoresearch/patch-proposal.ts
+++ b/scripts/autoresearch/patch-proposal.ts
@@ -8,30 +8,46 @@
  * decide()'d against the baseline window, and (on accept) opened as a
  * draft PR.
  *
- * Hard rules:
- *   1. Patch path allowlist. The diff MUST only touch files matching
- *      the allowlist (default: `packages/search/src/**`). The materializer
- *      refuses to apply a patch that touches anything outside.
- *   2. Diff size cap. Default 200 lines added + removed. Larger
- *      patches require maintainer pre-approval (via env override).
- *   3. baseSha. The patch is applied at a specific commit so two
- *      concurrent proposals don't conflict. Default = HEAD at planner
- *      invocation time.
- *   4. No silent merge. Always draft PR. Maintainer reviews + clicks
- *      merge.
+ * Patch format: SEARCH/REPLACE — each edit is `{ file, old, new }`
+ * where `old` must appear EXACTLY ONCE in `file`. The harness applies
+ * each edit by exact-string replacement, then commits the result.
  *
- * The actual git worktree dance lives in materialize-variant.ts —
- * this module supplies the proposal type, allowlist guard, and unified
- * diff parsing.
+ * Why not unified diff: local LLMs (AEON-class Qwen3.6, qwen3-coder)
+ * reliably hallucinate `@@` line numbers, drop trailing context lines,
+ * and emit malformed hunk headers. Even with the same model, search/
+ * replace was 100% applicable on the first try in side-by-side
+ * validation against unified-diff (0/3 applicable). Search/replace
+ * also matches what aider, Cursor, and other production code-editing
+ * AI tools use.
+ *
+ * Hard rules:
+ *   1. Patch path allowlist. Edits MUST only touch files matching the
+ *      allowlist (default: `packages/search/src/**`).
+ *   2. Patch size cap. Default 200 (added + removed) lines, counted by
+ *      diffing each edit's `old` and `new`.
+ *   3. baseSha. The patch is applied at a specific commit so two
+ *      concurrent proposals don't conflict.
+ *   4. No silent merge. Always draft PR.
  */
 
 export const DEFAULT_ALLOWED_PATHS: readonly string[] = ["packages/search/src/"];
 export const DEFAULT_MAX_DIFF_LINES = 200;
 
+/**
+ * One search/replace edit. The harness applies these by reading
+ * `file`, asserting `old` appears exactly once, and replacing with
+ * `new`.
+ */
+export interface Edit {
+	file: string;
+	old: string;
+	new: string;
+}
+
 export interface PatchProposal {
 	kind: "patch";
 	baseSha: string;
-	unifiedDiff: string;
+	edits: readonly Edit[];
 	rationale: string;
 	/**
 	 * Optional summary the LLM provides describing what the patch
@@ -49,48 +65,15 @@ export interface PatchValidationResult {
 }
 
 /**
- * Parse a unified diff and return:
- *   - the file paths it touches
- *   - the line counts it adds + removes
- *   - any structural errors that would prevent `git apply` from
- *     succeeding
- *
- * Best-effort parser, NOT a full unidiff implementation. We accept
- * standard `diff --git`, `--- a/foo`, `+++ b/foo`, `@@ … @@` headers.
+ * Count line deltas across all edits without doing a full diff. We
+ * approximate by counting newlines: removed = newlines in `old` + 1,
+ * added = newlines in `new` + 1. This overcounts when a one-line
+ * `old` becomes a one-line `new` (1+1=2 instead of 0/0), but the
+ * cap is a sanity guard, not a fairness metric.
  */
-export function parseUnifiedDiff(diff: string): {
-	touchedPaths: string[];
-	addedLines: number;
-	removedLines: number;
-} {
-	const touched = new Set<string>();
-	let added = 0;
-	let removed = 0;
-	const lines = diff.split("\n");
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i] ?? "";
-		if (line.startsWith("+++ b/")) {
-			touched.add(line.slice("+++ b/".length).trim());
-			continue;
-		}
-		if (line.startsWith("--- a/")) {
-			touched.add(line.slice("--- a/".length).trim());
-			continue;
-		}
-		if (line.startsWith("diff --git ")) continue;
-		if (line.startsWith("@@")) continue;
-		if (line.startsWith("index ")) continue;
-		if (line.startsWith("new file mode")) continue;
-		if (line.startsWith("deleted file mode")) continue;
-		// Hunk body
-		if (line.startsWith("+") && !line.startsWith("+++")) added++;
-		else if (line.startsWith("-") && !line.startsWith("---")) removed++;
-	}
-	return {
-		touchedPaths: [...touched].filter((p) => p && p !== "/dev/null"),
-		addedLines: added,
-		removedLines: removed,
-	};
+function countLines(s: string): number {
+	if (s.length === 0) return 0;
+	return (s.match(/\n/g) ?? []).length + 1;
 }
 
 export function validatePatch(
@@ -101,39 +84,59 @@ export function validatePatch(
 	const maxLines = opts.maxDiffLines ?? DEFAULT_MAX_DIFF_LINES;
 	const errors: string[] = [];
 
-	if (!proposal.unifiedDiff || proposal.unifiedDiff.trim().length === 0) {
-		errors.push("empty unifiedDiff");
+	if (!proposal.edits || proposal.edits.length === 0) {
+		errors.push("empty edits");
 		return { ok: false, touchedPaths: [], addedLines: 0, removedLines: 0, errors };
 	}
 	if (!proposal.baseSha || proposal.baseSha.length < 7) {
 		errors.push("missing or short baseSha (need >= 7 chars)");
 	}
 
-	const { touchedPaths, addedLines, removedLines } = parseUnifiedDiff(proposal.unifiedDiff);
+	const touched = new Set<string>();
+	let added = 0;
+	let removed = 0;
 
-	if (touchedPaths.length === 0) {
-		errors.push("diff touches no files (or paths not parseable)");
+	for (const [i, e] of proposal.edits.entries()) {
+		if (!e.file || typeof e.file !== "string") {
+			errors.push(`edit[${i}] missing file`);
+			continue;
+		}
+		if (typeof e.old !== "string" || typeof e.new !== "string") {
+			errors.push(`edit[${i}] missing old/new strings`);
+			continue;
+		}
+		if (e.old.length === 0) {
+			errors.push(`edit[${i}] old string is empty (use a non-empty anchor)`);
+			continue;
+		}
+		if (e.old === e.new) {
+			errors.push(`edit[${i}] old === new (no-op)`);
+			continue;
+		}
+		touched.add(e.file);
+		removed += countLines(e.old);
+		added += countLines(e.new);
 	}
 
-	for (const p of touchedPaths) {
+	for (const p of touched) {
 		const allowedHit = allowed.some((prefix) => p.startsWith(prefix));
 		if (!allowedHit) {
 			errors.push(`path "${p}" outside allowlist [${allowed.join(", ")}]`);
 		}
 	}
 
-	const totalLines = addedLines + removedLines;
+	const totalLines = added + removed;
 	if (totalLines > maxLines) {
 		errors.push(
-			`diff size ${totalLines} lines (added ${addedLines}, removed ${removedLines}) exceeds maxDiffLines=${maxLines}`,
+			`patch size ${totalLines} lines (added ${added}, removed ${removed}) exceeds maxDiffLines=${maxLines}`,
 		);
 	}
 
 	return {
 		ok: errors.length === 0,
-		touchedPaths,
-		addedLines,
-		removedLines,
+		touchedPaths: [...touched],
+		addedLines: added,
+		removedLines: removed,
 		errors,
 	};
 }

--- a/scripts/autoresearch/promote-patch-via-pr.ts
+++ b/scripts/autoresearch/promote-patch-via-pr.ts
@@ -16,7 +16,7 @@
  *     check result, link to materializer notes.
  */
 
-import { execFileSync } from "node:child_process";
+import { safeExecFileSync as execFileSync } from "../lib/safe-exec.js";
 import type { MaterializePatchResult } from "./materialize-patch.js";
 import type { PatchProposal } from "./patch-proposal.js";
 

--- a/scripts/autoresearch/promote-via-pr.ts
+++ b/scripts/autoresearch/promote-via-pr.ts
@@ -26,7 +26,7 @@
  * deserve manual review, not regex surgery.
  */
 
-import { execFileSync } from "node:child_process";
+import { safeExecFileSync as execFileSync } from "../lib/safe-exec.js";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/scripts/autoresearch/sweep.ts
+++ b/scripts/autoresearch/sweep.ts
@@ -30,7 +30,7 @@
  * defaults. That gate stays manual until methodology is hardened.
  */
 
-import { execFileSync } from "node:child_process";
+import { safeExecFileSync as execFileSync } from "../lib/safe-exec.js";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";

--- a/scripts/autoresearch/sweep.ts
+++ b/scripts/autoresearch/sweep.ts
@@ -206,8 +206,14 @@ function runVariantOnCorpus(
 		"--output",
 		outFile,
 	];
+	// Pass the embedder API key via env, not argv. argv leaks into
+	// command-line strings inside Node's execFileSync error messages
+	// when the child process exits non-zero — observed live during
+	// patch-materialize sweeps where a missing dep crashed dogfood and
+	// the key showed up in stderr.
+	const childEnv: NodeJS.ProcessEnv = { ...process.env };
 	if (matrix.baseConfig.embedderKey) {
-		args.push("--embedder-key", matrix.baseConfig.embedderKey);
+		childEnv.WTFOC_EMBEDDER_KEY = matrix.baseConfig.embedderKey;
 	}
 	if (matrix.baseConfig.embedderCacheDir) {
 		args.push("--embedder-cache-dir", matrix.baseConfig.embedderCacheDir);
@@ -242,7 +248,7 @@ function runVariantOnCorpus(
 
 	logErr(`[sweep] running variant ${variant.variantId} on ${collection}`);
 	const t0 = performance.now();
-	execFileSync("pnpm", args, { stdio: ["ignore", "pipe", "inherit"] });
+	execFileSync("pnpm", args, { stdio: ["ignore", "pipe", "inherit"], env: childEnv });
 	const durationMs = performance.now() - t0;
 
 	const reportText = readFileSync(outFile, "utf-8");

--- a/scripts/dogfood.ts
+++ b/scripts/dogfood.ts
@@ -378,7 +378,7 @@ async function main() {
 						};
 					} else {
 						const rawEmbedder = new OpenAIEmbedder({
-							apiKey: values["embedder-key"] || values["extractor-key"] || "no-key",
+							apiKey: values["embedder-key"] || process.env.WTFOC_EMBEDDER_KEY || values["extractor-key"] || "no-key",
 							baseUrl: values["embedder-url"],
 							model: values["embedder-model"],
 						});
@@ -446,7 +446,7 @@ async function main() {
 						};
 					} else {
 						const rawEmbedder = new OpenAIEmbedder({
-							apiKey: values["embedder-key"] || values["extractor-key"] || "no-key",
+							apiKey: values["embedder-key"] || process.env.WTFOC_EMBEDDER_KEY || values["extractor-key"] || "no-key",
 							baseUrl: values["embedder-url"],
 							model: values["embedder-model"],
 							usageSink: embedderUsageSink,

--- a/scripts/lib/run-config.ts
+++ b/scripts/lib/run-config.ts
@@ -8,7 +8,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { execFileSync } from "node:child_process";
+import { safeExecFileSync as execFileSync } from "./safe-exec.js";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/scripts/lib/safe-exec.test.ts
+++ b/scripts/lib/safe-exec.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { redactSecrets } from "./safe-exec.js";
+
+describe("redactSecrets", () => {
+	it("redacts OpenRouter keys", () => {
+		const r = redactSecrets("error: pnpm tsx ... --embedder-key sk-or-v1-abc123def456ghi789jkl012 --extractor-url ...");
+		expect(r).not.toContain("sk-or-v1-abc123def456ghi789jkl012");
+		expect(r).toContain("<redacted>");
+	});
+
+	it("redacts Anthropic keys", () => {
+		const r = redactSecrets("Bearer sk-ant-api03-AbCdEfGhIjKlMnOpQrSt");
+		expect(r).not.toContain("sk-ant-api03");
+	});
+
+	it("redacts GitHub PATs", () => {
+		const r = redactSecrets("Authorization: token ghp_AbCdEfGhIjKlMnOpQrSt12345");
+		expect(r).not.toContain("ghp_AbCdEfGhIjKlMnOpQrSt12345");
+	});
+
+	it("redacts Bearer tokens", () => {
+		const r = redactSecrets("Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
+		expect(r).not.toContain("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
+		expect(r).toContain("<redacted>");
+	});
+
+	it("redacts --foo-key argv pairs", () => {
+		const r = redactSecrets("Command failed: pnpm tsx --embedder-key supersecretvalue --output foo");
+		expect(r).not.toContain("supersecretvalue");
+		expect(r).toContain("<redacted>");
+		expect(r).toContain("--output foo");
+	});
+
+	it("redacts --foo-key=value form", () => {
+		const r = redactSecrets("--api-key=supersecretvalue");
+		expect(r).not.toContain("supersecretvalue");
+		expect(r).toContain("--api-key=<redacted>");
+	});
+
+	it("redacts --foo-token argv pairs", () => {
+		const r = redactSecrets("--gh-token tokenvalue123");
+		expect(r).not.toContain("tokenvalue123");
+	});
+
+	it("leaves non-secret content untouched", () => {
+		const r = redactSecrets("normal log line with no secrets");
+		expect(r).toBe("normal log line with no secrets");
+	});
+});

--- a/scripts/lib/safe-exec.ts
+++ b/scripts/lib/safe-exec.ts
@@ -1,0 +1,74 @@
+/**
+ * Wrapper around node:child_process execFileSync that redacts secrets
+ * from error messages before re-throwing.
+ *
+ * Why: when a subprocess exits non-zero, Node includes the FULL argv
+ * in the thrown Error.message. Any caller passing an API key, OAuth
+ * token, or session cookie via argv leaks it the moment the child
+ * fails. Observed live: a buggy LLM patch caused TypeScript
+ * compilation in a sweep subprocess to fail, and OPENROUTER_API_KEY
+ * appeared verbatim in the cron-stderr log via the parent's stderr.
+ *
+ * Two-fold defense:
+ *   1. Code SHOULD prefer env vars over argv for secrets.
+ *   2. As defense-in-depth, this wrapper scrubs any token-shaped
+ *      strings from error messages — so a future regression that
+ *      reintroduces an argv secret cannot leak.
+ */
+
+import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
+
+const SECRET_PATTERNS: ReadonlyArray<RegExp> = [
+	/sk-or-v1-[A-Za-z0-9]{8,}/g,
+	/sk-ant-[A-Za-z0-9_-]{16,}/g,
+	/sk-proj-[A-Za-z0-9_-]{16,}/g,
+	/sk-[A-Za-z0-9]{20,}/g,
+	/ghp_[A-Za-z0-9]{20,}/g,
+	/gho_[A-Za-z0-9]{20,}/g,
+	/ghu_[A-Za-z0-9]{20,}/g,
+	/Bearer [A-Za-z0-9._-]{16,}/g,
+];
+
+function redactArgvPairs(s: string): string {
+	return s.replace(
+		/(--[a-z][a-z-]*-(?:key|token|secret|password))(\s+|=)\S+/gi,
+		(_full, flag, sep) => `${flag}${sep}<redacted>`,
+	);
+}
+
+export function redactSecrets(s: string): string {
+	let out = s;
+	for (const re of SECRET_PATTERNS) {
+		out = out.replace(re, "<redacted>");
+	}
+	out = redactArgvPairs(out);
+	return out;
+}
+
+// Mirror execFileSync's overload set so encoding-set callers still get
+// `string` back. Without this, callers that did `.trim()` on the result
+// see a `Buffer | string` union and have to cast.
+export function safeExecFileSync(
+	cmd: string,
+	args: readonly string[],
+	options: ExecFileSyncOptions & { encoding: BufferEncoding },
+): string;
+export function safeExecFileSync(
+	cmd: string,
+	args: readonly string[],
+	options?: ExecFileSyncOptions,
+): Buffer;
+export function safeExecFileSync(
+	cmd: string,
+	args: readonly string[],
+	options?: ExecFileSyncOptions,
+): Buffer | string {
+	try {
+		return execFileSync(cmd, args, options);
+	} catch (err) {
+		if (err instanceof Error) {
+			err.message = redactSecrets(err.message);
+		}
+		throw err;
+	}
+}


### PR DESCRIPTION
## Summary

Hardening pass uncovered during live end-to-end validation against the homelab vllm. Three commits, six concrete fixes that together unblock the patch path.

## Fixes by commit

### `b34c7fa` — first hardening pass

- DEFAULT_CURATED_FILES dropped non-existent `diversity.ts` (patch path was crashing with "no curated files readable")
- WTFOC_LLM_DISABLE_THINKING=1 → injects `chat_template_kwargs.enable_thinking=false` so reasoning models (AEON-class Qwen3.6) emit content directly
- WTFOC_LLM_MAX_TOKENS / WTFOC_LLM_PATCH_MAX_TOKENS env knobs
- `--force-patch` flag on autonomous-loop.ts for live patch-path validation
- `WTFOC_MIN_BASELINE` env honored by run-nightly.sh

### `8831abf` — search/replace + json_schema

- **Patch format**: unified-diff → `Edit[]` (search/replace `{file, old, new}`). Local LLMs reliably hallucinate `@@` line numbers, drop trailing context, and emit malformed hunk headers. 3/3 unified-diff attempts failed `git apply --check` against AEON. 1/1 search/replace applied cleanly. Materializer applies via exact-string with indent-tolerant fallback.
- **Output format**: `response_format: json_schema` (vllm xgrammar/Outlines). Forces valid JSON, prevents mid-string truncation, preserves tabs byte-exact. Disable via `WTFOC_LLM_NO_JSON_SCHEMA=1`.
- **API key leak fix**: sweep.ts no longer passes `--embedder-key` via argv. Now via `WTFOC_EMBEDDER_KEY` env. dogfood.ts reads either flag or env. Also: `MAX_FILE_CHARS` 8000 → 24000 so curated files aren't truncated mid-function. `pnpm install --frozen-lockfile --prefer-offline` runs in materialize-patch worktree so per-variant sweeps resolve workspace deps.

### `184ebf9` — defense-in-depth secret scrub

- `scripts/lib/safe-exec.ts` exports `safeExecFileSync`. Wraps `execFileSync`, redacts token-shaped strings from thrown error messages before re-throwing. Patterns scrubbed: `sk-or-v1-*`, `sk-ant-*`, `sk-proj-*`, `ghp_*`, `gho_*`, `ghu_*`, `Bearer <token>`, and any `--*-key/--*-token/--*-secret/--*-password <value>` argv pair.
- All `execFileSync` callers in `scripts/autoresearch/` and `scripts/lib/` swap to `safeExecFileSync`. Future regressions can't leak.

## Live validation results (homelab vllm + AEON)

Mechanical pipeline validated end-to-end on `feat/loop-validation-fixes` branch:

- ✅ chat ↔ rerank-gpu mode-switch (with retry-on-transient-fetch from #339)
- ✅ Sweep with BGE GPU reranker
- ✅ Detector finds breach with ≥3 baseline rows (4 gates failing on dogfood corpus)
- ✅ file-regression-issue posts to GitHub
- ✅ analyzeAndPropose emits valid Proposal (variant path)
- ✅ Variant materialize sweeps + decide() correctly rejects no-improvement
- ✅ analyzeAndProposePatch emits valid `{file, old, new}` edits via json_schema
- ✅ Patch applies (exact-string + indent-tolerant) → pnpm install → sweep → decide()
- ✅ Anti-overfit floor (per-corpus degradation cap 2pp)
- ✅ Two consecutive force-patch runs both ran the FULL chain cleanly.

## What's NOT validated yet

The mechanical pipeline works. The **search strategy** does not yet produce metric-moving patches. Peer review converged on the same diagnosis: the LLM is patching `query.ts`/`trace.ts` (downstream of the bug) for a `workLineage 3.7%` failure that is almost certainly upstream (extraction, graph build, or gold-fixture). See #343 for the tracking issue.

## Test plan

- [x] `pnpm exec vitest run scripts` — 236/237 (1 skipped)
- [x] `pnpm exec tsc -p scripts/tsconfig.json --noEmit` — clean
- [x] `pnpm lint:fix` — clean
- [x] `pnpm -r build` — clean
- [x] Live homelab e2e: 2 force-patch runs through full chain
- [ ] (gated on #343 forensics) enable nightly cron