### PR TITLE
feat(autoresearch): stratified-template recipe primitives (step 2a)

### DIFF
--- a/packages/search/src/eval/stratified-template-recipe.test.ts
+++ b/packages/search/src/eval/stratified-template-recipe.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import {
+	applyAdversarialFilter,
+	type CandidateQuery,
+	type CatalogArtifact,
+	groupByStratum,
+	lengthBucketOf,
+	type QueryTemplate,
+	type RetrieveTopK,
+	sampleStratified,
+	stratifyArtifacts,
+	stratumKey,
+} from "./stratified-template-recipe.js";
+
+function makeArtifact(partial: Partial<CatalogArtifact> & { artifactId: string }): CatalogArtifact {
+	return {
+		sourceType: "code",
+		contentLength: 1000,
+		...partial,
+	};
+}
+
+function seededRng(seed: number): () => number {
+	let s = seed;
+	return () => {
+		s = (s * 9301 + 49297) % 233280;
+		return s / 233280;
+	};
+}
+
+describe("lengthBucketOf", () => {
+	it("uses default boundaries 800/4000", () => {
+		expect(lengthBucketOf(500)).toBe("short");
+		expect(lengthBucketOf(2000)).toBe("medium");
+		expect(lengthBucketOf(10_000)).toBe("long");
+	});
+	it("respects custom boundaries", () => {
+		const opts = { lengthBuckets: { short: 100, medium: 500 } };
+		expect(lengthBucketOf(50, opts)).toBe("short");
+		expect(lengthBucketOf(200, opts)).toBe("medium");
+		expect(lengthBucketOf(600, opts)).toBe("long");
+	});
+});
+
+describe("stratifyArtifacts", () => {
+	it("emits one row per (artifact, edgeType) pair", () => {
+		const arts = [
+			makeArtifact({ artifactId: "a", edgeTypes: ["imports", "references"] }),
+			makeArtifact({ artifactId: "b" }),
+		];
+		const rows = stratifyArtifacts(arts);
+		// "a" -> 2 rows (imports, references); "b" -> 1 row (edgeType: null)
+		expect(rows).toHaveLength(3);
+	});
+
+	it("tags low-frequency combos as `rare` per the rarity threshold", () => {
+		const arts = Array.from({ length: 20 }, (_, i) =>
+			makeArtifact({ artifactId: `code${i}`, sourceType: "code" }),
+		).concat([makeArtifact({ artifactId: "doc1", sourceType: "markdown" })]);
+		const rows = stratifyArtifacts(arts, { rarityFraction: 0.1 });
+		const docRow = rows.find((r) => r.artifact.artifactId === "doc1");
+		const codeRow = rows.find((r) => r.artifact.artifactId === "code0");
+		expect(docRow?.stratum.rarity).toBe("rare"); // 1/21 ~= 4.7% < 10%
+		expect(codeRow?.stratum.rarity).toBe("common");
+	});
+
+	it("returns [] on empty input", () => {
+		expect(stratifyArtifacts([])).toEqual([]);
+	});
+});
+
+describe("groupByStratum + stratumKey", () => {
+	it("groups rows sharing the same stratum", () => {
+		const rows = stratifyArtifacts([
+			makeArtifact({ artifactId: "a", sourceType: "code", contentLength: 200 }),
+			makeArtifact({ artifactId: "b", sourceType: "code", contentLength: 300 }),
+			makeArtifact({ artifactId: "c", sourceType: "code", contentLength: 9000 }),
+		]);
+		const grouped = groupByStratum(rows);
+		// "a" + "b" share short-bucket stratum; "c" is in long-bucket.
+		expect(grouped.size).toBe(2);
+	});
+
+	it("stratumKey is stable across runs", () => {
+		const k1 = stratumKey({
+			sourceType: "code",
+			edgeType: "imports",
+			lengthBucket: "short",
+			rarity: "common",
+		});
+		const k2 = stratumKey({
+			sourceType: "code",
+			edgeType: "imports",
+			lengthBucket: "short",
+			rarity: "common",
+		});
+		expect(k1).toBe(k2);
+	});
+});
+
+describe("sampleStratified", () => {
+	it("yields up to samplesPerStratum per occupied stratum", () => {
+		const arts = Array.from({ length: 10 }, (_, i) =>
+			makeArtifact({ artifactId: `c${i}`, sourceType: "code" }),
+		);
+		const samples = sampleStratified(arts, { samplesPerStratum: 2, rng: seededRng(42) });
+		// All 10 share one stratum (code/null/medium/common); cap at 2.
+		expect(samples).toHaveLength(2);
+	});
+
+	it("is deterministic when rng is seeded", () => {
+		const arts = Array.from({ length: 50 }, (_, i) => makeArtifact({ artifactId: `c${i}` }));
+		const a = sampleStratified(arts, { samplesPerStratum: 5, rng: seededRng(7) });
+		const b = sampleStratified(arts, { samplesPerStratum: 5, rng: seededRng(7) });
+		expect(a.map((s) => s.artifact.artifactId)).toEqual(b.map((s) => s.artifact.artifactId));
+	});
+
+	it("respects maxTotalSamples cap", () => {
+		const arts = Array.from({ length: 30 }, (_, i) =>
+			makeArtifact({
+				artifactId: `c${i}`,
+				sourceType: i < 10 ? "code" : i < 20 ? "markdown" : "github-issue",
+			}),
+		);
+		const samples = sampleStratified(arts, {
+			samplesPerStratum: 5,
+			maxTotalSamples: 7,
+			rng: seededRng(11),
+		});
+		expect(samples).toHaveLength(7);
+	});
+});
+
+function makeCandidate(query: string, requiredArtifactIds: string[]): CandidateQuery {
+	const template: QueryTemplate = {
+		id: "t1",
+		intent: "test",
+		queryType: "lookup",
+		difficulty: "easy",
+		targetLayerHints: ["ranking"],
+		exampleSurface: "find X",
+	};
+	return {
+		template,
+		stratum: { sourceType: "code", edgeType: null, lengthBucket: "short", rarity: "common" },
+		draft: {
+			authoredFromCollectionId: "alpha",
+			applicableCorpora: ["alpha"],
+			query,
+			queryType: "lookup",
+			difficulty: "easy",
+			targetLayerHints: ["ranking"],
+			expectedEvidence: requiredArtifactIds.map((id) => ({ artifactId: id, required: true })),
+			acceptableAnswerFacts: [],
+			requiredSourceTypes: [],
+			minResults: 1,
+		},
+	};
+}
+
+describe("applyAdversarialFilter", () => {
+	it("discards candidates whose required artifact is in vector top-K", async () => {
+		const c = makeCandidate("how does X work", ["doc/easy.ts"]);
+		const retrieve: RetrieveTopK = async () => [
+			{ artifactId: "doc/easy.ts" },
+			{ artifactId: "doc/other.ts" },
+		];
+		const result = await applyAdversarialFilter([c], retrieve, { topK: 3 });
+		expect(result.kept).toEqual([]);
+		expect(result.discarded).toHaveLength(1);
+		expect(result.discarded[0]?.reason).toContain("doc/easy.ts");
+	});
+
+	it("keeps candidates whose required artifact is NOT in top-K", async () => {
+		const c = makeCandidate("how does X work", ["doc/hard.ts"]);
+		const retrieve: RetrieveTopK = async () => [
+			{ artifactId: "doc/decoy1.ts" },
+			{ artifactId: "doc/decoy2.ts" },
+			{ artifactId: "doc/decoy3.ts" },
+		];
+		const result = await applyAdversarialFilter([c], retrieve, { topK: 3 });
+		expect(result.kept).toHaveLength(1);
+		expect(result.discarded).toEqual([]);
+	});
+
+	it("keeps candidates with no required evidence (cannot judge difficulty)", async () => {
+		const c = makeCandidate("how does X work", []);
+		const retrieve: RetrieveTopK = async () => [];
+		const result = await applyAdversarialFilter([c], retrieve);
+		expect(result.kept).toHaveLength(1);
+	});
+});

--- a/packages/search/src/eval/stratified-template-recipe.ts
+++ b/packages/search/src/eval/stratified-template-recipe.ts
@@ -1,0 +1,290 @@
+/**
+ * Stratified-template recipe primitives for #344 step 2 (gold-query
+ * regeneration). The legacy fixture used unstructured human-authored queries
+ * with substring patterns that drift from real catalog ids; this module is
+ * the foundation for the replacement: deterministic stratified sampling,
+ * template-driven LLM authoring, and an adversarial filter that discards
+ * queries vector-search alone solves.
+ *
+ * Three peer reviewers (codex/gemini/cursor) converged on this recipe in
+ * round 3 (see `reference_peer_review_snapshots.md`):
+ *
+ *   1. Stratify the corpus by `(sourceType × edgeType × length × rarity)`.
+ *   2. Apply 8–15 templates across strata. Variety from strata, not artistry.
+ *   3. LLM generates candidate queries anchored to sampled spans.
+ *   4. Human approves / edits / rejects — NOT human authors.
+ *   5. Adversarial filter: discard any candidate whose required evidence is
+ *      in top-3 of a plain vector search (too easy; doesn't exercise trace).
+ *   6. Difficulty tags + per-template caps prevent overfitting the scaffold.
+ *
+ * This module ships **only** the deterministic primitives (stratification,
+ * sampling, adversarial filter, types). The actual LLM authoring loop +
+ * per-collection invocations land as separate per-collection PRs.
+ *
+ * @see https://github.com/SgtPooki/wtfoc/issues/344
+ */
+
+import type { GoldQuery, QueryType } from "./gold-standard-queries.js";
+
+/** Bucket axis values used to key strata. */
+export type LengthBucket = "short" | "medium" | "long";
+
+/**
+ * Stratum key. Strata are defined as the cartesian product of axis values
+ * present in the corpus. The recipe targets ≥1 sample per (occupied)
+ * stratum so generated queries cover the corpus shape evenly.
+ */
+export interface Stratum {
+	sourceType: string;
+	edgeType: string | null;
+	lengthBucket: LengthBucket;
+	/** "rare" if the (sourceType, edgeType) combo appears in <5% of catalog. */
+	rarity: "common" | "rare";
+}
+
+/**
+ * One source artifact + its measurable shape, used as input to stratified
+ * sampling. Keep this minimal — concrete corpora may carry richer metadata
+ * but the recipe should stay corpus-agnostic.
+ */
+export interface CatalogArtifact {
+	artifactId: string;
+	sourceType: string;
+	/**
+	 * Edge-types this artifact participates in (e.g. `imports`, `closes`,
+	 * `references`). Empty/undefined for artifacts the graph builder hasn't
+	 * touched yet.
+	 */
+	edgeTypes?: string[];
+	/** Length in characters of the canonical chunk content. */
+	contentLength: number;
+}
+
+/**
+ * One template the LLM uses to generate candidate queries. Templates are
+ * intent-shaped, not surface-shaped — "find the implementation that closes
+ * this issue" not "where is X.ts".
+ */
+export interface QueryTemplate {
+	id: string;
+	intent: string;
+	queryType: QueryType;
+	/** Difficulty floor for queries authored from this template. */
+	difficulty: GoldQuery["difficulty"];
+	/** Layer hints to seed `targetLayerHints` on generated queries. */
+	targetLayerHints: GoldQuery["targetLayerHints"];
+	/**
+	 * Strata this template is appropriate for. When empty, applies to every
+	 * stratum — rare for a useful template; most templates target specific
+	 * source-type/edge combinations.
+	 */
+	appliesToStrata?: Array<Partial<Stratum>>;
+	/**
+	 * Example surface form, for the human reviewer. NOT injected into the
+	 * LLM prompt verbatim (would prime the candidates toward this phrasing).
+	 */
+	exampleSurface: string;
+}
+
+/**
+ * One sample anchored in the catalog. The LLM-authoring step receives
+ * `(template, sample)` pairs and emits one or more `CandidateQuery` records
+ * per pair.
+ */
+export interface RecipeSample {
+	stratum: Stratum;
+	artifact: CatalogArtifact;
+}
+
+/**
+ * One LLM-generated candidate query awaiting human review and adversarial
+ * filtering. Shape mirrors `GoldQuery` so an approved candidate can drop
+ * straight into `GOLD_STANDARD_QUERIES` after the filter passes.
+ */
+export interface CandidateQuery {
+	template: QueryTemplate;
+	stratum: Stratum;
+	draft: Omit<GoldQuery, "id"> & { id?: string };
+}
+
+export interface SamplingOptions {
+	/** Target samples per occupied stratum (default 2). */
+	samplesPerStratum?: number;
+	/** Length bucket boundaries in chars. Default: 0–800 / 800–4000 / 4000+. */
+	lengthBuckets?: { short: number; medium: number };
+	/**
+	 * Rarity cutoff — `(sourceType, edgeType)` combos seen in less than this
+	 * fraction of the catalog are tagged `rare`. Default 0.05.
+	 */
+	rarityFraction?: number;
+	/** Deterministic RNG for sample selection. Defaults to `Math.random`. */
+	rng?: () => number;
+	/** Hard cap on total samples (defense against pathological strata). */
+	maxTotalSamples?: number;
+}
+
+/** Classify content length into a bucket using configured boundaries. */
+export function lengthBucketOf(length: number, opts: SamplingOptions = {}): LengthBucket {
+	const buckets = opts.lengthBuckets ?? { short: 800, medium: 4000 };
+	if (length < buckets.short) return "short";
+	if (length < buckets.medium) return "medium";
+	return "long";
+}
+
+/**
+ * Compute the stratum each artifact falls into. An artifact with multiple
+ * edge types yields multiple strata entries (one per edge-type, plus one
+ * with `edgeType: null` for "no-edge-context" baseline).
+ */
+export function stratifyArtifacts(
+	artifacts: ReadonlyArray<CatalogArtifact>,
+	opts: SamplingOptions = {},
+): Array<{ stratum: Stratum; artifact: CatalogArtifact }> {
+	const rarityFraction = opts.rarityFraction ?? 0.05;
+	const total = artifacts.length;
+	if (total === 0) return [];
+
+	// Pass 1: per (sourceType, edgeType) frequency for the rarity tag.
+	const comboCount = new Map<string, number>();
+	for (const a of artifacts) {
+		const edges = a.edgeTypes && a.edgeTypes.length > 0 ? a.edgeTypes : [null];
+		for (const e of edges) {
+			const key = `${a.sourceType}::${e ?? ""}`;
+			comboCount.set(key, (comboCount.get(key) ?? 0) + 1);
+		}
+	}
+
+	// Pass 2: emit one row per (artifact, edgeType) cell.
+	const out: Array<{ stratum: Stratum; artifact: CatalogArtifact }> = [];
+	for (const a of artifacts) {
+		const edges = a.edgeTypes && a.edgeTypes.length > 0 ? a.edgeTypes : [null];
+		for (const e of edges) {
+			const key = `${a.sourceType}::${e ?? ""}`;
+			const count = comboCount.get(key) ?? 0;
+			const rarity: Stratum["rarity"] = count / total < rarityFraction ? "rare" : "common";
+			out.push({
+				stratum: {
+					sourceType: a.sourceType,
+					edgeType: e,
+					lengthBucket: lengthBucketOf(a.contentLength, opts),
+					rarity,
+				},
+				artifact: a,
+			});
+		}
+	}
+	return out;
+}
+
+/** Group strata-tagged artifacts into a Map keyed by serialized Stratum. */
+export function groupByStratum(
+	rows: ReadonlyArray<{ stratum: Stratum; artifact: CatalogArtifact }>,
+): Map<string, Array<{ stratum: Stratum; artifact: CatalogArtifact }>> {
+	const out = new Map<string, Array<{ stratum: Stratum; artifact: CatalogArtifact }>>();
+	for (const row of rows) {
+		const key = stratumKey(row.stratum);
+		const list = out.get(key) ?? [];
+		list.push(row);
+		out.set(key, list);
+	}
+	return out;
+}
+
+export function stratumKey(s: Stratum): string {
+	return `${s.sourceType}::${s.edgeType ?? "_"}::${s.lengthBucket}::${s.rarity}`;
+}
+
+/**
+ * Stratified sampling — pick `samplesPerStratum` artifacts from each
+ * occupied stratum. Deterministic when `opts.rng` is supplied. Capped by
+ * `maxTotalSamples` (default 1000) to defend against pathological corpora.
+ */
+export function sampleStratified(
+	artifacts: ReadonlyArray<CatalogArtifact>,
+	opts: SamplingOptions = {},
+): RecipeSample[] {
+	const samplesPer = opts.samplesPerStratum ?? 2;
+	const cap = opts.maxTotalSamples ?? 1000;
+	const rng = opts.rng ?? Math.random;
+	const grouped = groupByStratum(stratifyArtifacts(artifacts, opts));
+	const out: RecipeSample[] = [];
+	for (const rows of grouped.values()) {
+		// Fisher-Yates with the supplied RNG, then take prefix.
+		const shuffled = [...rows];
+		for (let i = shuffled.length - 1; i > 0; i--) {
+			const j = Math.floor(rng() * (i + 1));
+			const a = shuffled[i];
+			const b = shuffled[j];
+			if (!a || !b) continue;
+			shuffled[i] = b;
+			shuffled[j] = a;
+		}
+		for (const row of shuffled.slice(0, samplesPer)) {
+			out.push({ stratum: row.stratum, artifact: row.artifact });
+			if (out.length >= cap) return out;
+		}
+	}
+	return out;
+}
+
+export type RetrieveTopK = (
+	queryText: string,
+	k: number,
+) => Promise<ReadonlyArray<{ artifactId: string }>>;
+
+export interface AdversarialFilterOptions {
+	/** Top-K to read from the retriever. Default 3 (peer-review consensus). */
+	topK?: number;
+	/**
+	 * If `true`, log the retriever's top-K snapshot per discarded candidate
+	 * so the human reviewer can audit why the filter rejected each.
+	 */
+	verbose?: boolean;
+}
+
+export interface AdversarialFilterResult {
+	kept: CandidateQuery[];
+	discarded: Array<{ candidate: CandidateQuery; reason: string }>;
+}
+
+/**
+ * Adversarial filter. Discards a candidate when ≥1 of its `required:true`
+ * artifacts appears in the retriever's top-K for the candidate's query
+ * text. Such queries are too easy — vector search alone solves them — and
+ * do not exercise the trace engine that wtfoc differentiates on.
+ *
+ * The retrieve fn is supplied by the caller so this module stays
+ * corpus-agnostic and unit-testable. Production wiring passes a thin
+ * adapter around the live `query()` from `@wtfoc/search`.
+ */
+export async function applyAdversarialFilter(
+	candidates: ReadonlyArray<CandidateQuery>,
+	retrieve: RetrieveTopK,
+	opts: AdversarialFilterOptions = {},
+): Promise<AdversarialFilterResult> {
+	const topK = opts.topK ?? 3;
+	const kept: CandidateQuery[] = [];
+	const discarded: Array<{ candidate: CandidateQuery; reason: string }> = [];
+	for (const c of candidates) {
+		const queryText = c.draft.query;
+		const required = c.draft.expectedEvidence.filter((e) => e.required).map((e) => e.artifactId);
+		if (required.length === 0) {
+			// No required evidence — cannot reason about adversarial difficulty;
+			// keep with a note so downstream review sees it.
+			kept.push(c);
+			continue;
+		}
+		const hits = await retrieve(queryText, topK);
+		const hitSet = new Set(hits.map((h) => h.artifactId));
+		const easyMatch = required.find((id) => hitSet.has(id));
+		if (easyMatch) {
+			discarded.push({
+				candidate: c,
+				reason: `vector top-${topK} already contains required artifact "${easyMatch}" — query too easy`,
+			});
+		} else {
+			kept.push(c);
+		}
+	}
+	return { kept, discarded };
+}

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -50,6 +50,26 @@ export type { AggregateLineageMetrics, LineageMetrics } from "./eval/lineage-met
 export { aggregateLineageMetrics, computeLineageMetrics } from "./eval/lineage-metrics.js";
 export { evaluateQualityQueries } from "./eval/quality-queries-evaluator.js";
 export { evaluateSearch } from "./eval/search-evaluator.js";
+export type {
+	AdversarialFilterOptions,
+	AdversarialFilterResult,
+	CandidateQuery,
+	CatalogArtifact,
+	LengthBucket,
+	QueryTemplate,
+	RecipeSample,
+	RetrieveTopK,
+	SamplingOptions,
+	Stratum,
+} from "./eval/stratified-template-recipe.js";
+export {
+	applyAdversarialFilter,
+	groupByStratum,
+	lengthBucketOf,
+	sampleStratified,
+	stratifyArtifacts,
+	stratumKey,
+} from "./eval/stratified-template-recipe.js";
 export { evaluateThemes } from "./eval/themes-evaluator.js";
 export type { VectorBackend, VectorIndexConfig } from "./index/factory.js";
 export { createVectorIndex } from "./index/factory.js";


### PR DESCRIPTION
## Summary

#344 step 2a — deterministic primitives for the gold-query regeneration recipe agreed by all three peer reviewers (codex / gemini / cursor) in round 3:

1. Stratify the corpus by `(sourceType × edgeType × length × rarity)`.
2. 8–15 templates across strata; variety from strata, not artistry.
3. LLM generates candidate queries anchored to sampled spans.
4. Human approves / edits / rejects — NOT human authors.
5. Adversarial filter: discard candidates whose required evidence is in top-3 of plain vector search (too easy; doesn't exercise trace).

This PR ships **only** the deterministic primitives. Actual LLM authoring + per-collection invocations land as separate PRs:

- step 2b: wtfoc-self queries
- step 2c: filoz/synapse queries
- step 2d: GitHub PR threads collection (non-code, per peer-review consensus)
- step 2e: podcast transcripts collection (non-code)

## Public API

```ts
type Stratum, CatalogArtifact, RecipeSample, QueryTemplate, CandidateQuery
type SamplingOptions, AdversarialFilterOptions, AdversarialFilterResult
type LengthBucket, RetrieveTopK

lengthBucketOf(length, opts): LengthBucket
stratifyArtifacts(artifacts, opts): Array<{stratum, artifact}>
groupByStratum(rows): Map<key, rows>
stratumKey(stratum): string
sampleStratified(artifacts, opts): RecipeSample[]
applyAdversarialFilter(candidates, retrieve, opts): {kept, discarded}
```

Stratification emits one row per `(artifact, edgeType)` cell so multi-edge artifacts contribute to every relevant stratum. Sampling is Fisher-Yates with a seedable RNG (deterministic when `opts.rng` is supplied). Adversarial filter takes a corpus-agnostic `RetrieveTopK` so the recipe stays unit-testable; production wiring passes a thin adapter around the live `query()`.

## Test plan

- [x] 13 unit tests cover: length-bucket boundaries; stratification of empty / multi-edge inputs; rarity tagging via custom thresholds; `groupByStratum` convergence; deterministic sampling; `samplesPerStratum` cap; `maxTotalSamples` cap; adversarial discard / keep paths; no-required-evidence keep-with-note path.
- [x] `pnpm test`: 1698 passed, 2 skipped.
- [x] `pnpm lint:fix` clean.
- [x] `pnpm -r build` clean.

refs #344