### PR TITLE
feat(autoresearch): tier-staged patch capsule selector

### DIFF
--- a/scripts/autoresearch/patch-capsule.test.ts
+++ b/scripts/autoresearch/patch-capsule.test.ts
@@ -1,0 +1,123 @@
+import type { FailureLayer } from "@wtfoc/search";
+import { describe, expect, it } from "vitest";
+import {
+	assertNoFrozenLeak,
+	selectPatchCapsule,
+	TIER_0_FROZEN_PATHS,
+	TIER_1_RANKING_PATHS,
+	TIER_2_CHUNKING_EMBEDDING_PATHS,
+	TIER_3_EXTRACTORS_PATHS,
+} from "./patch-capsule.js";
+
+describe("selectPatchCapsule", () => {
+	it("returns null for human-only fixture layer", () => {
+		expect(selectPatchCapsule("fixture")).toBeNull();
+	});
+
+	it("returns null for human-only ingest layer", () => {
+		expect(selectPatchCapsule("ingest")).toBeNull();
+	});
+
+	it("returns null when dominantLayer is null (no failures)", () => {
+		expect(selectPatchCapsule(null)).toBeNull();
+	});
+
+	it("ranking layer maps to Tier 1 only", () => {
+		const c = selectPatchCapsule("ranking");
+		expect(c).not.toBeNull();
+		expect(c?.tiers).toEqual([1]);
+		expect(c?.allowedPaths).toEqual(TIER_1_RANKING_PATHS);
+	});
+
+	it("trace layer maps to Tier 1 only (trace.ts is in Tier 1)", () => {
+		const c = selectPatchCapsule("trace");
+		expect(c?.tiers).toEqual([1]);
+		expect(c?.allowedPaths).toEqual(TIER_1_RANKING_PATHS);
+	});
+
+	it("embedding layer opens Tier 1+2", () => {
+		const c = selectPatchCapsule("embedding");
+		expect(c?.tiers).toEqual([1, 2]);
+		expect(c?.allowedPaths).toEqual([
+			...TIER_1_RANKING_PATHS,
+			...TIER_2_CHUNKING_EMBEDDING_PATHS,
+		]);
+	});
+
+	it("chunking layer opens Tier 1+2", () => {
+		const c = selectPatchCapsule("chunking");
+		expect(c?.tiers).toEqual([1, 2]);
+	});
+
+	it("edge-extraction layer opens Tier 1+3", () => {
+		const c = selectPatchCapsule("edge-extraction");
+		expect(c?.tiers).toEqual([1, 3]);
+		expect(c?.allowedPaths).toEqual([
+			...TIER_1_RANKING_PATHS,
+			...TIER_3_EXTRACTORS_PATHS,
+		]);
+	});
+
+	it("every capsule includes a description and curatedFiles", () => {
+		const layers: FailureLayer[] = ["ranking", "trace", "embedding", "chunking", "edge-extraction"];
+		for (const layer of layers) {
+			const c = selectPatchCapsule(layer);
+			expect(c?.description.length, `${layer} description`).toBeGreaterThan(0);
+			expect(c?.curatedFiles.length, `${layer} curatedFiles`).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe("Tier 0 frozen invariant", () => {
+	it("Tier 1 paths do not overlap Tier 0", () => {
+		for (const p of TIER_1_RANKING_PATHS) {
+			for (const f of TIER_0_FROZEN_PATHS) {
+				expect(p.startsWith(f), `Tier 1 path "${p}" overlaps frozen "${f}"`).toBe(false);
+				expect(f.startsWith(p), `Frozen "${f}" overlaps Tier 1 "${p}"`).toBe(false);
+			}
+		}
+	});
+
+	it("Tier 2 paths do not overlap Tier 0", () => {
+		for (const p of TIER_2_CHUNKING_EMBEDDING_PATHS) {
+			for (const f of TIER_0_FROZEN_PATHS) {
+				expect(p.startsWith(f), `Tier 2 "${p}" overlaps frozen "${f}"`).toBe(false);
+				expect(f.startsWith(p), `Frozen "${f}" overlaps Tier 2 "${p}"`).toBe(false);
+			}
+		}
+	});
+
+	it("Tier 3 paths do not overlap Tier 0", () => {
+		for (const p of TIER_3_EXTRACTORS_PATHS) {
+			for (const f of TIER_0_FROZEN_PATHS) {
+				expect(p.startsWith(f), `Tier 3 "${p}" overlaps frozen "${f}"`).toBe(false);
+				expect(f.startsWith(p), `Frozen "${f}" overlaps Tier 3 "${p}"`).toBe(false);
+			}
+		}
+	});
+
+	it("assertNoFrozenLeak passes for every selectable capsule", () => {
+		for (const layer of [
+			"ranking",
+			"trace",
+			"embedding",
+			"chunking",
+			"edge-extraction",
+		] as FailureLayer[]) {
+			const c = selectPatchCapsule(layer);
+			if (c) expect(() => assertNoFrozenLeak(c)).not.toThrow();
+		}
+	});
+
+	it("assertNoFrozenLeak throws when a capsule includes a frozen prefix", () => {
+		expect(() =>
+			assertNoFrozenLeak({
+				dominantLayer: "ranking",
+				tiers: [1],
+				allowedPaths: ["packages/search/src/eval/sneaky.ts"],
+				curatedFiles: [],
+				description: "leak test",
+			}),
+		).toThrow(/Tier 0 frozen path leak/);
+	});
+});

--- a/scripts/autoresearch/patch-capsule.ts
+++ b/scripts/autoresearch/patch-capsule.ts
@@ -1,0 +1,175 @@
+/**
+ * Tier-staged patch capsule selector for the autoresearch LLM proposer (#344
+ * step 5). Maps `diagnosisAggregate.dominantLayer` to a layer-scoped patch
+ * surface so the proposer can only edit files relevant to the diagnosed
+ * failure layer. The frozen tier (graders, fixtures, scorer, runner, gold
+ * paths) NEVER appears in any capsule — this is what stops the loop from
+ * "fixing" a regression by relaxing the test.
+ *
+ * Tier hierarchy (per #344):
+ *
+ *   Tier 0 — graders/fixtures/scorer/runner  (FROZEN, never patchable)
+ *   Tier 1 — query.ts, trace.ts, ranking weights / rerankers
+ *   Tier 2 — chunking + segmentation + embedding namespaces
+ *   Tier 3 — extractors + edge-type registry
+ *   Tier 4 — ingest adapters + schemas        (HUMAN-ONLY, never patchable)
+ *
+ * Layer → capsule mapping:
+ *
+ *   fixture          -> null (Tier 4 / human; skip cycle)
+ *   ingest           -> null (Tier 4 / human; skip cycle)
+ *   ranking          -> Tier 1
+ *   trace            -> Tier 1 (trace.ts already in Tier 1)
+ *   embedding        -> Tier 1 + Tier 2
+ *   chunking         -> Tier 1 + Tier 2
+ *   edge-extraction  -> Tier 1 + Tier 3
+ *
+ * Why include Tier 1 alongside higher tiers: when diagnosis pins to chunking
+ * or extraction, the ranking layer is often a co-conspirator (e.g. a chunk
+ * boundary change interacts with type-boost weights). Letting the proposer
+ * see both surfaces in the same capsule prevents "fix one layer, regress
+ * another" oscillation that strict single-tier capsules would produce.
+ *
+ * @see https://github.com/SgtPooki/wtfoc/issues/344
+ */
+
+import type { FailureLayer } from "@wtfoc/search";
+
+/** Numeric tier identifier — purely for documentation / debugging. */
+export type Tier = 0 | 1 | 2 | 3 | 4;
+
+export interface PatchCapsule {
+	/** Layer the capsule was selected for (drives the tier set). */
+	dominantLayer: FailureLayer;
+	/** Tiers the LLM proposer may edit on this cycle (sorted ascending). */
+	tiers: Tier[];
+	/**
+	 * Path prefixes the patch validator (`validatePatch.allowedPaths`)
+	 * accepts on this cycle. The proposer's tools enforce these on the
+	 * applied diff; the validator enforces them again on the proposal.
+	 */
+	allowedPaths: readonly string[];
+	/**
+	 * Files inlined verbatim into the LLM prompt (override the analyzer's
+	 * `curatedFiles`). Keep small; the prompt budget is finite.
+	 */
+	curatedFiles: readonly string[];
+	/** Short human-readable description for the proposal record / PR body. */
+	description: string;
+}
+
+/**
+ * Tier 0 — FROZEN. These paths never appear in any capsule. The validator
+ * still uses the standard allowlist as a backstop, but the capsule selector
+ * deliberately omits them so even a misconfigured allowlist cannot leak.
+ */
+export const TIER_0_FROZEN_PATHS: readonly string[] = [
+	"packages/search/src/eval/",
+	"scripts/autoresearch/decision.ts",
+	"scripts/autoresearch/decision.test.ts",
+	"scripts/autoresearch/headline.ts",
+	"scripts/autoresearch/headline.test.ts",
+	"scripts/dogfood.ts",
+];
+
+export const TIER_1_RANKING_PATHS: readonly string[] = [
+	"packages/search/src/query.ts",
+	"packages/search/src/trace/",
+	"packages/search/src/rerankers/",
+	"packages/search/src/persona/",
+];
+
+export const TIER_2_CHUNKING_EMBEDDING_PATHS: readonly string[] = [
+	"packages/ingest/src/chunkers/",
+	"packages/ingest/src/segment-builder.ts",
+	"packages/search/src/embedders/",
+	"packages/search/src/index/",
+];
+
+export const TIER_3_EXTRACTORS_PATHS: readonly string[] = [
+	"packages/ingest/src/edges/",
+	"packages/search/src/edge-resolution.ts",
+];
+
+/** Tier 1 default curated set (matches the analyzer's pre-#344 default). */
+export const TIER_1_CURATED: readonly string[] = [
+	"packages/search/src/query.ts",
+	"packages/search/src/trace/trace.ts",
+];
+
+export const TIER_2_CURATED: readonly string[] = [
+	"packages/search/src/query.ts",
+	"packages/ingest/src/chunkers/index.ts",
+	"packages/ingest/src/segment-builder.ts",
+];
+
+export const TIER_3_CURATED: readonly string[] = [
+	"packages/search/src/query.ts",
+	"packages/search/src/trace/trace.ts",
+	"packages/search/src/edge-resolution.ts",
+];
+
+/**
+ * Select a tier-staged patch capsule for the next LLM proposal cycle.
+ *
+ * Returns `null` when the diagnosed layer is human-only (`fixture` or
+ * `ingest`). The autoresearch loop should skip patch generation for that
+ * cycle and emit a triage marker instead — there is no LLM patch surface
+ * that can fix a fixture or ingest-adapter problem without human review.
+ */
+export function selectPatchCapsule(dominantLayer: FailureLayer | null): PatchCapsule | null {
+	if (dominantLayer === null) return null;
+	switch (dominantLayer) {
+		case "fixture":
+		case "ingest":
+			return null;
+		case "ranking":
+		case "trace":
+			return {
+				dominantLayer,
+				tiers: [1],
+				allowedPaths: TIER_1_RANKING_PATHS,
+				curatedFiles: TIER_1_CURATED,
+				description: `Tier 1 (ranking + trace) capsule — diagnosis pinned to "${dominantLayer}".`,
+			};
+		case "embedding":
+		case "chunking":
+			return {
+				dominantLayer,
+				tiers: [1, 2],
+				allowedPaths: [...TIER_1_RANKING_PATHS, ...TIER_2_CHUNKING_EMBEDDING_PATHS],
+				curatedFiles: TIER_2_CURATED,
+				description: `Tier 1+2 (ranking + chunking/embedding) capsule — diagnosis pinned to "${dominantLayer}".`,
+			};
+		case "edge-extraction":
+			return {
+				dominantLayer,
+				tiers: [1, 3],
+				allowedPaths: [...TIER_1_RANKING_PATHS, ...TIER_3_EXTRACTORS_PATHS],
+				curatedFiles: TIER_3_CURATED,
+				description: `Tier 1+3 (ranking + extractors) capsule — diagnosis pinned to "edge-extraction".`,
+			};
+		default: {
+			// Exhaustive switch — TS will flag if a new FailureLayer is added.
+			const _exhaustive: never = dominantLayer;
+			return _exhaustive;
+		}
+	}
+}
+
+/**
+ * Assert that a capsule's `allowedPaths` does not overlap any Tier 0 frozen
+ * path. Defensive — the selector should never produce one, but a regression
+ * here is silent failure of the human-only invariant.
+ */
+export function assertNoFrozenLeak(capsule: PatchCapsule): void {
+	for (const p of capsule.allowedPaths) {
+		for (const frozen of TIER_0_FROZEN_PATHS) {
+			if (p.startsWith(frozen) || frozen.startsWith(p)) {
+				throw new Error(
+					`patch-capsule: Tier 0 frozen path leak — capsule for layer "${capsule.dominantLayer}" exposes "${p}" which overlaps frozen prefix "${frozen}"`,
+				);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

#344 step 5. Tier-staged patch capsule selector. Maps `diagnosisAggregate.dominantLayer` (from #347) to a layer-scoped patch surface so the LLM proposer can only edit files relevant to the diagnosed failure layer. Tier 0 (graders / fixtures / scorer / runner / gold paths) NEVER appears in any capsule — this is the invariant that stops the loop from "fixing" a regression by relaxing the test.

## Tier hierarchy

| Tier | Scope | Status |
|---|---|---|
| 0 | `packages/search/src/eval/`, `decision.ts`, `headline.ts`, `dogfood.ts` | **FROZEN** |
| 1 | `query.ts`, `trace/`, `rerankers/`, `persona/` | Default |
| 2 | ingest `chunkers/`, `segment-builder.ts`, search `embedders/`, `index/` | Diagnosis-gated |
| 3 | ingest `edges/`, `edge-resolution.ts` | Diagnosis-gated |
| 4 | ingest adapters + schemas | **HUMAN-ONLY** |

## Layer → capsule

| `dominantLayer` | Tiers | Note |
|---|---|---|
| `fixture` | — | `null`; skip cycle, human triage |
| `ingest` | — | `null`; skip cycle, human triage |
| `ranking` | 1 | |
| `trace` | 1 | `trace.ts` already in Tier 1 |
| `embedding` | 1 + 2 | |
| `chunking` | 1 + 2 | |
| `edge-extraction` | 1 + 3 | |

Tier 1 is included alongside higher tiers because failures pinned to chunking or extraction frequently have ranking-layer co-conspirators (a chunk-boundary change interacts with type-boost weights). Single-tier capsules would produce fix-one-layer / regress-another oscillation.

## Public API

- `selectPatchCapsule(dominantLayer): PatchCapsule | null`
- `PatchCapsule { dominantLayer, tiers, allowedPaths, curatedFiles, description }`
- `assertNoFrozenLeak(capsule)` defensive — throws if any allowed path overlaps Tier 0
- `TIER_0_FROZEN_PATHS`, `TIER_1_RANKING_PATHS`, `TIER_2_CHUNKING_EMBEDDING_PATHS`, `TIER_3_EXTRACTORS_PATHS`

The autoresearch loop's wiring layer can pass `capsule.allowedPaths` straight into `validatePatch.allowedPaths` and `capsule.curatedFiles` into `analyze-and-propose-patch.curatedFiles`.

## Out of scope

- Wiring `selectPatchCapsule()` into the autoresearch loop's proposal path (small follow-up once the loop runs against multi-corpus baselines and the diagnosis aggregate is threaded through — gated on #344 step 2 corpora ingestion).
- Step 6 (manual `--skip-pr` validation against the new gates).
- Step 7 (enable nightly cron).
- Step 2 (stratified-template fixture regeneration; running in parallel).

## Test plan

- [x] 14 new unit tests cover every layer mapping (including `fixture`/`ingest` → `null`), the Tier 0 frozen invariant (no path in any other tier overlaps Tier 0), and `assertNoFrozenLeak` positive + negative cases.
- [x] `pnpm test`: 1675 passed, 2 skipped.
- [x] `pnpm lint:fix` clean.
- [x] `pnpm -r build` clean.

refs #344