### PR TITLE
test(autoresearch): wiring integration tests for diagnosis + capsule routing

### DIFF
--- a/scripts/autoresearch/autonomous-loop-wiring.test.ts
+++ b/scripts/autoresearch/autonomous-loop-wiring.test.ts
@@ -1,0 +1,162 @@
+import type { DiagnosisAggregate, FailureLayer } from "@wtfoc/search";
+import { describe, expect, it } from "vitest";
+import type { ExtendedDogfoodReport } from "../lib/run-config.js";
+import { extractDominantLayer } from "./autonomous-loop.js";
+import { selectPatchCapsule } from "./patch-capsule.js";
+
+/**
+ * Wiring integration test for the diagnosis -> capsule routing path
+ * (#344 step 5 / #350). Exercises the same function chain `runPatchPath`
+ * uses, so a regression that breaks the routing surfaces here in CI
+ * without needing a live LLM or homelab GPU.
+ *
+ * The end-to-end live validation lives in step 6 of #344 and runs against
+ * the real autoresearch loop on the maintainer's homelab.
+ */
+
+function makeReport(
+	dominantLayer: FailureLayer | null,
+	overrides?: Partial<DiagnosisAggregate>,
+): ExtendedDogfoodReport {
+	const aggregate: DiagnosisAggregate = {
+		totalFailures: dominantLayer === null ? 0 : 5,
+		byFailureClass: {
+			"fixture-invalid": 0,
+			"gold-not-indexed": 0,
+			"retrieved-not-ranked": 0,
+			"missing-edge": 0,
+			"answer-synthesis": 0,
+			"hard-negative-violated": 0,
+		},
+		byLayer: {
+			fixture: 0,
+			ingest: 0,
+			chunking: 0,
+			embedding: 0,
+			"edge-extraction": 0,
+			ranking: 0,
+			trace: 0,
+		},
+		dominantLayer,
+		dominantLayerShare: dominantLayer === null ? 0 : 1,
+		...overrides,
+	};
+	return {
+		reportSchemaVersion: "1.0.0",
+		timestamp: new Date().toISOString(),
+		collectionId: "alpha",
+		collectionName: "alpha",
+		stages: [
+			{
+				stage: "quality-queries",
+				startedAt: "",
+				durationMs: 0,
+				verdict: "pass",
+				summary: "",
+				metrics: { diagnosisAggregate: aggregate },
+				checks: [],
+			},
+		],
+		verdict: "pass",
+		durationMs: 0,
+		runConfig: {
+			collectionId: "alpha",
+			corpusDigest: "x",
+			goldFixtureVersion: "2.0.0",
+			goldFixtureHash: "h",
+			embedder: { url: "u", model: "m" },
+			extractor: null,
+			reranker: null,
+			grader: null,
+			retrieval: {
+				topK: 10,
+				traceMaxPerSource: 3,
+				traceMaxTotal: 15,
+				traceMaxHops: 3,
+				traceMinScore: 0.3,
+				traceMode: "analytical",
+				autoRoute: false,
+				diversityEnforce: false,
+			},
+			evaluation: { checkParaphrases: false, groundCheck: false },
+			promptHashes: {},
+			seed: 0,
+			gitSha: null,
+			packageVersions: {},
+			nodeVersion: "24.11",
+			cacheNamespaceSchemeVersion: 1,
+		},
+		runConfigFingerprint: "fp",
+		fingerprintVersion: 1,
+	};
+}
+
+describe("extractDominantLayer", () => {
+	it("returns null when the report is null", () => {
+		expect(extractDominantLayer(null)).toBeNull();
+	});
+
+	it("returns null when there is no quality-queries stage", () => {
+		const report = makeReport("ranking");
+		report.stages = [];
+		expect(extractDominantLayer(report)).toBeNull();
+	});
+
+	it("returns null when the stage has no diagnosisAggregate (older report)", () => {
+		const report = makeReport("ranking");
+		const stage = report.stages[0];
+		if (stage) stage.metrics = {};
+		expect(extractDominantLayer(report)).toBeNull();
+	});
+
+	it("extracts the dominantLayer from a current report", () => {
+		expect(extractDominantLayer(makeReport("ranking"))).toBe("ranking");
+		expect(extractDominantLayer(makeReport("chunking"))).toBe("chunking");
+		expect(extractDominantLayer(makeReport("fixture"))).toBe("fixture");
+		expect(extractDominantLayer(makeReport(null))).toBeNull();
+	});
+});
+
+describe("diagnosis -> capsule routing chain", () => {
+	it("routes fixture-dominant report to a null capsule (skip cycle)", () => {
+		const report = makeReport("fixture");
+		const layer = extractDominantLayer(report);
+		expect(selectPatchCapsule(layer)).toBeNull();
+	});
+
+	it("routes ingest-dominant report to a null capsule (human-only)", () => {
+		const report = makeReport("ingest");
+		const layer = extractDominantLayer(report);
+		expect(selectPatchCapsule(layer)).toBeNull();
+	});
+
+	it("routes ranking-dominant report to Tier 1 capsule with the legacy curatedFiles", () => {
+		const report = makeReport("ranking");
+		const capsule = selectPatchCapsule(extractDominantLayer(report));
+		expect(capsule?.tiers).toEqual([1]);
+		expect(capsule?.curatedFiles).toContain("packages/search/src/query.ts");
+		expect(capsule?.curatedFiles).toContain("packages/search/src/trace/trace.ts");
+	});
+
+	it("routes chunking-dominant report to Tier 1+2 capsule", () => {
+		const capsule = selectPatchCapsule(extractDominantLayer(makeReport("chunking")));
+		expect(capsule?.tiers).toEqual([1, 2]);
+	});
+
+	it("routes edge-extraction-dominant report to Tier 1+3 capsule", () => {
+		const capsule = selectPatchCapsule(extractDominantLayer(makeReport("edge-extraction")));
+		expect(capsule?.tiers).toEqual([1, 3]);
+	});
+
+	it("falls back to no capsule when the report carries no diagnosis (older sweep)", () => {
+		const report = makeReport("ranking");
+		const stage = report.stages[0];
+		if (stage) stage.metrics = {};
+		const layer = extractDominantLayer(report);
+		expect(layer).toBeNull();
+		// `selectPatchCapsule(null)` returns null — the loop's wiring then
+		// falls through to analyzeAndProposePatch's built-in defaults rather
+		// than skipping the cycle (backwards compat for pre-#347 reports).
+		expect(selectPatchCapsule(layer)).toBeNull();
+	});
+});

--- a/scripts/autoresearch/autonomous-loop.ts
+++ b/scripts/autoresearch/autonomous-loop.ts
@@ -193,9 +193,10 @@ function findBaselineForFinding(finding: Finding): ExtendedDogfoodReport | null 
 /**
  * Read `diagnosisAggregate.dominantLayer` from a dogfood report's
  * quality-queries stage metrics. Returns `null` when the field is absent
- * (older reports) or when there are no failures to diagnose.
+ * (older reports) or when there are no failures to diagnose. Exported for
+ * the wiring integration test.
  */
-function extractDominantLayer(report: ExtendedDogfoodReport | null): FailureLayer | null {
+export function extractDominantLayer(report: ExtendedDogfoodReport | null): FailureLayer | null {
 	if (!report) return null;
 	const stage = report.stages.find((s) => s.stage === "quality-queries");
 	const metrics = stage?.metrics as { diagnosisAggregate?: DiagnosisAggregate } | undefined;


### PR DESCRIPTION
## Summary

Wiring integration tests for the diagnosis -> capsule routing chain that #350 wired into `runPatchPath`. Catches regressions in CI without needing a live LLM or homelab GPU.

```
ExtendedDogfoodReport
  -> extractDominantLayer()
  -> selectPatchCapsule()
  -> analyzeAndProposePatch.{allowedPaths, curatedFiles}
```

## Coverage

10 new unit tests:

- `extractDominantLayer` null / missing-stage / empty-metrics paths.
- `extractDominantLayer` happy paths for `ranking` / `chunking` / `fixture` / `null`.
- `fixture`-dominant report -> null capsule (skip cycle).
- `ingest`-dominant report -> null capsule (human-only).
- `ranking`-dominant report -> Tier 1 with the legacy curatedFiles (`query.ts`, `trace/trace.ts`).
- `chunking`-dominant report -> Tier 1+2.
- `edge-extraction`-dominant report -> Tier 1+3.
- Older report without `diagnosisAggregate` -> null layer + null capsule -> wiring falls through to `analyzeAndProposePatch` built-in defaults (backwards compat for pre-#347 sweep reports).

## Out of scope

- End-to-end live validation against the real autoresearch loop (#344 step 6 — separate task running on the maintainer's homelab; sweep currently in-flight).
- `decideMulti` integration (gated on multi-corpus baselines from #344 step 2).

## Test plan

- [x] `pnpm test`: 1685 passed, 2 skipped.
- [x] `pnpm lint:fix` clean.
- [x] `pnpm -r build` clean.

refs #344