### PR TITLE
feat(autoresearch): decideMulti() with per-corpus floors + trimmed-mean + catastrophic veto

### DIFF
--- a/scripts/autoresearch/decision.test.ts
+++ b/scripts/autoresearch/decision.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ExtendedDogfoodReport, RunConfig } from "../lib/run-config.js";
-import { decide, DEFAULT_GATES } from "./decision.js";
+import { decide, decideMulti, DEFAULT_GATES, trimmedMean } from "./decision.js";
 
 interface ScoreOpts {
 	id: string;
@@ -252,5 +252,173 @@ describe("decide", () => {
 		// With identical baseline+candidate, no lift → reject.
 		expect(verdict.accept).toBe(false);
 		expect(DEFAULT_GATES.demoCriticalMin).toBe(1);
+	});
+});
+
+describe("trimmedMean", () => {
+	it("returns 0 on empty input", () => {
+		expect(trimmedMean([], 0.1)).toBe(0);
+	});
+	it("returns the single value when length=1", () => {
+		expect(trimmedMean([0.5], 0.1)).toBe(0.5);
+	});
+	it("returns the arithmetic mean when fraction=0", () => {
+		expect(trimmedMean([0.1, 0.2, 0.3], 0)).toBeCloseTo(0.2);
+	});
+	it("drops the highest and lowest tails", () => {
+		// 10 values; trim 10% drops 1 from each end → mean of middle 8.
+		const vals = [1, 2, 3, 4, 5, 6, 7, 8, 9, 100];
+		const mean = trimmedMean(vals, 0.1);
+		// middle 8 = 2..9 → mean 5.5
+		expect(mean).toBeCloseTo(5.5);
+	});
+	it("clamps absurd fractions instead of throwing", () => {
+		expect(trimmedMean([1, 2, 3], 0.99)).not.toBeNaN();
+	});
+});
+
+function makeMultiReport(passRate: number, scoreCount = 30): ExtendedDogfoodReport {
+	const scores = Array.from({ length: scoreCount }, (_, i) =>
+		score({ id: `q${i}`, passed: i / scoreCount < passRate }),
+	);
+	return makeReport({ scores, passRate });
+}
+
+describe("decideMulti", () => {
+	it("ACCEPTS when every must-pass corpus delta clears the floor and trimmed-mean clears minLift", () => {
+		const baseline = new Map([
+			["alpha", makeMultiReport(0.5)],
+			["beta", makeMultiReport(0.5)],
+		]);
+		const candidate = new Map([
+			["alpha", makeMultiReport(0.6)],
+			["beta", makeMultiReport(0.6)],
+		]);
+		const v = decideMulti({ baseline, candidate, cumulativeLocChange: 5 });
+		expect(v.accept).toBe(true);
+		expect(v.trimmedMeanDelta).toBeCloseTo(0.1, 1);
+		expect(v.perCorpus).toHaveLength(2);
+	});
+
+	it("REJECTS on per-corpus floor breach", () => {
+		const baseline = new Map([
+			["alpha", makeMultiReport(0.6)],
+			["beta", makeMultiReport(0.6)],
+		]);
+		// alpha gains 30pp, beta drops 10pp -> trimmed-mean still positive but
+		// must-pass floor on beta is -3pp by default.
+		const candidate = new Map([
+			["alpha", makeMultiReport(0.9)],
+			["beta", makeMultiReport(0.5)],
+		]);
+		const v = decideMulti({ baseline, candidate, cumulativeLocChange: 5 });
+		expect(v.accept).toBe(false);
+		expect(v.reasons.some((r) => r.includes('"beta"') && r.includes("below floor"))).toBe(true);
+	});
+
+	it("REJECTS on catastrophic loss veto regardless of mean", () => {
+		const baseline = new Map([
+			["alpha", makeMultiReport(0.6)],
+			["beta", makeMultiReport(0.6)],
+		]);
+		// beta drops 35pp — catastrophic floor is 30pp.
+		const candidate = new Map([
+			["alpha", makeMultiReport(0.95)],
+			["beta", makeMultiReport(0.25)],
+		]);
+		const v = decideMulti({ baseline, candidate, cumulativeLocChange: 5 });
+		expect(v.accept).toBe(false);
+		expect(v.reasons.some((r) => r.includes("catastrophic"))).toBe(true);
+	});
+
+	it("REJECTS on minMeaningfulLoC veto when patch is no-op", () => {
+		const baseline = new Map([["alpha", makeMultiReport(0.5)]]);
+		const candidate = new Map([["alpha", makeMultiReport(0.6)]]);
+		const v = decideMulti({ baseline, candidate, cumulativeLocChange: 0 });
+		expect(v.accept).toBe(false);
+		expect(v.reasons.some((r) => r.includes("LOC change"))).toBe(true);
+	});
+
+	it("REJECTS when trimmed-mean delta is below minLift even with no per-corpus breach", () => {
+		const baseline = new Map([
+			["alpha", makeMultiReport(0.6)],
+			["beta", makeMultiReport(0.6)],
+		]);
+		// Both gain 1pp.
+		const candidate = new Map([
+			["alpha", makeMultiReport(0.61)],
+			["beta", makeMultiReport(0.61)],
+		]);
+		const v = decideMulti({ baseline, candidate, cumulativeLocChange: 5 });
+		expect(v.accept).toBe(false);
+		expect(v.reasons.some((r) => r.includes("minLift"))).toBe(true);
+	});
+
+	it("REJECTS when query-type aggregate regresses past typeFloor", () => {
+		const baseScores = Array.from({ length: 30 }, (_, i) =>
+			score({ id: `q${i}`, passed: i < 18, category: "work-lineage" }),
+		);
+		const candScores = Array.from({ length: 30 }, (_, i) =>
+			score({ id: `q${i}`, passed: i < 24, category: "work-lineage" }),
+		);
+		const baseline = new Map([
+			[
+				"alpha",
+				makeReport({
+					scores: baseScores,
+					passRate: 0.6,
+					workLineage: 0.9,
+				}),
+			],
+		]);
+		const candidate = new Map([
+			[
+				"alpha",
+				makeReport({
+					scores: candScores,
+					passRate: 0.7,
+					// work-lineage drops to 0.8, delta -10pp, breaches typeFloor 5pp
+					workLineage: 0.8,
+				}),
+			],
+		]);
+		const v = decideMulti({ baseline, candidate, cumulativeLocChange: 5 });
+		const wlReason = v.reasons.find((r) => r.includes("work-lineage"));
+		expect(wlReason).toBeDefined();
+	});
+
+	it("treats single-corpus calls as a special case and accepts cleanly", () => {
+		const baseline = new Map([["alpha", makeMultiReport(0.5)]]);
+		const candidate = new Map([["alpha", makeMultiReport(0.7)]]);
+		const v = decideMulti({ baseline, candidate, cumulativeLocChange: 10 });
+		expect(v.accept).toBe(true);
+		expect(v.perCorpus).toHaveLength(1);
+	});
+
+	it("flags missing must-pass corpora", () => {
+		const baseline = new Map([["alpha", makeMultiReport(0.5)]]);
+		const candidate = new Map([["alpha", makeMultiReport(0.7)]]);
+		const v = decideMulti({
+			baseline,
+			candidate,
+			mustPassCorpora: ["alpha", "missing"],
+			cumulativeLocChange: 5,
+		});
+		expect(v.accept).toBe(false);
+		expect(v.reasons.some((r) => r.includes("missing"))).toBe(true);
+	});
+
+	it("emits perCorpus deltas in the verdict", () => {
+		const baseline = new Map([
+			["alpha", makeMultiReport(0.5)],
+			["beta", makeMultiReport(0.6)],
+		]);
+		const candidate = new Map([
+			["alpha", makeMultiReport(0.7)],
+			["beta", makeMultiReport(0.7)],
+		]);
+		const v = decideMulti({ baseline, candidate, cumulativeLocChange: 5 });
+		expect(v.perCorpus.find((p) => p.corpusId === "alpha")?.delta).toBeCloseTo(0.2, 1);
+		expect(v.perCorpus.find((p) => p.corpusId === "beta")?.delta).toBeCloseTo(0.1, 1);
 	});
 });

--- a/scripts/autoresearch/decision.test.ts
+++ b/scripts/autoresearch/decision.test.ts
@@ -281,7 +281,9 @@ function makeMultiReport(passRate: number, scoreCount = 30): ExtendedDogfoodRepo
 	const scores = Array.from({ length: scoreCount }, (_, i) =>
 		score({ id: `q${i}`, passed: i / scoreCount < passRate }),
 	);
-	return makeReport({ scores, passRate });
+	const actualPassRate =
+		scores.length === 0 ? 0 : scores.filter((entry) => entry.passed).length / scores.length;
+	return makeReport({ scores, passRate: actualPassRate });
 }
 
 describe("decideMulti", () => {
@@ -376,7 +378,7 @@ describe("decideMulti", () => {
 				"alpha",
 				makeReport({
 					scores: candScores,
-					passRate: 0.7,
+					passRate: 0.8,
 					// work-lineage drops to 0.8, delta -10pp, breaches typeFloor 5pp
 					workLineage: 0.8,
 				}),

--- a/scripts/autoresearch/decision.ts
+++ b/scripts/autoresearch/decision.ts
@@ -26,6 +26,237 @@ import type { ExtendedDogfoodReport } from "../lib/run-config.js";
 export const MIN_LIFT = 0.04;
 export const MIN_PROBABILITY = 0.95;
 
+/**
+ * #344 step 4 — multi-corpus decision rule.
+ *
+ * Replaces the legacy `sqrt(portable_v12 × portable_v3)` headline for accept/
+ * reject gating. Aggregate is a trimmed-mean of per-corpus pass-rate deltas;
+ * per-corpus and per-query-type floors prevent a single-corpus collapse from
+ * being averaged away; catastrophic-loss veto auto-rejects any corpus drop
+ * past `catastrophicFloor`; minMeaningfulLoC blocks zombie no-op patches.
+ *
+ * Drop geometric mean from gates. `headline.ts` may still emit it for
+ * legacy report compatibility, but the loop's accept decision lives here.
+ *
+ * @see https://github.com/SgtPooki/wtfoc/issues/344
+ */
+export const DEFAULT_TRIM_FRACTION = 0.1;
+export const DEFAULT_MUST_PASS_FLOOR = 0.03;
+export const DEFAULT_TYPE_FLOOR = 0.05;
+export const DEFAULT_CATASTROPHIC_FLOOR = 0.3;
+export const DEFAULT_MIN_MEANINGFUL_LOC = 1;
+
+export interface PerCorpusFloors {
+	/** Maximum tolerated delta drop on a must-pass corpus (default 3pp). */
+	mustPassFloor?: number;
+	/** Maximum tolerated delta drop on any query-type aggregate (default 5pp). */
+	typeFloor?: number;
+	/** Single-corpus drop that auto-rejects regardless of mean (default 30pp). */
+	catastrophicFloor?: number;
+	/** Trimming fraction for the per-corpus delta aggregate (default 10%). */
+	trimFraction?: number;
+	/** Minimum cumulative LOC change to consider non-no-op (default 1). */
+	minMeaningfulLoC?: number;
+	/** Minimum trimmed-mean delta to accept (default `MIN_LIFT`). */
+	minLift?: number;
+}
+
+export interface DecideMultiInputs {
+	/** Baseline reports keyed by corpus id. */
+	baseline: ReadonlyMap<string, ExtendedDogfoodReport>;
+	/** Candidate reports keyed by corpus id. */
+	candidate: ReadonlyMap<string, ExtendedDogfoodReport>;
+	/**
+	 * Corpora that must each clear `mustPassFloor`. When unset, every corpus
+	 * present in both baseline and candidate is treated as must-pass.
+	 */
+	mustPassCorpora?: ReadonlyArray<string>;
+	/** Optional per-corpus floor overrides; values take precedence over defaults. */
+	perCorpusFloorOverrides?: ReadonlyMap<string, number>;
+	/** Cumulative LOC change for the candidate patch. Required for LoC veto. */
+	cumulativeLocChange?: number;
+	/** Floors + thresholds; falls back to defaults. */
+	floors?: PerCorpusFloors;
+	/** Hard gates applied per-corpus on the candidate report. */
+	gates?: HardGates;
+}
+
+export interface PerCorpusDelta {
+	corpusId: string;
+	baselinePassRate: number;
+	candidatePassRate: number;
+	delta: number;
+	gateResults: DecisionVerdict["gateResults"];
+}
+
+export interface DecideMultiVerdict {
+	accept: boolean;
+	reasons: string[];
+	perCorpus: PerCorpusDelta[];
+	trimmedMeanDelta: number;
+	mustPassCorpora: string[];
+	queryTypeDeltas: Array<{ queryType: string; delta: number }>;
+	cumulativeLocChange: number | null;
+}
+
+/**
+ * Trimmed mean: drop the highest and lowest `fraction` of values then average
+ * the rest. With `fraction = 0` returns the arithmetic mean. With one value,
+ * returns that value (trim degenerates).
+ */
+export function trimmedMean(values: ReadonlyArray<number>, fraction: number): number {
+	if (values.length === 0) return 0;
+	if (values.length === 1) return values[0] ?? 0;
+	const sorted = [...values].sort((a, b) => a - b);
+	const drop = Math.floor(sorted.length * Math.max(0, Math.min(0.49, fraction)));
+	const sliced = sorted.slice(drop, sorted.length - drop);
+	if (sliced.length === 0) return 0;
+	const sum = sliced.reduce((a, b) => a + b, 0);
+	return sum / sliced.length;
+}
+
+function aggregateQueryTypeDeltas(
+	baseline: ReadonlyMap<string, ExtendedDogfoodReport>,
+	candidate: ReadonlyMap<string, ExtendedDogfoodReport>,
+): Array<{ queryType: string; delta: number }> {
+	const types = new Set<string>();
+	const baseTotals = new Map<string, { sum: number; n: number }>();
+	const candTotals = new Map<string, { sum: number; n: number }>();
+	for (const [, rep] of baseline) {
+		const m = qq(rep);
+		const cb = m?.categoryBreakdown ?? {};
+		for (const [t, v] of Object.entries(cb)) {
+			types.add(t);
+			const cur = baseTotals.get(t) ?? { sum: 0, n: 0 };
+			cur.sum += v?.passRate ?? 0;
+			cur.n += 1;
+			baseTotals.set(t, cur);
+		}
+	}
+	for (const [, rep] of candidate) {
+		const m = qq(rep);
+		const cb = m?.categoryBreakdown ?? {};
+		for (const [t, v] of Object.entries(cb)) {
+			types.add(t);
+			const cur = candTotals.get(t) ?? { sum: 0, n: 0 };
+			cur.sum += v?.passRate ?? 0;
+			cur.n += 1;
+			candTotals.set(t, cur);
+		}
+	}
+	const out: Array<{ queryType: string; delta: number }> = [];
+	for (const t of types) {
+		const b = baseTotals.get(t);
+		const c = candTotals.get(t);
+		if (!b || !c || b.n === 0 || c.n === 0) continue;
+		out.push({ queryType: t, delta: c.sum / c.n - b.sum / b.n });
+	}
+	return out.sort((a, b) => a.queryType.localeCompare(b.queryType));
+}
+
+export function decideMulti(input: DecideMultiInputs): DecideMultiVerdict {
+	const floors = input.floors ?? {};
+	const trim = floors.trimFraction ?? DEFAULT_TRIM_FRACTION;
+	const minLift = floors.minLift ?? MIN_LIFT;
+	const mustPassFloor = floors.mustPassFloor ?? DEFAULT_MUST_PASS_FLOOR;
+	const typeFloor = floors.typeFloor ?? DEFAULT_TYPE_FLOOR;
+	const catastrophicFloor = floors.catastrophicFloor ?? DEFAULT_CATASTROPHIC_FLOOR;
+	const minLoc = floors.minMeaningfulLoC ?? DEFAULT_MIN_MEANINGFUL_LOC;
+	const gates = input.gates ?? DEFAULT_GATES;
+
+	const sharedCorpora = Array.from(input.baseline.keys()).filter((k) =>
+		input.candidate.has(k),
+	);
+	const mustPass = input.mustPassCorpora ?? sharedCorpora;
+
+	const perCorpus: PerCorpusDelta[] = [];
+	for (const corpusId of sharedCorpora) {
+		const b = input.baseline.get(corpusId);
+		const c = input.candidate.get(corpusId);
+		if (!b || !c) continue;
+		const bm = qq(b);
+		const cm = qq(c);
+		const baselinePassRate = bm?.passRate ?? 0;
+		const candidatePassRate = cm?.passRate ?? 0;
+		perCorpus.push({
+			corpusId,
+			baselinePassRate,
+			candidatePassRate,
+			delta: candidatePassRate - baselinePassRate,
+			gateResults: evaluateGates(c, gates),
+		});
+	}
+
+	const reasons: string[] = [];
+
+	if (perCorpus.length === 0) {
+		reasons.push("no shared corpora between baseline and candidate");
+	}
+
+	const deltas = perCorpus.map((p) => p.delta);
+	const aggregate = trimmedMean(deltas, trim);
+	if (aggregate < minLift) {
+		reasons.push(
+			`trimmed-mean delta ${aggregate.toFixed(3)} < minLift ${minLift} (per-corpus deltas: ${deltas.map((d) => d.toFixed(3)).join(", ")})`,
+		);
+	}
+
+	for (const corpusId of mustPass) {
+		const entry = perCorpus.find((p) => p.corpusId === corpusId);
+		if (!entry) {
+			reasons.push(`must-pass corpus "${corpusId}" missing from baseline+candidate`);
+			continue;
+		}
+		const floor = input.perCorpusFloorOverrides?.get(corpusId) ?? mustPassFloor;
+		if (entry.delta < -floor) {
+			reasons.push(
+				`must-pass corpus "${corpusId}" delta ${entry.delta.toFixed(3)} below floor -${floor}`,
+			);
+		}
+	}
+
+	for (const entry of perCorpus) {
+		if (-entry.delta > catastrophicFloor) {
+			reasons.push(
+				`catastrophic loss on "${entry.corpusId}": delta ${entry.delta.toFixed(3)} > catastrophicFloor ${catastrophicFloor}`,
+			);
+		}
+		for (const g of entry.gateResults) {
+			if (!g.ok) {
+				reasons.push(
+					`hard gate "${g.name}" failed on "${entry.corpusId}": ${(g.actual * 100).toFixed(1)}% < ${(g.floor * 100).toFixed(1)}%`,
+				);
+			}
+		}
+	}
+
+	const queryTypeDeltas = aggregateQueryTypeDeltas(input.baseline, input.candidate);
+	for (const t of queryTypeDeltas) {
+		if (t.delta < -typeFloor) {
+			reasons.push(
+				`query-type "${t.queryType}" regressed: delta ${t.delta.toFixed(3)} < -typeFloor ${typeFloor}`,
+			);
+		}
+	}
+
+	const cumulativeLocChange = input.cumulativeLocChange ?? null;
+	if (cumulativeLocChange !== null && cumulativeLocChange < minLoc) {
+		reasons.push(
+			`cumulative LOC change ${cumulativeLocChange} < minMeaningfulLoC ${minLoc} — likely no-op`,
+		);
+	}
+
+	return {
+		accept: reasons.length === 0,
+		reasons,
+		perCorpus,
+		trimmedMeanDelta: aggregate,
+		mustPassCorpora: [...mustPass],
+		queryTypeDeltas,
+		cumulativeLocChange,
+	};
+}
+
 /** Hard gates that must hold regardless of bootstrap signal. */
 export interface HardGates {
 	overallMin: number;

--- a/scripts/autoresearch/decision.ts
+++ b/scripts/autoresearch/decision.ts
@@ -73,8 +73,12 @@ export interface DecideMultiInputs {
 	mustPassCorpora?: ReadonlyArray<string>;
 	/** Optional per-corpus floor overrides; values take precedence over defaults. */
 	perCorpusFloorOverrides?: ReadonlyMap<string, number>;
-	/** Cumulative LOC change for the candidate patch. Required for LoC veto. */
-	cumulativeLocChange?: number;
+	/**
+	 * Cumulative LOC change for the candidate patch. Required — passing
+	 * `undefined` is a schema error (caller did not measure the patch). Pass
+	 * `0` explicitly for a no-op patch and the LoC veto will reject it.
+	 */
+	cumulativeLocChange: number;
 	/** Floors + thresholds; falls back to defaults. */
 	floors?: PerCorpusFloors;
 	/** Hard gates applied per-corpus on the candidate report. */
@@ -96,7 +100,7 @@ export interface DecideMultiVerdict {
 	trimmedMeanDelta: number;
 	mustPassCorpora: string[];
 	queryTypeDeltas: Array<{ queryType: string; delta: number }>;
-	cumulativeLocChange: number | null;
+	cumulativeLocChange: number;
 }
 
 /**
@@ -218,7 +222,7 @@ export function decideMulti(input: DecideMultiInputs): DecideMultiVerdict {
 	for (const entry of perCorpus) {
 		if (-entry.delta > catastrophicFloor) {
 			reasons.push(
-				`catastrophic loss on "${entry.corpusId}": delta ${entry.delta.toFixed(3)} > catastrophicFloor ${catastrophicFloor}`,
+				`catastrophic loss on "${entry.corpusId}": drop ${(-entry.delta).toFixed(3)} > catastrophicFloor ${catastrophicFloor}`,
 			);
 		}
 		for (const g of entry.gateResults) {
@@ -239,8 +243,8 @@ export function decideMulti(input: DecideMultiInputs): DecideMultiVerdict {
 		}
 	}
 
-	const cumulativeLocChange = input.cumulativeLocChange ?? null;
-	if (cumulativeLocChange !== null && cumulativeLocChange < minLoc) {
+	const cumulativeLocChange = input.cumulativeLocChange;
+	if (cumulativeLocChange < minLoc) {
 		reasons.push(
 			`cumulative LOC change ${cumulativeLocChange} < minMeaningfulLoC ${minLoc} — likely no-op`,
 		);
@@ -253,7 +257,7 @@ export function decideMulti(input: DecideMultiInputs): DecideMultiVerdict {
 		trimmedMeanDelta: aggregate,
 		mustPassCorpora: [...mustPass],
 		queryTypeDeltas,
-		cumulativeLocChange,
+		cumulativeLocChange: cumulativeLocChange,
 	};
 }
 


### PR DESCRIPTION
## Summary

#344 step 4. Replaces the legacy `sqrt(portable_v12 × portable_v3)` geometric-mean headline as the autoresearch loop's accept-gate with a multi-corpus aggregate that punishes single-corpus collapse instead of averaging it away.

## Decision rule

Accept iff **all** of:

| Gate | Default | Knob |
|---|---|---|
| `trimmedMean(perCorpusDeltas, fraction=10%) >= minLift` | 4pp | `floors.minLift` |
| Every must-pass corpus delta `>= -mustPassFloor` | -3pp | `floors.mustPassFloor`, `perCorpusFloorOverrides` |
| Every query-type aggregate delta `>= -typeFloor` | -5pp | `floors.typeFloor` |
| No single-corpus drop `> catastrophicFloor` | 30pp | `floors.catastrophicFloor` |
| `cumulativeLocChange >= minMeaningfulLoC` | 1 | `floors.minMeaningfulLoC` |
| Every per-corpus hard gate (`DEFAULT_GATES`) passes | existing | `gates` |

`mustPassCorpora` defaults to every shared corpus key; pass a subset to require only those. `perCorpusFloorOverrides: Map<corpusId, floor>` lets the caller tighten floors per corpus type — the knob flagged for non-code lanes in #344 step 2.

## What's NOT in this PR

- `headline.ts` still emits `sqrt(portable_v12 × portable_v3)` for legacy report compatibility. The loop's gate moved here; cleanup of the headline scalar is a separate small follow-up once no consumer reads it.
- The single-corpus `decide()` is unchanged; bootstrap + paired-CI signal still useful where applicable.
- Wiring `decideMulti()` into the autoresearch loop's promotion path — small follow-up that swaps `decide()` call sites once the autonomous loop runs against multi-corpus baselines (gated on #344 step 2 corpora ingestion).

## Test plan

- [x] 11 new unit tests cover trimmed-mean math (empty/single/clamping/tail-drop), per-corpus floor breach, catastrophic veto, LOC veto, minLift floor, query-type regression, missing must-pass corpus, single-corpus delegation, perCorpus delta surface.
- [x] `pnpm test`: 1661 passed, 2 skipped.
- [x] `pnpm lint:fix` clean.
- [x] `pnpm -r build` clean.

refs #344