### PR TITLE
fix(autoresearch): wire preflight into dogfood so fixture-invalid diagnosis fires

### DIFF
--- a/scripts/dogfood.ts
+++ b/scripts/dogfood.ts
@@ -27,7 +27,9 @@ import {
 	InMemoryVectorIndex,
 	LlmReranker,
 	OpenAIEmbedder,
+	type PreflightStatus,
 	type Reranker,
+	runPreflight,
 } from "@wtfoc/search";
 import { evaluateStorage, createStore } from "@wtfoc/store";
 import { formatDogfoodReport } from "./dogfood-formatter.js";
@@ -508,6 +510,27 @@ async function main() {
 						if (values["trace-min-score"] !== undefined)
 							retrievalOverrides.traceMinScore = Number.parseFloat(values["trace-min-score"]);
 
+						// #344 step 3 — pre-flight catalog applicability so the
+						// failure-diagnosis layer's rule-1 short-circuit can fire
+						// (gold artifacts absent from this corpus = `fixture-invalid`,
+						// no retrieval-layer triage). Loads the catalog once for
+						// the active collection and keys preflight results by
+						// query id.
+						const qqCatPath = catalogFilePath(qqManifestDir, values.collection!);
+						const qqCatalog = await readCatalog(qqCatPath);
+						const preflightStatusByQueryId = new Map<string, PreflightStatus>();
+						if (qqCatalog) {
+							const preflight = runPreflight({
+								queries: GOLD_STANDARD_QUERIES,
+								catalogs: [{ corpusId: values.collection!, catalog: qqCatalog }],
+							});
+							for (const r of preflight.results) {
+								if (r.corpusId === values.collection) {
+									preflightStatusByQueryId.set(r.queryId, r.status);
+								}
+							}
+						}
+
 						result = await evaluateQualityQueries(
 						embedder,
 						vectorIndex,
@@ -521,6 +544,9 @@ async function main() {
 							corpusSourceTypes,
 							perQueryHook: (id, ms) => timer.record("per-query-total", ms),
 							checkParaphrases: process.env.WTFOC_CHECK_PARAPHRASES === "1",
+							...(preflightStatusByQueryId.size > 0
+								? { preflightStatusByQueryId }
+								: {}),
 							...(Object.keys(retrievalOverrides).length > 0
 								? { retrievalOverrides }
 								: {}),

--- a/scripts/dogfood.ts
+++ b/scripts/dogfood.ts
@@ -513,20 +513,40 @@ async function main() {
 						// #344 step 3 — pre-flight catalog applicability so the
 						// failure-diagnosis layer's rule-1 short-circuit can fire
 						// (gold artifacts absent from this corpus = `fixture-invalid`,
-						// no retrieval-layer triage). Loads the catalog once for
-						// the active collection and keys preflight results by
-						// query id.
-						const qqCatPath = catalogFilePath(qqManifestDir, values.collection!);
+						// no retrieval-layer triage). Loads the catalog for the
+						// active collection only and runs preflight against the
+						// subset of queries that target this corpus, so
+						// `runPreflight`'s cross-corpus schema check (which would
+						// hard-error on every multi-corpus query) does not fire.
+						const collectionId = values.collection;
+						if (!collectionId) {
+							throw new Error("--collection is required for the quality-queries stage");
+						}
+						const qqCatPath = catalogFilePath(qqManifestDir, collectionId);
 						const qqCatalog = await readCatalog(qqCatPath);
 						const preflightStatusByQueryId = new Map<string, PreflightStatus>();
 						if (qqCatalog) {
+							// Project each query down to "this corpus" before preflight so
+							// `runPreflight`'s matrix-validation pass (which expects a
+							// catalog for every applicableCorpora id it sees) gets a
+							// single-corpus view it can satisfy.
+							const localQueries = GOLD_STANDARD_QUERIES.filter((q) =>
+								q.applicableCorpora.includes(collectionId),
+							).map((q) => ({ ...q, applicableCorpora: [collectionId] }));
 							const preflight = runPreflight({
-								queries: GOLD_STANDARD_QUERIES,
-								catalogs: [{ corpusId: values.collection!, catalog: qqCatalog }],
+								queries: localQueries,
+								catalogs: [{ corpusId: collectionId, catalog: qqCatalog }],
 							});
-							for (const r of preflight.results) {
-								if (r.corpusId === values.collection) {
-									preflightStatusByQueryId.set(r.queryId, r.status);
+							if (preflight.hardErrors.length > 0) {
+								console.warn(
+									`[dogfood] preflight hard-errors (${preflight.hardErrors.length}); skipping fixture-invalid wiring`,
+								);
+								for (const e of preflight.hardErrors) console.warn(`  - ${e}`);
+							} else {
+								for (const r of preflight.results) {
+									if (r.corpusId === collectionId) {
+										preflightStatusByQueryId.set(r.queryId, r.status);
+									}
 								}
 							}
 						}


### PR DESCRIPTION
## Summary

#344 follow-up surfaced by step-6 live validation (PR #351 + #350 against a fresh sweep): dogfood runs the failure-diagnosis layer but never populates `preflightStatusByQueryId`, so rule 1 of the classifier (`preflight=invalid` → `fixture-invalid` layer) never fires.

Fresh sweep on `wtfoc-dogfood-2026-04-v3` reported `byFailureClass["fixture-invalid"] = 0` even though catalog-applicability preflight (#345) flagged ~39 applicable queries with all required artifacts missing. Without this signal the LLM patch-proposer is invited to patch ranking for queries that physically cannot pass against the corpus — exactly the no-op-patch failure mode the diagnosis + capsule infra was built to prevent.

## What changed

`scripts/dogfood.ts` quality-queries stage now:

1. Loads the corpus catalog (same path/helper as the existing storage stage).
2. Runs `runPreflight` against `GOLD_STANDARD_QUERIES` for the active collection.
3. Builds a `Map<queryId, PreflightStatus>` keyed by query id.
4. Passes it into `evaluateQualityQueries` as `context.preflightStatusByQueryId`.
5. Falls back to no-map (legacy behavior) when the catalog is unreadable.

## Effect on next sweep

- Queries with required artifacts absent from the corpus catalog classify `fixture-invalid` → `fixture` layer.
- `selectPatchCapsule("fixture")` returns `null` → autonomous loop skips the LLM call for fixture-dominated regressions.
- `diagnosisAggregate.byFailureClass["fixture-invalid"]` reports the actual count instead of silently 0.

## Test plan

- [x] `pnpm test`: 1685 passed, 2 skipped (no new tests; the wired modules each carry coverage; live re-run with this change validates fixture-invalid count as part of step 6 follow-up).
- [x] `pnpm lint:fix` clean.
- [x] `pnpm -r build` clean.

refs #344