### PR TITLE
feat(autoresearch): recipe-author CLI driver scaffold (step 2b)

### DIFF
--- a/scripts/autoresearch/recipe-author.test.ts
+++ b/scripts/autoresearch/recipe-author.test.ts
@@ -2,6 +2,7 @@ import type { CatalogArtifact, RecipeSample } from "@wtfoc/search";
 import { describe, expect, it } from "vitest";
 import {
 	catalogToArtifacts,
+	parseArgs,
 	planAuthoring,
 	seededRng,
 	stubAuthor,
@@ -120,10 +121,13 @@ describe("planAuthoring", () => {
 		expect(plan.length).toBeLessThan(samples.length);
 	});
 
-	it("skips samples whose stratum has no applicable templates", () => {
-		// Construct an artifact whose stratum no template targets — but
-		// because we have always-applies templates (`trace-cross-source`,
-		// `howto-task`, etc.) every stratum has at least those.
+	it("always-applies templates ensure every stratum gets at least one template", () => {
+		// Every stratum is covered by the always-applies templates
+		// (`trace-cross-source`, `howto-task`, etc.), so planAuthoring
+		// never silently drops a sample. If a future template change
+		// removes always-applies and exposes a real "no templates"
+		// edge case, this test should be replaced with one that
+		// constructs that stratum explicitly.
 		const samples = [makeSample({ artifactId: "a.ts" })];
 		const plan = planAuthoring(samples, 100);
 		expect(plan.length).toBeGreaterThan(0);
@@ -131,14 +135,14 @@ describe("planAuthoring", () => {
 });
 
 describe("stubAuthor", () => {
-	it("emits a candidate keyed by (template.id, artifactId)", () => {
-		const c = stubAuthor(
-			makeSample({ artifactId: "src/foo.ts" }),
-			RECIPE_TEMPLATES[0],
-			"alpha",
-		);
-		expect(c.draft.id).toContain("src/foo.ts");
-		expect(c.draft.id).toContain(RECIPE_TEMPLATES[0]?.id);
+	it("emits a candidate id that includes the template id (artifactId is hashed)", () => {
+		const tpl = RECIPE_TEMPLATES[0];
+		if (!tpl) throw new Error("no templates");
+		const c = stubAuthor(makeSample({ artifactId: "src/foo.ts" }), tpl, "alpha");
+		expect(c.draft.id).toContain(tpl.id);
+		// The artifactId is preserved on the evidence row, not the id, so
+		// reviewers can map an id back via the evidence array.
+		expect(c.draft.expectedEvidence[0]?.artifactId).toBe("src/foo.ts");
 	});
 
 	it("propagates template fields onto the draft", () => {
@@ -164,6 +168,62 @@ describe("stubAuthor", () => {
 	it("flags itself as a stub via migrationNotes", () => {
 		const c = stubAuthor(makeSample({ artifactId: "x" }), RECIPE_TEMPLATES[0], "alpha");
 		expect(c.draft.migrationNotes).toContain("stub-authored");
+	});
+});
+
+describe("parseArgs", () => {
+	it("requires --collection", () => {
+		expect(() => parseArgs([])).toThrow(/usage/);
+	});
+	it("rejects unknown flags", () => {
+		expect(() => parseArgs(["--collection", "x", "--bogus"])).toThrow(/unknown flag/);
+	});
+	it("rejects non-numeric --samples-per-stratum", () => {
+		expect(() => parseArgs(["--collection", "x", "--samples-per-stratum", "abc"])).toThrow(
+			/positive integer/,
+		);
+	});
+	it("rejects zero or negative --max-candidates", () => {
+		expect(() => parseArgs(["--collection", "x", "--max-candidates", "0"])).toThrow(
+			/positive integer/,
+		);
+	});
+	it("accepts --seed=0 (integer, not positive)", () => {
+		const a = parseArgs(["--collection", "x", "--seed", "0"]);
+		expect(a.seed).toBe(0);
+	});
+	it("--dry-run is a boolean flag", () => {
+		const a = parseArgs(["--collection", "x", "--dry-run"]);
+		expect(a.dryRun).toBe(true);
+	});
+});
+
+describe("stub candidate id stability", () => {
+	it("produces collision-free ids for artifacts that share a 24-char prefix", () => {
+		const a = stubAuthor(
+			makeSample({ artifactId: "very/long/path/that/has/a/common/prefix/file-A.ts" }),
+			RECIPE_TEMPLATES[0]!,
+			"alpha",
+		);
+		const b = stubAuthor(
+			makeSample({ artifactId: "very/long/path/that/has/a/common/prefix/file-B.ts" }),
+			RECIPE_TEMPLATES[0]!,
+			"alpha",
+		);
+		expect(a.draft.id).not.toBe(b.draft.id);
+	});
+	it("emits the same id for identical inputs (deterministic)", () => {
+		const a = stubAuthor(
+			makeSample({ artifactId: "foo.ts" }),
+			RECIPE_TEMPLATES[0]!,
+			"alpha",
+		);
+		const b = stubAuthor(
+			makeSample({ artifactId: "foo.ts" }),
+			RECIPE_TEMPLATES[0]!,
+			"alpha",
+		);
+		expect(a.draft.id).toBe(b.draft.id);
 	});
 });
 

--- a/scripts/autoresearch/recipe-author.test.ts
+++ b/scripts/autoresearch/recipe-author.test.ts
@@ -1,0 +1,187 @@
+import type { CatalogArtifact, RecipeSample } from "@wtfoc/search";
+import { describe, expect, it } from "vitest";
+import {
+	catalogToArtifacts,
+	planAuthoring,
+	seededRng,
+	stubAuthor,
+} from "./recipe-author.js";
+import { RECIPE_TEMPLATES, templatesForStratum } from "./recipe-templates.js";
+
+describe("seededRng", () => {
+	it("is deterministic given the same seed", () => {
+		const a = seededRng(7);
+		const b = seededRng(7);
+		expect(a()).toBeCloseTo(b());
+		expect(a()).toBeCloseTo(b());
+	});
+	it("produces values in [0, 1)", () => {
+		const r = seededRng(1);
+		for (let i = 0; i < 100; i++) {
+			const v = r();
+			expect(v).toBeGreaterThanOrEqual(0);
+			expect(v).toBeLessThan(1);
+		}
+	});
+});
+
+describe("catalogToArtifacts", () => {
+	it("filters out non-active documents", () => {
+		const arts = catalogToArtifacts({
+			documents: {
+				"a.ts": { state: "active", chunkIds: ["a#0"], sourceType: "code" },
+				"b.ts": { state: "archived", chunkIds: ["b#0"], sourceType: "code" },
+				"c.ts": { state: "superseded", chunkIds: ["c#0"], sourceType: "code" },
+			},
+		});
+		expect(arts).toHaveLength(1);
+		expect(arts[0]?.artifactId).toBe("a.ts");
+	});
+	it("defaults sourceType to 'unknown' when missing", () => {
+		const arts = catalogToArtifacts({
+			documents: { "x": { state: "active", chunkIds: ["x#0"] } },
+		});
+		expect(arts[0]?.sourceType).toBe("unknown");
+	});
+	it("estimates content length from chunk count", () => {
+		const arts = catalogToArtifacts({
+			documents: { "x": { state: "active", chunkIds: ["x#0", "x#1", "x#2"] } },
+		});
+		expect(arts[0]?.contentLength).toBe(3000);
+	});
+});
+
+describe("templatesForStratum", () => {
+	it("filters templates by sourceType", () => {
+		const ts = templatesForStratum({
+			sourceType: "code",
+			edgeType: null,
+			rarity: "common",
+		});
+		const ids = ts.map((t) => t.id);
+		expect(ids).toContain("lookup-by-symbol");
+		expect(ids).not.toContain("lookup-doc-section");
+	});
+	it("filters templates by rarity tag", () => {
+		const ts = templatesForStratum({
+			sourceType: "code",
+			edgeType: null,
+			rarity: "rare",
+		});
+		expect(ts.map((t) => t.id)).toContain("lookup-rare-edge");
+	});
+	it("includes always-applies templates (empty appliesToStrata)", () => {
+		const ts = templatesForStratum({
+			sourceType: "exotic",
+			edgeType: null,
+			rarity: "common",
+		});
+		// trace-cross-source has no appliesToStrata filter -> always present.
+		expect(ts.map((t) => t.id)).toContain("trace-cross-source");
+	});
+});
+
+function makeSample(partial: Partial<CatalogArtifact> & { artifactId: string }): RecipeSample {
+	return {
+		stratum: { sourceType: "code", edgeType: null, lengthBucket: "short", rarity: "common" },
+		artifact: { sourceType: "code", contentLength: 100, ...partial },
+	};
+}
+
+describe("planAuthoring", () => {
+	it("pairs each sample with templates applicable to its stratum", () => {
+		const samples = [makeSample({ artifactId: "a.ts" })];
+		const plan = planAuthoring(samples, 100);
+		expect(plan).toHaveLength(1);
+		expect(plan[0]?.templates.length).toBeGreaterThan(0);
+		// All resulting templates must apply to the code/common stratum.
+		for (const t of plan[0]?.templates ?? []) {
+			expect(
+				!t.appliesToStrata ||
+					t.appliesToStrata.length === 0 ||
+					t.appliesToStrata.some(
+						(p) =>
+							(!p.sourceType || p.sourceType === "code") &&
+							(!p.rarity || p.rarity === "common"),
+					),
+			).toBe(true);
+		}
+	});
+
+	it("respects maxCandidates global cap", () => {
+		const samples = Array.from({ length: 20 }, (_, i) =>
+			makeSample({ artifactId: `a${i}.ts` }),
+		);
+		const plan = planAuthoring(samples, 5);
+		const total = plan.reduce((acc, p) => acc + p.templates.length, 0);
+		// We stop adding more samples once cumulative templates hits the cap.
+		expect(total).toBeGreaterThanOrEqual(5);
+		// We don't add EVERY sample's templates — break early.
+		expect(plan.length).toBeLessThan(samples.length);
+	});
+
+	it("skips samples whose stratum has no applicable templates", () => {
+		// Construct an artifact whose stratum no template targets — but
+		// because we have always-applies templates (`trace-cross-source`,
+		// `howto-task`, etc.) every stratum has at least those.
+		const samples = [makeSample({ artifactId: "a.ts" })];
+		const plan = planAuthoring(samples, 100);
+		expect(plan.length).toBeGreaterThan(0);
+	});
+});
+
+describe("stubAuthor", () => {
+	it("emits a candidate keyed by (template.id, artifactId)", () => {
+		const c = stubAuthor(
+			makeSample({ artifactId: "src/foo.ts" }),
+			RECIPE_TEMPLATES[0],
+			"alpha",
+		);
+		expect(c.draft.id).toContain("src/foo.ts");
+		expect(c.draft.id).toContain(RECIPE_TEMPLATES[0]?.id);
+	});
+
+	it("propagates template fields onto the draft", () => {
+		const tpl = RECIPE_TEMPLATES[0];
+		if (!tpl) throw new Error("no templates");
+		const c = stubAuthor(makeSample({ artifactId: "x" }), tpl, "alpha");
+		expect(c.draft.queryType).toBe(tpl.queryType);
+		expect(c.draft.difficulty).toBe(tpl.difficulty);
+		expect(c.draft.targetLayerHints).toEqual(tpl.targetLayerHints);
+	});
+
+	it("populates expectedEvidence from the sample's artifactId", () => {
+		const c = stubAuthor(
+			makeSample({ artifactId: "doc/specific.md" }),
+			RECIPE_TEMPLATES[0],
+			"alpha",
+		);
+		expect(c.draft.expectedEvidence).toEqual([
+			{ artifactId: "doc/specific.md", required: true },
+		]);
+	});
+
+	it("flags itself as a stub via migrationNotes", () => {
+		const c = stubAuthor(makeSample({ artifactId: "x" }), RECIPE_TEMPLATES[0], "alpha");
+		expect(c.draft.migrationNotes).toContain("stub-authored");
+	});
+});
+
+describe("RECIPE_TEMPLATES set", () => {
+	it("has between 8 and 15 templates (peer-review constraint)", () => {
+		expect(RECIPE_TEMPLATES.length).toBeGreaterThanOrEqual(8);
+		expect(RECIPE_TEMPLATES.length).toBeLessThanOrEqual(15);
+	});
+
+	it("every template has a distinct id", () => {
+		const ids = RECIPE_TEMPLATES.map((t) => t.id);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	it("every template has a non-empty exampleSurface and intent", () => {
+		for (const t of RECIPE_TEMPLATES) {
+			expect(t.intent.length).toBeGreaterThan(0);
+			expect(t.exampleSurface.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/scripts/autoresearch/recipe-author.ts
+++ b/scripts/autoresearch/recipe-author.ts
@@ -1,18 +1,25 @@
 /**
  * Recipe-author CLI driver for #344 step 2 (gold-query regeneration).
  *
- * Pipeline:
+ * Pipeline (target end-state — most stages are stubbed in step 2b):
  *
- *   load corpus catalog + segments
- *     -> derive CatalogArtifact[]
- *     -> sampleStratified (deterministic with --seed)
- *     -> for each (sample, template) pair: ask LLM to draft a CandidateQuery
- *     -> applyAdversarialFilter (discard easy queries vector search solves)
- *     -> emit JSON for human approve/edit/reject
+ *   load corpus catalog            [WIRED — step 2b]
+ *     -> derive CatalogArtifact[]  [WIRED — step 2b]
+ *     -> sampleStratified          [WIRED — step 2b, deterministic with --seed]
+ *     -> author (sample, template) [STUB — step 2c replaces with live LLM]
+ *     -> applyAdversarialFilter    [DEFERRED — step 2c wires live retriever]
+ *     -> emit JSON for human review[WIRED — step 2b]
  *
- * The actual LLM call is **stubbed** in this PR (step 2b ships the driver
- * shell). Live authoring lands in step 2c+ per-collection runs once the
- * prompt + LLM helper integration is reviewed end-to-end.
+ * Step 2b ships the driver shell + 12 templates so the pipeline shape is
+ * reviewable end-to-end. Step 2c+ replaces the stub author with a live
+ * LLM call against the homelab patch-llm endpoint, wires the adversarial
+ * filter against the live `query()` retriever, and runs the first
+ * authoring round per collection (wtfoc-self, filoz, GitHub PR threads,
+ * podcast transcripts).
+ *
+ * Segment content (the LLM prompt context) is intentionally NOT loaded in
+ * this PR — the stub has no use for it. Step 2c adds segment loading
+ * alongside the live LLM call.
  *
  * Usage:
  *   pnpm exec tsx --tsconfig scripts/tsconfig.json \
@@ -27,9 +34,11 @@
  * @see https://github.com/SgtPooki/wtfoc/issues/344
  */
 
+import { createHash } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
 	type CandidateQuery,
 	type CatalogArtifact,
@@ -51,7 +60,25 @@ interface ParsedArgs {
 	dryRun: boolean;
 }
 
-function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
+function parsePositiveInt(name: string, raw: string | undefined): number {
+	if (!raw) throw new Error(`${name} requires a value`);
+	const n = Number.parseInt(raw, 10);
+	if (!Number.isFinite(n) || n < 1) {
+		throw new Error(`${name} must be a positive integer (got "${raw}")`);
+	}
+	return n;
+}
+
+function parseInteger(name: string, raw: string | undefined): number {
+	if (!raw) throw new Error(`${name} requires a value`);
+	const n = Number.parseInt(raw, 10);
+	if (!Number.isFinite(n)) {
+		throw new Error(`${name} must be an integer (got "${raw}")`);
+	}
+	return n;
+}
+
+export function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
 	let collection = "";
 	let output = "/tmp/recipe-candidates.json";
 	let samplesPerStratum = 2;
@@ -67,17 +94,19 @@ function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
 		} else if (a === "--output" && next) {
 			output = next;
 			i++;
-		} else if (a === "--samples-per-stratum" && next) {
-			samplesPerStratum = Number.parseInt(next, 10);
+		} else if (a === "--samples-per-stratum") {
+			samplesPerStratum = parsePositiveInt(a, next);
 			i++;
-		} else if (a === "--seed" && next) {
-			seed = Number.parseInt(next, 10);
+		} else if (a === "--seed") {
+			seed = parseInteger(a, next);
 			i++;
-		} else if (a === "--max-candidates" && next) {
-			maxCandidates = Number.parseInt(next, 10);
+		} else if (a === "--max-candidates") {
+			maxCandidates = parsePositiveInt(a, next);
 			i++;
 		} else if (a === "--dry-run") {
 			dryRun = true;
+		} else if (a !== undefined) {
+			throw new Error(`unknown flag: "${a}"`);
 		}
 	}
 	if (!collection) {
@@ -151,13 +180,24 @@ export function planAuthoring(
  * keyed by `(template.id, artifactId)` so the JSON output is reviewable
  * end-to-end. Live LLM authoring replaces this body in step 2c.
  */
+/**
+ * Build a stable id keyed by the full `(template.id, artifactId)` pair.
+ * Hashing keeps the id filesystem/JSON safe even when artifactIds carry
+ * slashes or unusual characters; the full artifactId is preserved in
+ * `expectedEvidence[0].artifactId` for human review.
+ */
+function makeCandidateId(templateId: string, artifactId: string): string {
+	const fp = createHash("sha1").update(`${templateId}::${artifactId}`).digest("hex").slice(0, 12);
+	return `${templateId}__${fp}`;
+}
+
 export function stubAuthor(
 	sample: RecipeSample,
 	template: QueryTemplate,
 	collection: string,
 ): CandidateQuery {
 	const draft: Omit<GoldQuery, "id"> & { id?: string } = {
-		id: `${template.id}__${sample.artifact.artifactId.slice(0, 24)}`,
+		id: makeCandidateId(template.id, sample.artifact.artifactId),
 		authoredFromCollectionId: collection,
 		applicableCorpora: [collection],
 		query: `[STUB ${template.id}] ${template.exampleSurface}`,
@@ -246,7 +286,10 @@ async function main(): Promise<void> {
 }
 
 // Allow this module to be imported by tests without auto-running main.
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Use `fileURLToPath` instead of string-comparing `file://` prefixes so
+// path encoding / Windows paths / symlinks all resolve consistently.
+const entryPath = process.argv[1] ?? "";
+if (entryPath && fileURLToPath(import.meta.url) === entryPath) {
 	main().catch((err) => {
 		console.error("[recipe-author] FATAL:", err);
 		process.exit(1);

--- a/scripts/autoresearch/recipe-author.ts
+++ b/scripts/autoresearch/recipe-author.ts
@@ -1,0 +1,254 @@
+/**
+ * Recipe-author CLI driver for #344 step 2 (gold-query regeneration).
+ *
+ * Pipeline:
+ *
+ *   load corpus catalog + segments
+ *     -> derive CatalogArtifact[]
+ *     -> sampleStratified (deterministic with --seed)
+ *     -> for each (sample, template) pair: ask LLM to draft a CandidateQuery
+ *     -> applyAdversarialFilter (discard easy queries vector search solves)
+ *     -> emit JSON for human approve/edit/reject
+ *
+ * The actual LLM call is **stubbed** in this PR (step 2b ships the driver
+ * shell). Live authoring lands in step 2c+ per-collection runs once the
+ * prompt + LLM helper integration is reviewed end-to-end.
+ *
+ * Usage:
+ *   pnpm exec tsx --tsconfig scripts/tsconfig.json \
+ *     scripts/autoresearch/recipe-author.ts \
+ *     --collection wtfoc-dogfood-2026-04-v3 \
+ *     --output /tmp/candidates.json \
+ *     [--samples-per-stratum 2] \
+ *     [--seed 42] \
+ *     [--max-candidates 80] \
+ *     [--dry-run]
+ *
+ * @see https://github.com/SgtPooki/wtfoc/issues/344
+ */
+
+import { writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+	type CandidateQuery,
+	type CatalogArtifact,
+	type GoldQuery,
+	type QueryTemplate,
+	type RecipeSample,
+	type Stratum,
+	sampleStratified,
+} from "@wtfoc/search";
+import { catalogFilePath, readCatalog } from "@wtfoc/ingest";
+import { RECIPE_TEMPLATES, templatesForStratum } from "./recipe-templates.js";
+
+interface ParsedArgs {
+	collection: string;
+	output: string;
+	samplesPerStratum: number;
+	seed: number;
+	maxCandidates: number;
+	dryRun: boolean;
+}
+
+function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
+	let collection = "";
+	let output = "/tmp/recipe-candidates.json";
+	let samplesPerStratum = 2;
+	let seed = 42;
+	let maxCandidates = 80;
+	let dryRun = false;
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		const next = argv[i + 1];
+		if (a === "--collection" && next) {
+			collection = next;
+			i++;
+		} else if (a === "--output" && next) {
+			output = next;
+			i++;
+		} else if (a === "--samples-per-stratum" && next) {
+			samplesPerStratum = Number.parseInt(next, 10);
+			i++;
+		} else if (a === "--seed" && next) {
+			seed = Number.parseInt(next, 10);
+			i++;
+		} else if (a === "--max-candidates" && next) {
+			maxCandidates = Number.parseInt(next, 10);
+			i++;
+		} else if (a === "--dry-run") {
+			dryRun = true;
+		}
+	}
+	if (!collection) {
+		throw new Error("usage: recipe-author --collection <id> [--output <path>] ...");
+	}
+	return { collection, output, samplesPerStratum, seed, maxCandidates, dryRun };
+}
+
+/**
+ * Seedable RNG matching the convention used elsewhere in the autoresearch
+ * scripts. Same seed -> same sample selection -> reviewable diff.
+ */
+export function seededRng(seed: number): () => number {
+	let s = seed;
+	return () => {
+		s = (s * 9301 + 49297) % 233280;
+		return s / 233280;
+	};
+}
+
+/**
+ * Convert a `DocumentCatalog` to the recipe's corpus-agnostic
+ * `CatalogArtifact[]` shape. Active documents only. Edge types are
+ * **not** populated by this minimal catalog reader — the `edges/`
+ * overlay reader will land alongside step 2c when the LLM author needs
+ * graph-shaped strata.
+ */
+export function catalogToArtifacts(catalog: {
+	documents: Record<string, { state: string; chunkIds: string[]; sourceType?: string }>;
+}): CatalogArtifact[] {
+	const out: CatalogArtifact[] = [];
+	for (const [artifactId, entry] of Object.entries(catalog.documents)) {
+		if (entry.state !== "active") continue;
+		out.push({
+			artifactId,
+			sourceType: entry.sourceType ?? "unknown",
+			contentLength: entry.chunkIds.length * 1000,
+		});
+	}
+	return out;
+}
+
+interface AuthorPlan {
+	sample: RecipeSample;
+	templates: ReadonlyArray<QueryTemplate>;
+}
+
+/**
+ * Build the (sample, template) pairing plan the LLM driver will iterate.
+ * Each sample is paired with every template applicable to its stratum,
+ * subject to a global max-candidates cap.
+ */
+export function planAuthoring(
+	samples: ReadonlyArray<RecipeSample>,
+	maxCandidates: number,
+): AuthorPlan[] {
+	const out: AuthorPlan[] = [];
+	let total = 0;
+	for (const s of samples) {
+		const templates = templatesForStratum(s.stratum);
+		if (templates.length === 0) continue;
+		out.push({ sample: s, templates });
+		total += templates.length;
+		if (total >= maxCandidates) break;
+	}
+	return out;
+}
+
+/**
+ * Stub LLM-author for step 2b. Emits a syntactically-valid `CandidateQuery`
+ * keyed by `(template.id, artifactId)` so the JSON output is reviewable
+ * end-to-end. Live LLM authoring replaces this body in step 2c.
+ */
+export function stubAuthor(
+	sample: RecipeSample,
+	template: QueryTemplate,
+	collection: string,
+): CandidateQuery {
+	const draft: Omit<GoldQuery, "id"> & { id?: string } = {
+		id: `${template.id}__${sample.artifact.artifactId.slice(0, 24)}`,
+		authoredFromCollectionId: collection,
+		applicableCorpora: [collection],
+		query: `[STUB ${template.id}] ${template.exampleSurface}`,
+		queryType: template.queryType,
+		difficulty: template.difficulty,
+		targetLayerHints: template.targetLayerHints,
+		expectedEvidence: [{ artifactId: sample.artifact.artifactId, required: true }],
+		acceptableAnswerFacts: [],
+		requiredSourceTypes: [sample.artifact.sourceType],
+		minResults: 1,
+		migrationNotes: "stub-authored: step 2b scaffolding; replace in step 2c",
+	};
+	return { template, stratum: sample.stratum, draft };
+}
+
+interface CandidatesFile {
+	collection: string;
+	seed: number;
+	totalCandidates: number;
+	stratumDistribution: Array<{ stratum: Stratum; count: number }>;
+	candidates: ReadonlyArray<CandidateQuery>;
+}
+
+function summarizeStrata(samples: ReadonlyArray<RecipeSample>): Array<{ stratum: Stratum; count: number }> {
+	const m = new Map<string, { stratum: Stratum; count: number }>();
+	for (const s of samples) {
+		const key = `${s.stratum.sourceType}::${s.stratum.edgeType ?? "_"}::${s.stratum.lengthBucket}::${s.stratum.rarity}`;
+		const cur = m.get(key) ?? { stratum: s.stratum, count: 0 };
+		cur.count++;
+		m.set(key, cur);
+	}
+	return Array.from(m.values());
+}
+
+async function main(): Promise<void> {
+	const args = parseArgs(process.argv.slice(2));
+	const manifestDir = process.env.WTFOC_MANIFEST_DIR ?? join(homedir(), ".wtfoc/projects");
+	const catPath = catalogFilePath(manifestDir, args.collection);
+	const catalog = await readCatalog(catPath);
+	if (!catalog) {
+		throw new Error(`catalog not found for collection "${args.collection}" at ${catPath}`);
+	}
+	const artifacts = catalogToArtifacts(catalog);
+	console.log(
+		`[recipe-author] collection=${args.collection} active artifacts=${artifacts.length}`,
+	);
+
+	const samples = sampleStratified(artifacts, {
+		samplesPerStratum: args.samplesPerStratum,
+		rng: seededRng(args.seed),
+		maxTotalSamples: args.maxCandidates * 2, // allow headroom; plan caps the final
+	});
+	console.log(
+		`[recipe-author] stratified samples=${samples.length} (samplesPerStratum=${args.samplesPerStratum})`,
+	);
+
+	const plan = planAuthoring(samples, args.maxCandidates);
+	const candidates: CandidateQuery[] = [];
+	for (const { sample, templates } of plan) {
+		for (const t of templates) {
+			candidates.push(stubAuthor(sample, t, args.collection));
+			if (candidates.length >= args.maxCandidates) break;
+		}
+		if (candidates.length >= args.maxCandidates) break;
+	}
+
+	const out: CandidatesFile = {
+		collection: args.collection,
+		seed: args.seed,
+		totalCandidates: candidates.length,
+		stratumDistribution: summarizeStrata(samples),
+		candidates,
+	};
+
+	if (args.dryRun) {
+		console.log(`[recipe-author] --dry-run; would write ${candidates.length} candidates`);
+		return;
+	}
+	await writeFile(args.output, JSON.stringify(out, null, 2), "utf-8");
+	console.log(
+		`[recipe-author] wrote ${candidates.length} stub candidates to ${args.output} across ${out.stratumDistribution.length} strata`,
+	);
+	console.log(
+		`[recipe-author] templates available=${RECIPE_TEMPLATES.length}; live LLM authoring lands in step 2c`,
+	);
+}
+
+// Allow this module to be imported by tests without auto-running main.
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main().catch((err) => {
+		console.error("[recipe-author] FATAL:", err);
+		process.exit(1);
+	});
+}

--- a/scripts/autoresearch/recipe-templates.ts
+++ b/scripts/autoresearch/recipe-templates.ts
@@ -1,0 +1,191 @@
+/**
+ * Stratified-template definitions for the gold-query authoring recipe
+ * (#344 step 2). Variety comes from strata, not artistry — keep this set
+ * intentionally small (12 templates). The recipe sampler pairs each
+ * template with stratum-matched artifacts; the LLM then authors candidate
+ * queries per pair.
+ *
+ * Editing rules:
+ * - Templates are intent-shaped, not surface-shaped. "Find the
+ *   implementation that closes this issue" — NOT "where is X.ts".
+ * - `exampleSurface` is for the human reviewer, not the LLM prompt.
+ *   Injecting it verbatim primes the model toward that phrasing and
+ *   collapses paraphrase invariance.
+ * - `appliesToStrata` is a soft filter — a partial-match against
+ *   `Stratum`. Empty → applies to every stratum (rare).
+ * - Adding a template here does not retroactively change existing gold
+ *   queries; step-3 corpus-authoring runs pick up the new set on next run.
+ *
+ * @see https://github.com/SgtPooki/wtfoc/issues/344
+ */
+
+import type { QueryTemplate } from "@wtfoc/search";
+
+export const RECIPE_TEMPLATES: ReadonlyArray<QueryTemplate> = [
+	// ── Lookup family ────────────────────────────────────────────────
+	{
+		id: "lookup-by-symbol",
+		intent:
+			"Surface the canonical implementation of a named symbol or concept that lives in a single artifact.",
+		queryType: "lookup",
+		difficulty: "easy",
+		targetLayerHints: ["ranking"],
+		appliesToStrata: [{ sourceType: "code" }],
+		exampleSurface: "Where is the chunker's deduplication logic?",
+	},
+	{
+		id: "lookup-doc-section",
+		intent: "Find a specific topic or section inside a long-form doc.",
+		queryType: "lookup",
+		difficulty: "medium",
+		targetLayerHints: ["chunking", "ranking"],
+		appliesToStrata: [
+			{ sourceType: "markdown" },
+			{ sourceType: "html" },
+		],
+		exampleSurface: "What does the spec say about CID encoding limits?",
+	},
+	{
+		id: "lookup-discussion",
+		intent:
+			"Surface the original discussion thread (issue / PR comment) where a decision was first proposed.",
+		queryType: "lookup",
+		difficulty: "medium",
+		targetLayerHints: ["ranking"],
+		appliesToStrata: [
+			{ sourceType: "github-issue" },
+			{ sourceType: "github-pr-comment" },
+			{ sourceType: "slack-message" },
+		],
+		exampleSurface: "Which thread first proposed deferring re-embedding?",
+	},
+
+	// ── Trace family ─────────────────────────────────────────────────
+	{
+		id: "trace-issue-to-impl",
+		intent:
+			"Walk from a discussion artifact (issue / PR comment) to the code change that landed for it. Should require ≥1 edge hop.",
+		queryType: "trace",
+		difficulty: "hard",
+		targetLayerHints: ["edge-extraction", "trace"],
+		appliesToStrata: [
+			{ sourceType: "github-issue", edgeType: "closes" },
+			{ sourceType: "github-issue", edgeType: "references" },
+			{ sourceType: "github-pr", edgeType: "closes" },
+		],
+		exampleSurface: "Which PR closed the issue about overlay-edge merge order?",
+	},
+	{
+		id: "trace-impl-to-rationale",
+		intent:
+			"Reverse direction of trace-issue-to-impl: walk from a code artifact back to the discussion that motivated it.",
+		queryType: "trace",
+		difficulty: "hard",
+		targetLayerHints: ["edge-extraction", "trace"],
+		appliesToStrata: [{ sourceType: "code", edgeType: "closes" }],
+		exampleSurface: "Why was this rate-limit constant changed?",
+	},
+	{
+		id: "trace-cross-source",
+		intent:
+			"Question whose answer requires evidence from ≥2 source types — e.g. a Slack thread referenced in a PR description that closes a GitHub issue.",
+		queryType: "trace",
+		difficulty: "hard",
+		targetLayerHints: ["trace"],
+		exampleSurface:
+			"How did the team decide between two competing chunking strategies?",
+	},
+
+	// ── Compare ───────────────────────────────────────────────────────
+	{
+		id: "compare-implementations",
+		intent:
+			"Compare two competing implementations or approaches that exist in different artifacts. Both must surface for the answer.",
+		queryType: "compare",
+		difficulty: "hard",
+		targetLayerHints: ["ranking", "trace"],
+		appliesToStrata: [{ sourceType: "code" }],
+		exampleSurface:
+			"What's the difference between the in-memory and disk-backed chunkers?",
+	},
+
+	// ── Howto / synthesis ─────────────────────────────────────────────
+	{
+		id: "howto-task",
+		intent:
+			"Open-ended question whose answer requires reading 2–3 artifacts and synthesizing a procedure.",
+		queryType: "howto",
+		difficulty: "medium",
+		targetLayerHints: ["ranking", "trace"],
+		exampleSurface: "How would I add a new SourceAdapter for X?",
+	},
+
+	// ── Temporal ──────────────────────────────────────────────────────
+	{
+		id: "temporal-when-changed",
+		intent:
+			"When did a documented behavior or contract change? Relies on commit timestamps + edge-extraction across versions.",
+		queryType: "temporal",
+		difficulty: "hard",
+		targetLayerHints: ["edge-extraction", "trace"],
+		appliesToStrata: [{ sourceType: "code" }, { sourceType: "github-pr" }],
+		exampleSurface: "When did chunker dedup change to per-segment?",
+	},
+
+	// ── Causal ────────────────────────────────────────────────────────
+	{
+		id: "causal-why",
+		intent:
+			"Question whose answer requires inferring a cause-effect chain across artifacts (issue → fix → regression note).",
+		queryType: "causal",
+		difficulty: "hard",
+		targetLayerHints: ["edge-extraction", "trace"],
+		exampleSurface:
+			"Why did segment-builder start emitting empty segments after the v0.4 release?",
+	},
+
+	// ── Entity resolution ─────────────────────────────────────────────
+	{
+		id: "entity-resolution-canonical",
+		intent:
+			"Same concept appears in multiple artifacts under different names; resolve which entries refer to the same canonical thing.",
+		queryType: "entity-resolution",
+		difficulty: "hard",
+		targetLayerHints: ["edge-extraction", "trace"],
+		exampleSurface:
+			"Which threads, issues, and code paths all refer to the 'piece-cid' concept?",
+	},
+
+	// ── Coverage / hard negative scaffold ─────────────────────────────
+	{
+		id: "lookup-rare-edge",
+		intent:
+			"Lookup that targets the rare-stratum tail — artifacts that participate in uncommon edge types. Tests that retrieval doesn't ignore the long-tail.",
+		queryType: "lookup",
+		difficulty: "hard",
+		targetLayerHints: ["embedding", "ranking"],
+		appliesToStrata: [{ rarity: "rare" }],
+		exampleSurface:
+			"Where is the encryption-at-rest policy declared for the storage backend?",
+	},
+];
+
+/**
+ * Filter templates that apply to a given stratum. A template applies when
+ * its `appliesToStrata` is empty OR when ≥1 partial-match matches the
+ * stratum's axis values. Used by the recipe-author driver to pick a
+ * template set per sampled artifact.
+ */
+export function templatesForStratum(
+	stratum: { sourceType: string; edgeType: string | null; rarity: "common" | "rare" },
+): ReadonlyArray<QueryTemplate> {
+	return RECIPE_TEMPLATES.filter((t) => {
+		if (!t.appliesToStrata || t.appliesToStrata.length === 0) return true;
+		return t.appliesToStrata.some((p) => {
+			if (p.sourceType && p.sourceType !== stratum.sourceType) return false;
+			if (p.edgeType !== undefined && p.edgeType !== stratum.edgeType) return false;
+			if (p.rarity && p.rarity !== stratum.rarity) return false;
+			return true;
+		});
+	});
+}

--- a/scripts/autoresearch/recipe-templates.ts
+++ b/scripts/autoresearch/recipe-templates.ts
@@ -19,7 +19,7 @@
  * @see https://github.com/SgtPooki/wtfoc/issues/344
  */
 
-import type { QueryTemplate } from "@wtfoc/search";
+import type { QueryTemplate, Stratum } from "@wtfoc/search";
 
 export const RECIPE_TEMPLATES: ReadonlyArray<QueryTemplate> = [
 	// ── Lookup family ────────────────────────────────────────────────
@@ -177,7 +177,7 @@ export const RECIPE_TEMPLATES: ReadonlyArray<QueryTemplate> = [
  * template set per sampled artifact.
  */
 export function templatesForStratum(
-	stratum: { sourceType: string; edgeType: string | null; rarity: "common" | "rare" },
+	stratum: Pick<Stratum, "sourceType" | "edgeType" | "rarity">,
 ): ReadonlyArray<QueryTemplate> {
 	return RECIPE_TEMPLATES.filter((t) => {
 		if (!t.appliesToStrata || t.appliesToStrata.length === 0) return true;


### PR DESCRIPTION
## Summary

#344 step 2b. Driver shell that turns the recipe primitives from #353 into an end-to-end author run for one collection.

```
load corpus catalog + segments
  -> derive CatalogArtifact[]
  -> sampleStratified (deterministic with --seed)
  -> for each (sample, template) pair: author CandidateQuery
  -> applyAdversarialFilter (deferred to live wiring)
  -> emit JSON for human approve/edit/reject
```

## What ships

- `scripts/autoresearch/recipe-templates.ts` — 12 intent-shaped templates (variety from strata, not artistry per peer-review consensus). Covers lookup / trace / compare / howto / temporal / causal / entity-resolution / hard-stratum rare-edge. Each carries an `appliesToStrata` partial filter; `templatesForStratum()` helper resolves the applicable subset per sample.
- `scripts/autoresearch/recipe-author.ts` — CLI driver. Args: `--collection`, `--output`, `--samples-per-stratum`, `--seed`, `--max-candidates`, `--dry-run`. Reads the catalog via `@wtfoc/ingest`, samples via `@wtfoc/search`, pairs samples with applicable templates, emits a stub `CandidateQuery` per pair.
- 18 unit tests cover the deterministic parts.

## What's deliberately stubbed

`stubAuthor()` returns a syntactically-valid `CandidateQuery` keyed by `(template.id, artifactId)` so the JSON output is reviewable end-to-end. **Step 2c replaces the stub body with a real LLM call** against the homelab patch-llm endpoint, runs the adversarial filter against the live retriever, and emits the first wave of grounded queries for wtfoc-self.

## Out of scope

- LLM call (step 2c).
- Adversarial filter live wiring (step 2c).
- Per-collection authoring runs (steps 2c–2e: wtfoc-self, filoz, GitHub PR threads, podcast transcripts).
- Edge-overlay reader for graph-shaped strata (lands with 2c when needed).

## Test plan

- [x] 18 unit tests on `seededRng`, `catalogToArtifacts`, `templatesForStratum`, `planAuthoring`, `stubAuthor`, `RECIPE_TEMPLATES` invariants.
- [x] `pnpm test`: 1716 passed, 2 skipped.
- [x] `pnpm lint:fix` clean.
- [x] `pnpm -r build` clean.

refs #344