### PR TITLE
feat(autoresearch): rule-based failure-diagnosis layer

### DIFF
--- a/packages/search/src/eval/failure-diagnosis.test.ts
+++ b/packages/search/src/eval/failure-diagnosis.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+import {
+	aggregateDiagnoses,
+	type DiagnosisScoreInput,
+	diagnoseFailure,
+} from "./failure-diagnosis.js";
+import type { GoldQuery } from "./gold-standard-queries.js";
+
+function makeQuery(partial: Partial<GoldQuery> & { id: string }): GoldQuery {
+	return {
+		authoredFromCollectionId: "alpha",
+		applicableCorpora: ["alpha"],
+		query: "q",
+		queryType: "lookup",
+		difficulty: "easy",
+		targetLayerHints: ["ranking"],
+		expectedEvidence: [],
+		acceptableAnswerFacts: [],
+		requiredSourceTypes: [],
+		minResults: 1,
+		...partial,
+	};
+}
+
+function makeScore(partial: Partial<DiagnosisScoreInput> & { id: string }): DiagnosisScoreInput {
+	return {
+		passed: false,
+		passedQueryOnly: false,
+		resultCount: 0,
+		requiredTypesFound: false,
+		substringFound: false,
+		edgeHopFound: true,
+		crossSourceFound: true,
+		...partial,
+	};
+}
+
+describe("diagnoseFailure", () => {
+	it("returns null when the query passed", () => {
+		const result = diagnoseFailure({
+			score: makeScore({ id: "q1", passed: true, passedQueryOnly: true }),
+			query: makeQuery({ id: "q1" }),
+		});
+		expect(result).toBeNull();
+	});
+
+	it("returns null when the query was skipped", () => {
+		const result = diagnoseFailure({
+			score: makeScore({ id: "q1", skipped: true }),
+			query: makeQuery({ id: "q1" }),
+		});
+		expect(result).toBeNull();
+	});
+
+	it("classifies preflight-invalid as fixture-invalid + fixture layer", () => {
+		const result = diagnoseFailure({
+			score: makeScore({ id: "q1" }),
+			query: makeQuery({ id: "q1" }),
+			preflightStatus: "invalid",
+			corpusId: "alpha",
+		});
+		expect(result?.failureClass).toBe("fixture-invalid");
+		expect(result?.layer).toBe("fixture");
+		expect(result?.evidence.goldInCatalog).toBe(false);
+		expect(result?.corpusId).toBe("alpha");
+	});
+
+	it("classifies a failed hard-negative as hard-negative-violated", () => {
+		const result = diagnoseFailure({
+			score: makeScore({ id: "hn-1" }),
+			query: makeQuery({ id: "hn-1", isHardNegative: true }),
+			preflightStatus: "applicable",
+		});
+		expect(result?.failureClass).toBe("hard-negative-violated");
+		expect(result?.layer).toBe("ranking");
+	});
+
+	it("classifies absent-from-widerK as gold-not-indexed + embedding layer", () => {
+		const result = diagnoseFailure({
+			score: makeScore({
+				id: "q1",
+				goldProximity: {
+					widerK: 50,
+					topKCutoff: 10,
+					goldRank: null,
+					goldScore: null,
+					topKLastScore: 0.4,
+				},
+			}),
+			query: makeQuery({ id: "q1" }),
+			preflightStatus: "applicable",
+		});
+		expect(result?.failureClass).toBe("gold-not-indexed");
+		expect(result?.layer).toBe("embedding");
+		expect(result?.evidence.retrievedInWiderK).toBe(false);
+	});
+
+	it("classifies retrieved-but-below-cutoff as retrieved-not-ranked + ranking layer", () => {
+		const result = diagnoseFailure({
+			score: makeScore({
+				id: "q1",
+				goldProximity: {
+					widerK: 50,
+					topKCutoff: 10,
+					goldRank: 14,
+					goldScore: 0.7,
+					topKLastScore: 0.5,
+				},
+			}),
+			query: makeQuery({ id: "q1" }),
+			preflightStatus: "applicable",
+		});
+		expect(result?.failureClass).toBe("retrieved-not-ranked");
+		expect(result?.layer).toBe("ranking");
+		expect(result?.evidence.finalRank).toBe(14);
+	});
+
+	it("classifies query-only-pass-but-trace-fail as missing-edge + edge-extraction when edgeHop required", () => {
+		const result = diagnoseFailure({
+			score: makeScore({
+				id: "q1",
+				passed: false,
+				passedQueryOnly: true,
+				requiredTypesFound: true,
+				substringFound: true,
+				edgeHopFound: false,
+			}),
+			query: makeQuery({ id: "q1", requireEdgeHop: true }),
+			preflightStatus: "applicable",
+		});
+		expect(result?.failureClass).toBe("missing-edge");
+		expect(result?.layer).toBe("edge-extraction");
+	});
+
+	it("classifies query-only-pass-but-trace-fail as missing-edge + trace when no edgeHop required", () => {
+		const result = diagnoseFailure({
+			score: makeScore({
+				id: "q1",
+				passed: false,
+				passedQueryOnly: true,
+				requiredTypesFound: true,
+				substringFound: true,
+				crossSourceFound: false,
+			}),
+			query: makeQuery({ id: "q1", requireCrossSourceHops: true }),
+			preflightStatus: "applicable",
+		});
+		expect(result?.failureClass).toBe("missing-edge");
+		expect(result?.layer).toBe("trace");
+	});
+
+	it("classifies missing-substring as retrieved-not-ranked + ranking", () => {
+		const result = diagnoseFailure({
+			score: makeScore({
+				id: "q1",
+				resultCount: 5,
+				requiredTypesFound: true,
+				substringFound: false,
+			}),
+			query: makeQuery({ id: "q1" }),
+			preflightStatus: "applicable",
+		});
+		expect(result?.failureClass).toBe("retrieved-not-ranked");
+		expect(result?.layer).toBe("ranking");
+	});
+
+	it("falls through to answer-synthesis + trace when the rubric is otherwise satisfied", () => {
+		const result = diagnoseFailure({
+			score: makeScore({
+				id: "q1",
+				resultCount: 5,
+				requiredTypesFound: true,
+				substringFound: true,
+				edgeHopFound: true,
+				crossSourceFound: false,
+			}),
+			query: makeQuery({ id: "q1" }),
+			preflightStatus: "applicable",
+		});
+		expect(result?.failureClass).toBe("answer-synthesis");
+		expect(result?.layer).toBe("trace");
+	});
+
+	it("populates evidence.retrievedInWiderK as null when goldProximity is unrecorded", () => {
+		const result = diagnoseFailure({
+			score: makeScore({
+				id: "q1",
+				resultCount: 1,
+				substringFound: false,
+			}),
+			query: makeQuery({ id: "q1" }),
+			preflightStatus: "applicable",
+		});
+		expect(result?.evidence.retrievedInWiderK).toBeNull();
+	});
+});
+
+describe("aggregateDiagnoses", () => {
+	it("counts per-class and per-layer totals", () => {
+		const agg = aggregateDiagnoses([
+			{
+				queryId: "q1",
+				corpusId: "alpha",
+				failureClass: "fixture-invalid",
+				layer: "fixture",
+				evidence: {} as never,
+			},
+			{
+				queryId: "q2",
+				corpusId: "alpha",
+				failureClass: "retrieved-not-ranked",
+				layer: "ranking",
+				evidence: {} as never,
+			},
+			{
+				queryId: "q3",
+				corpusId: "alpha",
+				failureClass: "retrieved-not-ranked",
+				layer: "ranking",
+				evidence: {} as never,
+			},
+		]);
+		expect(agg.totalFailures).toBe(3);
+		expect(agg.byFailureClass["retrieved-not-ranked"]).toBe(2);
+		expect(agg.byFailureClass["fixture-invalid"]).toBe(1);
+		expect(agg.byLayer.ranking).toBe(2);
+		expect(agg.byLayer.fixture).toBe(1);
+		expect(agg.dominantLayer).toBe("ranking");
+		expect(agg.dominantLayerShare).toBeCloseTo(2 / 3);
+	});
+
+	it("returns dominantLayer null when no diagnoses", () => {
+		const agg = aggregateDiagnoses([]);
+		expect(agg.totalFailures).toBe(0);
+		expect(agg.dominantLayer).toBeNull();
+		expect(agg.dominantLayerShare).toBe(0);
+	});
+});

--- a/packages/search/src/eval/failure-diagnosis.ts
+++ b/packages/search/src/eval/failure-diagnosis.ts
@@ -1,0 +1,315 @@
+import type { PreflightStatus } from "./catalog-applicability-preflight.js";
+import type { GoldQuery } from "./gold-standard-queries.js";
+
+/**
+ * Failure-classification layer for the autonomous-research loop (#344 step 3).
+ *
+ * For every failing gold query, emit a structured `FailureDiagnosis` that
+ * pins the failure to a single pipeline layer. The LLM patch-proposer is
+ * gated on this diagnosis: a "ranking-only" tier capsule cannot accept a
+ * patch for a failure diagnosed as `chunking` or `fixture`. This is exactly
+ * the gap that drove two no-op patches into review (#343 forensics) — the
+ * proposer was patching ranking for failures that lived upstream.
+ *
+ * Rules-based (NO LLM in this layer). Inputs are the per-query `QueryScore`,
+ * the source `GoldQuery`, and the corresponding preflight status for the
+ * (query, corpus) pair. Output is `null` when the query passed (no diagnosis
+ * needed) and a `FailureDiagnosis` object otherwise.
+ *
+ * @see https://github.com/SgtPooki/wtfoc/issues/344
+ */
+
+/**
+ * Pipeline layer the failure most likely lives in. The patch-proposer's
+ * tier-staged allowlist (#344 step 5) maps these values to the file paths it
+ * is permitted to edit per cycle.
+ */
+export type FailureLayer =
+	| "fixture"
+	| "ingest"
+	| "chunking"
+	| "embedding"
+	| "edge-extraction"
+	| "ranking"
+	| "trace";
+
+export type FailureClass =
+	| "fixture-invalid"
+	| "gold-not-indexed"
+	| "retrieved-not-ranked"
+	| "missing-edge"
+	| "answer-synthesis"
+	| "hard-negative-violated";
+
+export interface DiagnosisEvidence {
+	/**
+	 * `true` if the catalog-applicability preflight confirmed ≥1 required
+	 * artifact resolves in the corpus. `false` means the fixture itself is
+	 * the bug — no retrieval change can fix this query on this corpus.
+	 */
+	goldInCatalog: boolean;
+	/**
+	 * `true` if the wider top-50 retrieval surfaced ≥1 gold artifact (i.e.
+	 * `goldProximity.goldRank !== null`). `false` means the chunk is missing
+	 * from the vector index entirely (ingest/chunking layer) or the embedder
+	 * does not cluster it near the query (embedding layer).
+	 *
+	 * `null` when `goldProximity` is unavailable (recordGoldProximity was off
+	 * or the query has no gold supporting set). The classifier downgrades
+	 * confidence in that case.
+	 */
+	retrievedInWiderK: boolean | null;
+	/**
+	 * 1-indexed rank of the first gold hit in the wider candidate list. null
+	 * when the gold did not appear, or proximity was not recorded.
+	 */
+	finalRank: number | null;
+	/** True when `requiredSourceTypes` were satisfied (post-trace). */
+	requiredTypesMet: boolean;
+	/** True when `requireEdgeHop` was either not required or satisfied. */
+	edgeHopsMet: boolean;
+	/** True when `requireCrossSourceHops` was either not required or satisfied. */
+	crossSourceMet: boolean;
+	/** True when ≥1 `required:true` artifactId surfaced in retrieved sources. */
+	substringFound: boolean;
+	/** Gold-source proximity context, when available. */
+	goldRank: number | null;
+	topKCutoff: number | null;
+	widerK: number | null;
+}
+
+export interface FailureDiagnosis {
+	queryId: string;
+	corpusId: string | null;
+	failureClass: FailureClass;
+	layer: FailureLayer;
+	evidence: DiagnosisEvidence;
+}
+
+/**
+ * Minimal QueryScore-shaped input for diagnosis. Mirrors the relevant fields
+ * of `quality-queries-evaluator.QueryScore` so this module does not have to
+ * depend on the evaluator's internal types.
+ */
+export interface DiagnosisScoreInput {
+	id: string;
+	skipped?: boolean;
+	passed: boolean;
+	passedQueryOnly: boolean;
+	resultCount: number;
+	requiredTypesFound: boolean;
+	substringFound: boolean;
+	edgeHopFound: boolean;
+	crossSourceFound: boolean;
+	goldProximity?: {
+		widerK: number;
+		topKCutoff: number;
+		goldRank: number | null;
+		goldScore: number | null;
+		topKLastScore: number | null;
+	};
+}
+
+export interface DiagnoseFailureInput {
+	score: DiagnosisScoreInput;
+	query: GoldQuery;
+	corpusId?: string;
+	/**
+	 * Result of the catalog-applicability preflight for this (query, corpus)
+	 * pair. When `invalid`, the diagnosis short-circuits to `fixture-invalid`
+	 * — no retrieval change can pass this query.
+	 */
+	preflightStatus?: PreflightStatus;
+}
+
+/**
+ * Diagnose a single failed query. Returns `null` when the query passed or was
+ * skipped (skipped queries are not failures and don't need a diagnosis).
+ */
+export function diagnoseFailure(input: DiagnoseFailureInput): FailureDiagnosis | null {
+	const { score, query, corpusId, preflightStatus } = input;
+	if (score.skipped) return null;
+	if (score.passed) return null;
+
+	const goldRank = score.goldProximity?.goldRank ?? null;
+	const widerK = score.goldProximity?.widerK ?? null;
+	const topKCutoff = score.goldProximity?.topKCutoff ?? null;
+	const retrievedInWiderK =
+		score.goldProximity === undefined ? null : score.goldProximity.goldRank !== null;
+	const goldInCatalog = preflightStatus !== "invalid";
+
+	const evidence: DiagnosisEvidence = {
+		goldInCatalog,
+		retrievedInWiderK,
+		finalRank: goldRank,
+		requiredTypesMet: score.requiredTypesFound,
+		edgeHopsMet: score.edgeHopFound,
+		crossSourceMet: score.crossSourceFound,
+		substringFound: score.substringFound,
+		goldRank,
+		topKCutoff,
+		widerK,
+	};
+
+	// Rule 1 — preflight already flagged the fixture as invalid for this
+	// corpus. No retrieval change can pass this query; diagnosis pins to the
+	// fixture layer so the patch-proposer skips it entirely.
+	if (preflightStatus === "invalid") {
+		return {
+			queryId: query.id,
+			corpusId: corpusId ?? null,
+			failureClass: "fixture-invalid",
+			layer: "fixture",
+			evidence,
+		};
+	}
+
+	// Rule 2 — hard-negative inversion. A failed hard-negative means
+	// retrieval surfaced strong-looking false positives. This is a
+	// retrieve-not-ranked failure but with inverted intent — flag it
+	// distinctly so the patch-proposer doesn't try to "fix" it by
+	// surfacing more results.
+	if (query.isHardNegative) {
+		return {
+			queryId: query.id,
+			corpusId: corpusId ?? null,
+			failureClass: "hard-negative-violated",
+			layer: "ranking",
+			evidence,
+		};
+	}
+
+	// Rule 3 — gold was not in the wider top-K. Either the chunk is not
+	// indexed at all (chunking/ingest), or the embedder doesn't cluster it
+	// near the query (embedding). Without a separate lexical-rank signal
+	// we cannot distinguish chunking vs embedding deterministically — we
+	// pin to `embedding` because it is the more common cause when gold is
+	// in catalog but absent from wider retrieval; chunking-layer triage
+	// can override this in step-5 patch-capsule selection.
+	if (retrievedInWiderK === false) {
+		return {
+			queryId: query.id,
+			corpusId: corpusId ?? null,
+			failureClass: "gold-not-indexed",
+			layer: "embedding",
+			evidence,
+		};
+	}
+
+	// Rule 4 — gold IS retrievable in widerK but ranked below the cutoff.
+	// Pure ranking failure: a reranker / topK / boost change is the
+	// minimum-blast-radius fix.
+	if (
+		retrievedInWiderK === true &&
+		goldRank !== null &&
+		topKCutoff !== null &&
+		goldRank > topKCutoff
+	) {
+		return {
+			queryId: query.id,
+			corpusId: corpusId ?? null,
+			failureClass: "retrieved-not-ranked",
+			layer: "ranking",
+			evidence,
+		};
+	}
+
+	// Rule 5 — query-only passed but trace-rescued pass failed. The graph
+	// did not contribute additional evidence the rubric required. Pin to
+	// trace; if trace itself was empty (zero edges followed), step-5 may
+	// re-route to edge-extraction.
+	if (score.passedQueryOnly && !score.passed) {
+		const layer: FailureLayer =
+			query.requireEdgeHop && !score.edgeHopFound ? "edge-extraction" : "trace";
+		return {
+			queryId: query.id,
+			corpusId: corpusId ?? null,
+			failureClass: "missing-edge",
+			layer,
+			evidence,
+		};
+	}
+
+	// Rule 6 — required types absent or substring absent: ranking layer.
+	// (Substring matching is the legacy proxy for evidence presence and
+	// will switch to exact documentId match in step 3 fixture regen; until
+	// then a substring miss is still a ranking failure on the gold set.)
+	if (!score.requiredTypesFound || !score.substringFound) {
+		return {
+			queryId: query.id,
+			corpusId: corpusId ?? null,
+			failureClass: "retrieved-not-ranked",
+			layer: "ranking",
+			evidence,
+		};
+	}
+
+	// Default — answer-synthesis. Required types met, gold artifacts seen,
+	// but the trace assembly didn't reach the cross-source threshold or
+	// some other rubric component failed. Pin to trace.
+	return {
+		queryId: query.id,
+		corpusId: corpusId ?? null,
+		failureClass: "answer-synthesis",
+		layer: "trace",
+		evidence,
+	};
+}
+
+/**
+ * Aggregate diagnosis output for a corpus. Used by the eval reporter and the
+ * step-5 patch-capsule selector to decide which layer the LLM proposer is
+ * permitted to edit on this cycle.
+ */
+export interface DiagnosisAggregate {
+	totalFailures: number;
+	byFailureClass: Record<FailureClass, number>;
+	byLayer: Record<FailureLayer, number>;
+	dominantLayer: FailureLayer | null;
+	dominantLayerShare: number;
+}
+
+const ALL_FAILURE_CLASSES: FailureClass[] = [
+	"fixture-invalid",
+	"gold-not-indexed",
+	"retrieved-not-ranked",
+	"missing-edge",
+	"answer-synthesis",
+	"hard-negative-violated",
+];
+const ALL_LAYERS: FailureLayer[] = [
+	"fixture",
+	"ingest",
+	"chunking",
+	"embedding",
+	"edge-extraction",
+	"ranking",
+	"trace",
+];
+
+export function aggregateDiagnoses(diagnoses: ReadonlyArray<FailureDiagnosis>): DiagnosisAggregate {
+	const byFailureClass = Object.fromEntries(ALL_FAILURE_CLASSES.map((c) => [c, 0])) as Record<
+		FailureClass,
+		number
+	>;
+	const byLayer = Object.fromEntries(ALL_LAYERS.map((l) => [l, 0])) as Record<FailureLayer, number>;
+	for (const d of diagnoses) {
+		byFailureClass[d.failureClass]++;
+		byLayer[d.layer]++;
+	}
+	let dominantLayer: FailureLayer | null = null;
+	let dominantCount = 0;
+	for (const l of ALL_LAYERS) {
+		if (byLayer[l] > dominantCount) {
+			dominantCount = byLayer[l];
+			dominantLayer = l;
+		}
+	}
+	return {
+		totalFailures: diagnoses.length,
+		byFailureClass,
+		byLayer,
+		dominantLayer,
+		dominantLayerShare: diagnoses.length > 0 ? dominantCount / diagnoses.length : 0,
+	};
+}

--- a/packages/search/src/eval/quality-queries-evaluator.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.ts
@@ -10,6 +10,13 @@ import type {
 import { classifyQueryPersona } from "../persona/classify-query.js";
 import { query } from "../query.js";
 import { trace } from "../trace/trace.js";
+import type { PreflightStatus } from "./catalog-applicability-preflight.js";
+import {
+	aggregateDiagnoses,
+	type DiagnosisAggregate,
+	diagnoseFailure,
+	type FailureDiagnosis,
+} from "./failure-diagnosis.js";
 import {
 	GOLD_STANDARD_QUERIES,
 	GOLD_STANDARD_QUERIES_VERSION,
@@ -270,6 +277,14 @@ export interface QualityQueriesContext {
 	 * — widen K"). Default: respects WTFOC_GOLD_PROXIMITY=1 env.
 	 */
 	recordGoldProximity?: boolean;
+	/**
+	 * #344 step 3 — per-query catalog-applicability preflight status, keyed
+	 * by query id. When provided, the failure diagnosis classifier short-
+	 * circuits to `fixture-invalid` for any (query, corpus) pair the
+	 * preflight already flagged as invalid. Caller is responsible for
+	 * running the preflight against the same corpus the eval consumes.
+	 */
+	preflightStatusByQueryId?: ReadonlyMap<string, PreflightStatus>;
 }
 
 export async function evaluateQualityQueries(
@@ -324,6 +339,23 @@ export async function evaluateQualityQueries(
 		if (score.passed) passCount++;
 		if (score.passedQueryOnly) queryOnlyPassCount++;
 	}
+
+	// #344 step 3 — emit per-failure diagnosis records for the patch-capsule
+	// selector. The classifier is rules-based so this adds negligible cost.
+	const diagnoses: FailureDiagnosis[] = [];
+	for (let i = 0; i < scores.length; i++) {
+		const s = scores[i];
+		const gq = activeQueries[i];
+		if (!s || !gq) continue;
+		const d = diagnoseFailure({
+			score: s,
+			query: gq,
+			corpusId: context.collectionId,
+			preflightStatus: context.preflightStatusByQueryId?.get(gq.id),
+		});
+		if (d) diagnoses.push(d);
+	}
+	const diagnosisAggregate: DiagnosisAggregate = aggregateDiagnoses(diagnoses);
 
 	const applicableTotal = activeQueries.length - skippedCount;
 	const passRate = applicableTotal > 0 ? passCount / applicableTotal : 0;
@@ -499,6 +531,11 @@ export async function evaluateQualityQueries(
 			// measures the memorization-not-retrieval risk peer-review
 			// flagged at #311.
 			paraphraseInvariance: aggregateParaphraseInvariance(scores),
+			// #344 step 3 — failure diagnoses + aggregate. The patch-capsule
+			// selector consumes `diagnosisAggregate.dominantLayer` to scope
+			// the LLM proposer's allowlist for the next cycle.
+			diagnoses,
+			diagnosisAggregate,
 		},
 		checks,
 	};

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -24,6 +24,19 @@ export {
 	runPreflight,
 } from "./eval/catalog-applicability-preflight.js";
 export { evaluateEdgeResolution } from "./eval/edge-resolution-evaluator.js";
+export type {
+	DiagnoseFailureInput,
+	DiagnosisAggregate,
+	DiagnosisEvidence,
+	DiagnosisScoreInput,
+	FailureClass,
+	FailureDiagnosis,
+	FailureLayer,
+} from "./eval/failure-diagnosis.js";
+export {
+	aggregateDiagnoses,
+	diagnoseFailure,
+} from "./eval/failure-diagnosis.js";
 export {
 	type Difficulty,
 	type ExpectedEvidence,


### PR DESCRIPTION
## Summary

#344 step 3 — failure-diagnosis layer. For every failing gold query, the evaluator now emits a structured `FailureDiagnosis` pinning the failure to a single pipeline layer (`fixture | ingest | chunking | embedding | edge-extraction | ranking | trace`). The patch-proposer (#344 step 5) consumes the dominant layer to scope its allowlist per cycle, so a "ranking-only" tier capsule can't accept a patch for a `chunking` failure. Pure code; no LLM in this layer.

This addresses the #343 forensics finding directly: the prior LLM proposer kept emitting no-op patches against ranking for failures that lived upstream (extraction, chunking, fixture). Diagnosis is the gate that stops that.

## Reordering note

#344's body lists fixture regeneration (stratified-template recipe) as step 2 and diagnosis as step 3. I'm shipping diagnosis first because:

1. Diagnosis is pure code; fixture regeneration is wall-clock human curation.
2. The `fixture-invalid` failure class is *exactly* what surfaces a broken fixture loud enough to drive correct triage. The 47% invalid signal from #345 preflight will land in `fixture-invalid`, and the patch-proposer will skip those queries entirely instead of trying to patch ranking for them.
3. Fixture regeneration still gates cron, but can run in parallel.

## Classification rules

| # | Trigger | failureClass | layer |
|---|---|---|---|
| 1 | preflight = `invalid` | `fixture-invalid` | `fixture` |
| 2 | hard-negative failed | `hard-negative-violated` | `ranking` |
| 3 | gold absent from widerK | `gold-not-indexed` | `embedding` |
| 4 | gold ranked > topKCutoff | `retrieved-not-ranked` | `ranking` |
| 5a | queryOnly-passed + trace-failed + edgeHop required + missed | `missing-edge` | `edge-extraction` |
| 5b | queryOnly-passed + trace-failed (else) | `missing-edge` | `trace` |
| 6 | requiredTypes / substring miss | `retrieved-not-ranked` | `ranking` |
| 7 | default | `answer-synthesis` | `trace` |

## Wiring

- New module `packages/search/src/eval/failure-diagnosis.ts` — exports `diagnoseFailure()`, `aggregateDiagnoses()`, types. Public via `@wtfoc/search`.
- `quality-queries-evaluator` now runs `diagnoseFailure()` per failing scored query. Eval metrics include `diagnoses: FailureDiagnosis[]` and `diagnosisAggregate: { totalFailures, byFailureClass, byLayer, dominantLayer, dominantLayerShare }`.
- New context field `QualityQueriesContext.preflightStatusByQueryId` so the caller can pass preflight status keyed by query id for the rule-1 short-circuit.

## Test plan

- [x] 13 new unit tests covering every classification rule, null/skipped paths, aggregate shape, and dominantLayer tie/empty handling.
- [x] `pnpm test`: 1647 passed, 2 skipped (no regression vs main).
- [x] `pnpm lint:fix` clean.
- [x] `pnpm -r build` clean.

## Out of scope

- `decide()` rewrite (per-corpus floors + trimmed-mean of deltas + catastrophic-loss veto) — #344 step 4.
- Tier-staged patch capsules (LLM gets layer-scoped allowlist from `dominantLayer`) — #344 step 5.
- Stratified-template fixture regeneration — #344 step 2 (running in parallel; not gating this PR).
- Manual `--skip-pr` validation — #344 step 6.
- Nightly cron — #344 step 7.

refs #344