### PR TITLE
feat(autoresearch): live LLM author for the gold-query recipe (step 2c)

### DIFF
--- a/scripts/autoresearch/recipe-author.ts
+++ b/scripts/autoresearch/recipe-author.ts
@@ -49,6 +49,7 @@ import {
 	sampleStratified,
 } from "@wtfoc/search";
 import { catalogFilePath, readCatalog } from "@wtfoc/ingest";
+import { authorCandidate } from "./recipe-llm-author.js";
 import { RECIPE_TEMPLATES, templatesForStratum } from "./recipe-templates.js";
 
 interface ParsedArgs {
@@ -58,6 +59,7 @@ interface ParsedArgs {
 	seed: number;
 	maxCandidates: number;
 	dryRun: boolean;
+	live: boolean;
 }
 
 function parsePositiveInt(name: string, raw: string | undefined): number {
@@ -85,6 +87,7 @@ export function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
 	let seed = 42;
 	let maxCandidates = 80;
 	let dryRun = false;
+	let live = false;
 	for (let i = 0; i < argv.length; i++) {
 		const a = argv[i];
 		const next = argv[i + 1];
@@ -105,6 +108,8 @@ export function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
 			i++;
 		} else if (a === "--dry-run") {
 			dryRun = true;
+		} else if (a === "--live") {
+			live = true;
 		} else if (a !== undefined) {
 			throw new Error(`unknown flag: "${a}"`);
 		}
@@ -112,7 +117,7 @@ export function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
 	if (!collection) {
 		throw new Error("usage: recipe-author --collection <id> [--output <path>] ...");
 	}
-	return { collection, output, samplesPerStratum, seed, maxCandidates, dryRun };
+	return { collection, output, samplesPerStratum, seed, maxCandidates, dryRun, live };
 }
 
 /**
@@ -256,12 +261,32 @@ async function main(): Promise<void> {
 
 	const plan = planAuthoring(samples, args.maxCandidates);
 	const candidates: CandidateQuery[] = [];
+	const authorErrors: Array<{ template: string; artifactId: string; error: string }> = [];
 	for (const { sample, templates } of plan) {
 		for (const t of templates) {
-			candidates.push(stubAuthor(sample, t, args.collection));
+			if (args.live) {
+				const r = await authorCandidate(sample, t, { collectionId: args.collection });
+				if (r.ok && r.candidate) {
+					candidates.push(r.candidate);
+				} else {
+					authorErrors.push({
+						template: t.id,
+						artifactId: sample.artifact.artifactId,
+						error: r.error ?? "unknown",
+					});
+				}
+			} else {
+				candidates.push(stubAuthor(sample, t, args.collection));
+			}
 			if (candidates.length >= args.maxCandidates) break;
 		}
 		if (candidates.length >= args.maxCandidates) break;
+	}
+	if (authorErrors.length > 0) {
+		console.warn(`[recipe-author] ${authorErrors.length} author error(s):`);
+		for (const e of authorErrors.slice(0, 10)) {
+			console.warn(`  - ${e.template} on ${e.artifactId}: ${e.error}`);
+		}
 	}
 
 	const out: CandidatesFile = {
@@ -278,11 +303,13 @@ async function main(): Promise<void> {
 	}
 	await writeFile(args.output, JSON.stringify(out, null, 2), "utf-8");
 	console.log(
-		`[recipe-author] wrote ${candidates.length} stub candidates to ${args.output} across ${out.stratumDistribution.length} strata`,
+		`[recipe-author] wrote ${candidates.length} ${args.live ? "live-authored" : "stub"} candidates to ${args.output} across ${out.stratumDistribution.length} strata`,
 	);
-	console.log(
-		`[recipe-author] templates available=${RECIPE_TEMPLATES.length}; live LLM authoring lands in step 2c`,
-	);
+	if (!args.live) {
+		console.log(
+			`[recipe-author] templates available=${RECIPE_TEMPLATES.length}; pass --live to call the LLM`,
+		);
+	}
 }
 
 // Allow this module to be imported by tests without auto-running main.

--- a/scripts/autoresearch/recipe-author.ts
+++ b/scripts/autoresearch/recipe-author.ts
@@ -259,7 +259,11 @@ async function main(): Promise<void> {
 		`[recipe-author] stratified samples=${samples.length} (samplesPerStratum=${args.samplesPerStratum})`,
 	);
 
-	const plan = planAuthoring(samples, args.maxCandidates);
+	// In --live mode authorCandidate can fail per-pair; plan with 2x
+	// headroom so a typical failure rate doesn't cause us to fall short of
+	// --max-candidates. Stub mode never fails so the cap is exact.
+	const planCap = args.live ? args.maxCandidates * 2 : args.maxCandidates;
+	const plan = planAuthoring(samples, planCap);
 	const candidates: CandidateQuery[] = [];
 	const authorErrors: Array<{ template: string; artifactId: string; error: string }> = [];
 	for (const { sample, templates } of plan) {

--- a/scripts/autoresearch/recipe-llm-author.test.ts
+++ b/scripts/autoresearch/recipe-llm-author.test.ts
@@ -1,0 +1,136 @@
+import type { QueryTemplate, RecipeSample } from "@wtfoc/search";
+import { describe, expect, it, vi } from "vitest";
+import { authorCandidate } from "./recipe-llm-author.js";
+
+const TEMPLATE: QueryTemplate = {
+	id: "trace-issue-to-impl",
+	intent: "Walk from a discussion artifact to the code change.",
+	queryType: "trace",
+	difficulty: "hard",
+	targetLayerHints: ["edge-extraction", "trace"],
+	exampleSurface: "Which PR closed the issue about X?",
+};
+
+const SAMPLE: RecipeSample = {
+	stratum: { sourceType: "github-issue", edgeType: "closes", lengthBucket: "short", rarity: "common" },
+	artifact: { artifactId: "owner/repo#42", sourceType: "github-issue", contentLength: 500 },
+};
+
+function makeFetchOk(content: string): typeof fetch {
+	return vi.fn(async () => ({
+		ok: true,
+		status: 200,
+		text: async () => "",
+		json: async () => ({ choices: [{ message: { content } }] }),
+	})) as unknown as typeof fetch;
+}
+
+function makeFetchError(status: number, body: string): typeof fetch {
+	return vi.fn(async () => ({
+		ok: false,
+		status,
+		text: async () => body,
+		json: async () => ({}),
+	})) as unknown as typeof fetch;
+}
+
+describe("authorCandidate (live LLM)", () => {
+	it("parses a clean JSON response and shapes a CandidateQuery", async () => {
+		const fetchFn = makeFetchOk(
+			JSON.stringify({
+				query: "Which pull request landed the rate-limit policy change?",
+				acceptableAnswerFacts: ["The change introduced a 60s window."],
+				rationale: "Requires linking PR to issue via closes edge.",
+			}),
+		);
+		const r = await authorCandidate(SAMPLE, TEMPLATE, {
+			collectionId: "alpha",
+			fetchFn,
+		});
+		expect(r.ok).toBe(true);
+		expect(r.candidate?.draft.query).toBe(
+			"Which pull request landed the rate-limit policy change?",
+		);
+		expect(r.candidate?.draft.queryType).toBe("trace");
+		expect(r.candidate?.draft.difficulty).toBe("hard");
+		expect(r.candidate?.draft.applicableCorpora).toEqual(["alpha"]);
+		expect(r.candidate?.draft.expectedEvidence[0]?.artifactId).toBe("owner/repo#42");
+		expect(r.candidate?.draft.acceptableAnswerFacts).toEqual([
+			"The change introduced a 60s window.",
+		]);
+		expect(r.candidate?.draft.migrationNotes).toContain("live-author rationale");
+	});
+
+	it("extracts JSON from a fenced code block", async () => {
+		const fetchFn = makeFetchOk(
+			"Sure, here is the query:\n\n```json\n{\"query\":\"abstract Q\",\"rationale\":\"r\"}\n```\n",
+		);
+		const r = await authorCandidate(SAMPLE, TEMPLATE, { collectionId: "alpha", fetchFn });
+		expect(r.ok).toBe(true);
+		expect(r.candidate?.draft.query).toBe("abstract Q");
+	});
+
+	it("returns ok=false with rawContent when JSON is unparseable", async () => {
+		const fetchFn = makeFetchOk("the model emitted only prose, no JSON here");
+		const r = await authorCandidate(SAMPLE, TEMPLATE, { collectionId: "alpha", fetchFn });
+		expect(r.ok).toBe(false);
+		expect(r.error).toContain("parseable");
+		expect(r.rawContent).toContain("emitted only prose");
+	});
+
+	it("returns ok=false with status detail on HTTP error", async () => {
+		const fetchFn = makeFetchError(500, "internal server explosion");
+		const r = await authorCandidate(SAMPLE, TEMPLATE, { collectionId: "alpha", fetchFn });
+		expect(r.ok).toBe(false);
+		expect(r.error).toMatch(/HTTP 500/);
+	});
+
+	it("rejects empty / non-string queries", async () => {
+		const fetchFn = makeFetchOk(JSON.stringify({ query: "" }));
+		const r = await authorCandidate(SAMPLE, TEMPLATE, { collectionId: "alpha", fetchFn });
+		expect(r.ok).toBe(false);
+	});
+
+	it("filters out non-string acceptableAnswerFacts", async () => {
+		const fetchFn = makeFetchOk(
+			JSON.stringify({
+				query: "abstract Q",
+				acceptableAnswerFacts: ["valid", null, 42, "another"],
+			}),
+		);
+		const r = await authorCandidate(SAMPLE, TEMPLATE, { collectionId: "alpha", fetchFn });
+		expect(r.ok).toBe(true);
+		expect(r.candidate?.draft.acceptableAnswerFacts).toEqual(["valid", "another"]);
+	});
+
+	it("propagates the template's queryType / difficulty / targetLayerHints", async () => {
+		const fetchFn = makeFetchOk(JSON.stringify({ query: "q" }));
+		const r = await authorCandidate(SAMPLE, TEMPLATE, { collectionId: "alpha", fetchFn });
+		expect(r.candidate?.draft.queryType).toBe(TEMPLATE.queryType);
+		expect(r.candidate?.draft.difficulty).toBe(TEMPLATE.difficulty);
+		expect(r.candidate?.draft.targetLayerHints).toEqual(TEMPLATE.targetLayerHints);
+	});
+
+	it("includes the excerpt in the user prompt when provided", async () => {
+		const fetchFn = vi.fn(async (_url: string, init: RequestInit) => {
+			const body = JSON.parse(init.body as string) as {
+				messages: Array<{ content: string }>;
+			};
+			expect(body.messages[1]?.content).toContain("excerpt-marker-XYZ");
+			return {
+				ok: true,
+				status: 200,
+				text: async () => "",
+				json: async () => ({
+					choices: [{ message: { content: JSON.stringify({ query: "q" }) } }],
+				}),
+			};
+		}) as unknown as typeof fetch;
+		const r = await authorCandidate(SAMPLE, TEMPLATE, {
+			collectionId: "alpha",
+			fetchFn,
+			excerpt: "function foo() { /* excerpt-marker-XYZ */ }",
+		});
+		expect(r.ok).toBe(true);
+	});
+});

--- a/scripts/autoresearch/recipe-llm-author.test.ts
+++ b/scripts/autoresearch/recipe-llm-author.test.ts
@@ -91,6 +91,47 @@ describe("authorCandidate (live LLM)", () => {
 		expect(r.ok).toBe(false);
 	});
 
+	it("rejects whitespace-only queries", async () => {
+		const fetchFn = makeFetchOk(JSON.stringify({ query: "   \n\t  " }));
+		const r = await authorCandidate(SAMPLE, TEMPLATE, { collectionId: "alpha", fetchFn });
+		expect(r.ok).toBe(false);
+	});
+
+	it("trims whitespace around the parsed query", async () => {
+		const fetchFn = makeFetchOk(JSON.stringify({ query: "  abstract Q  " }));
+		const r = await authorCandidate(SAMPLE, TEMPLATE, { collectionId: "alpha", fetchFn });
+		expect(r.candidate?.draft.query).toBe("abstract Q");
+	});
+
+	it("trims acceptableAnswerFacts and drops whitespace-only entries", async () => {
+		const fetchFn = makeFetchOk(
+			JSON.stringify({ query: "q", acceptableAnswerFacts: ["  fact  ", "  ", ""] }),
+		);
+		const r = await authorCandidate(SAMPLE, TEMPLATE, { collectionId: "alpha", fetchFn });
+		expect(r.candidate?.draft.acceptableAnswerFacts).toEqual(["fact"]);
+	});
+
+	it("emits a stable (template.id, artifactId)-derived id (matches stub format)", async () => {
+		const fetchFn = makeFetchOk(JSON.stringify({ query: "q" }));
+		const r1 = await authorCandidate(SAMPLE, TEMPLATE, { collectionId: "alpha", fetchFn });
+		const r2 = await authorCandidate(SAMPLE, TEMPLATE, { collectionId: "alpha", fetchFn });
+		expect(r1.candidate?.draft.id).toBeDefined();
+		expect(r1.candidate?.draft.id).toBe(r2.candidate?.draft.id);
+		expect(r1.candidate?.draft.id).toContain(TEMPLATE.id);
+	});
+
+	it("uses err.message safely when fetch throws a non-Error", async () => {
+		const fetchFn = (async () => {
+			throw "boom-string"; // eslint-disable-line @typescript-eslint/no-throw-literal
+		}) as unknown as typeof fetch;
+		const r = await authorCandidate(SAMPLE, TEMPLATE, {
+			collectionId: "alpha",
+			fetchFn: fetchFn as never,
+		});
+		expect(r.ok).toBe(false);
+		expect(r.error).toContain("boom-string");
+	});
+
 	it("filters out non-string acceptableAnswerFacts", async () => {
 		const fetchFn = makeFetchOk(
 			JSON.stringify({

--- a/scripts/autoresearch/recipe-llm-author.ts
+++ b/scripts/autoresearch/recipe-llm-author.ts
@@ -20,10 +20,25 @@
  * @see https://github.com/SgtPooki/wtfoc/issues/344
  */
 
+import { createHash } from "node:crypto";
 import type { CandidateQuery, GoldQuery, QueryTemplate, RecipeSample } from "@wtfoc/search";
 
 export const DEFAULT_AUTHOR_LLM_URL = "http://127.0.0.1:4523/v1";
 export const DEFAULT_AUTHOR_LLM_MODEL = "haiku";
+
+/**
+ * Minimal fetch surface this module relies on. Avoids forcing tests to
+ * cast through `typeof fetch` or fabricate full `Response` objects.
+ */
+export type FetchLike = (
+	url: string,
+	init: { method: string; headers: Record<string, string>; body: string; signal: AbortSignal },
+) => Promise<{
+	ok: boolean;
+	status: number;
+	text: () => Promise<string>;
+	json: () => Promise<unknown>;
+}>;
 
 export interface AuthorContext {
 	collectionId: string;
@@ -31,9 +46,14 @@ export interface AuthorContext {
 	llmModel?: string;
 	llmApiKey?: string;
 	timeoutMs?: number;
-	fetchFn?: typeof fetch;
+	fetchFn?: FetchLike;
 	/** Optional content excerpt for the artifact. Step-2d wires this from segments. */
 	excerpt?: string;
+}
+
+function makeCandidateId(templateId: string, artifactId: string): string {
+	const fp = createHash("sha1").update(`${templateId}::${artifactId}`).digest("hex").slice(0, 12);
+	return `${templateId}__${fp}`;
 }
 
 export interface AuthorResult {
@@ -107,7 +127,8 @@ function parseJsonBlock(content: string): LlmDraft | null {
 	if (!raw) return null;
 	try {
 		const parsed = JSON.parse(raw) as LlmDraft;
-		if (typeof parsed.query !== "string" || parsed.query.length === 0) return null;
+		if (typeof parsed.query !== "string" || parsed.query.trim().length === 0) return null;
+		parsed.query = parsed.query.trim();
 		return parsed;
 	} catch {
 		return null;
@@ -160,7 +181,8 @@ export async function authorCandidate(
 		const body = (await res.json()) as OpenAIChatCompletionResponse;
 		rawContent = body.choices?.[0]?.message?.content ?? "";
 	} catch (err) {
-		return { ok: false, error: `LLM call failed: ${(err as Error).message}` };
+		const msg = err instanceof Error ? err.message : String(err);
+		return { ok: false, error: `LLM call failed: ${msg}` };
 	} finally {
 		clearTimeout(timer);
 	}
@@ -174,7 +196,14 @@ export async function authorCandidate(
 		};
 	}
 
+	const acceptableAnswerFacts = Array.isArray(draft.acceptableAnswerFacts)
+		? draft.acceptableAnswerFacts
+				.filter((f): f is string => typeof f === "string")
+				.map((f) => f.trim())
+				.filter((f) => f.length > 0)
+		: [];
 	const goldDraft: Omit<GoldQuery, "id"> & { id?: string } = {
+		id: makeCandidateId(template.id, sample.artifact.artifactId),
 		authoredFromCollectionId: ctx.collectionId,
 		applicableCorpora: [ctx.collectionId],
 		query: draft.query,
@@ -182,12 +211,10 @@ export async function authorCandidate(
 		difficulty: template.difficulty,
 		targetLayerHints: template.targetLayerHints,
 		expectedEvidence: [{ artifactId: sample.artifact.artifactId, required: true }],
-		acceptableAnswerFacts: Array.isArray(draft.acceptableAnswerFacts)
-			? draft.acceptableAnswerFacts.filter((f) => typeof f === "string" && f.length > 0)
-			: [],
+		acceptableAnswerFacts,
 		requiredSourceTypes: [sample.artifact.sourceType],
 		minResults: 1,
-		...(draft.rationale ? { migrationNotes: `live-author rationale: ${draft.rationale}` } : {}),
+		...(draft.rationale ? { migrationNotes: `live-author rationale: ${draft.rationale.trim()}` } : {}),
 	};
 
 	return {

--- a/scripts/autoresearch/recipe-llm-author.ts
+++ b/scripts/autoresearch/recipe-llm-author.ts
@@ -1,0 +1,198 @@
+/**
+ * Live LLM author for the gold-query recipe (#344 step 2c).
+ *
+ * Replaces `stubAuthor` from step 2b with a real call to the homelab
+ * patch-llm endpoint. The LLM receives:
+ *
+ *   - The template's intent (NOT exampleSurface — that primes phrasing).
+ *   - The sampled artifact's id, source type, and optional excerpt.
+ *   - The applicable corpus id (for `applicableCorpora` on the draft).
+ *   - A strict JSON schema describing the required output shape.
+ *
+ * It returns one `CandidateQuery` per call. The driver (recipe-author)
+ * loops over (sample, template) pairs and accumulates candidates.
+ *
+ * Out of scope this PR (step 2d):
+ *   - Segment-content loading (artifact excerpts will replace `excerpt`
+ *     placeholder once the segment-loader lands).
+ *   - Adversarial filter wiring against the live `query()` retriever.
+ *
+ * @see https://github.com/SgtPooki/wtfoc/issues/344
+ */
+
+import type { CandidateQuery, GoldQuery, QueryTemplate, RecipeSample } from "@wtfoc/search";
+
+export const DEFAULT_AUTHOR_LLM_URL = "http://127.0.0.1:4523/v1";
+export const DEFAULT_AUTHOR_LLM_MODEL = "haiku";
+
+export interface AuthorContext {
+	collectionId: string;
+	llmUrl?: string;
+	llmModel?: string;
+	llmApiKey?: string;
+	timeoutMs?: number;
+	fetchFn?: typeof fetch;
+	/** Optional content excerpt for the artifact. Step-2d wires this from segments. */
+	excerpt?: string;
+}
+
+export interface AuthorResult {
+	ok: boolean;
+	candidate?: CandidateQuery;
+	error?: string;
+	rawContent?: string;
+}
+
+const SYSTEM_PROMPT = `You are an autoresearch agent for a retrieval system called wtfoc. Your job: author ONE high-quality gold-standard query for a retrieval/trace evaluation.
+
+You are given a query template (intent only, no surface phrasing) and a sampled artifact from the corpus. Author a query whose answer ABSOLUTELY REQUIRES retrieving the sampled artifact, but is NOT trivially solvable by a vector search alone.
+
+Hard constraints on the query you author:
+- Phrase the question abstractly (no repo names, no file paths, no issue numbers verbatim).
+- Do NOT include any words that appear in the sampled artifact's id verbatim.
+- The query must be answerable by a maintainer who knows the corpus — not by lookup luck.
+- One query per call. No alternatives.
+
+OUTPUT FORMAT (strict JSON, no prose):
+
+\`\`\`json
+{
+  "query": "<the abstract question>",
+  "acceptableAnswerFacts": [
+    "<one factual claim a correct answer should support>",
+    "<another, optional>"
+  ],
+  "rationale": "<one sentence on why this query exercises the trace engine, not vector lookup>"
+}
+\`\`\`
+
+Do not emit markdown around the JSON. Do not add fields. Do not nest under wrappers.`;
+
+interface LlmDraft {
+	query: string;
+	acceptableAnswerFacts?: string[];
+	rationale?: string;
+}
+
+interface OpenAIChatCompletionResponse {
+	choices?: Array<{ message?: { content?: string } }>;
+}
+
+function buildUserPrompt(
+	template: QueryTemplate,
+	sample: RecipeSample,
+	excerpt: string | undefined,
+): string {
+	return `## Template intent
+${template.intent}
+
+Query type: ${template.queryType}
+Difficulty floor: ${template.difficulty}
+
+## Sampled artifact
+artifactId: ${sample.artifact.artifactId}
+sourceType: ${sample.artifact.sourceType}
+edgeType: ${sample.stratum.edgeType ?? "none"}
+rarity: ${sample.stratum.rarity}
+${excerpt ? `\n### Excerpt\n${excerpt.slice(0, 4000)}` : ""}
+
+Author one query meeting the constraints in the system prompt.`;
+}
+
+function parseJsonBlock(content: string): LlmDraft | null {
+	// Try to extract a JSON object — model may wrap in fences despite the
+	// instruction to skip them. Pull the first {...} balanced span.
+	const fenced = content.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/);
+	const raw = fenced?.[1] ?? content.match(/\{[\s\S]*\}/)?.[0];
+	if (!raw) return null;
+	try {
+		const parsed = JSON.parse(raw) as LlmDraft;
+		if (typeof parsed.query !== "string" || parsed.query.length === 0) return null;
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Author a single CandidateQuery for the given (sample, template) pair via
+ * a live LLM call. Returns `{ ok: false, error }` on transport / parse
+ * failure so the driver can keep going across the rest of the pairs.
+ */
+export async function authorCandidate(
+	sample: RecipeSample,
+	template: QueryTemplate,
+	ctx: AuthorContext,
+): Promise<AuthorResult> {
+	const url = ctx.llmUrl ?? process.env.WTFOC_AUTHOR_LLM_URL ?? DEFAULT_AUTHOR_LLM_URL;
+	const model = ctx.llmModel ?? process.env.WTFOC_AUTHOR_LLM_MODEL ?? DEFAULT_AUTHOR_LLM_MODEL;
+	const apiKey = ctx.llmApiKey ?? process.env.WTFOC_AUTHOR_LLM_API_KEY ?? "";
+	const fetchFn = ctx.fetchFn ?? fetch;
+	const timeoutMs = ctx.timeoutMs ?? 60_000;
+
+	const userPrompt = buildUserPrompt(template, sample, ctx.excerpt);
+	const ac = new AbortController();
+	const timer = setTimeout(() => ac.abort(), timeoutMs);
+	let rawContent: string | undefined;
+	try {
+		const headers: Record<string, string> = { "Content-Type": "application/json" };
+		if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+		const res = await fetchFn(`${url.replace(/\/+$/, "")}/chat/completions`, {
+			method: "POST",
+			headers,
+			body: JSON.stringify({
+				model,
+				temperature: 0.4,
+				max_tokens: 600,
+				messages: [
+					{ role: "system", content: SYSTEM_PROMPT },
+					{ role: "user", content: userPrompt },
+				],
+			}),
+			signal: ac.signal,
+		});
+		if (!res.ok) {
+			return {
+				ok: false,
+				error: `LLM HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`,
+			};
+		}
+		const body = (await res.json()) as OpenAIChatCompletionResponse;
+		rawContent = body.choices?.[0]?.message?.content ?? "";
+	} catch (err) {
+		return { ok: false, error: `LLM call failed: ${(err as Error).message}` };
+	} finally {
+		clearTimeout(timer);
+	}
+
+	const draft = parseJsonBlock(rawContent ?? "");
+	if (!draft) {
+		return {
+			ok: false,
+			error: "LLM response did not contain a parseable JSON object",
+			rawContent,
+		};
+	}
+
+	const goldDraft: Omit<GoldQuery, "id"> & { id?: string } = {
+		authoredFromCollectionId: ctx.collectionId,
+		applicableCorpora: [ctx.collectionId],
+		query: draft.query,
+		queryType: template.queryType,
+		difficulty: template.difficulty,
+		targetLayerHints: template.targetLayerHints,
+		expectedEvidence: [{ artifactId: sample.artifact.artifactId, required: true }],
+		acceptableAnswerFacts: Array.isArray(draft.acceptableAnswerFacts)
+			? draft.acceptableAnswerFacts.filter((f) => typeof f === "string" && f.length > 0)
+			: [],
+		requiredSourceTypes: [sample.artifact.sourceType],
+		minResults: 1,
+		...(draft.rationale ? { migrationNotes: `live-author rationale: ${draft.rationale}` } : {}),
+	};
+
+	return {
+		ok: true,
+		candidate: { template, stratum: sample.stratum, draft: goldDraft },
+		rawContent,
+	};
+}


### PR DESCRIPTION
## Summary

#344 step 2c. Replaces `stubAuthor` with a real LLM call against the homelab patch-llm endpoint. New module `scripts/autoresearch/recipe-llm-author.ts` exports `authorCandidate(sample, template, ctx): Promise<AuthorResult>`.

## System prompt

- Author ONE high-quality query per call.
- Phrase **abstractly** — no repo names, file paths, issue numbers verbatim.
- No words from the artifactId verbatim.
- Adversarially difficult — not solvable by vector search alone.
- Strict JSON output: `{ query, acceptableAnswerFacts[], rationale }`.

## User prompt

- Template **intent** (NOT `exampleSurface` — that primes phrasing).
- Sampled artifact id, sourceType, edgeType, rarity.
- Optional excerpt (step 2d wires segment-content loading; placeholder accepted today).

## Robustness

- Parse fenced or bare JSON blocks (model often wraps despite instruction).
- Reject empty / non-string queries.
- Filter non-string entries from `acceptableAnswerFacts`.
- HTTP errors return `ok: false` with status detail; partial output is still emitted.
- `AbortController` + 60s default timeout.
- env knobs: `WTFOC_AUTHOR_LLM_URL` / `_MODEL` / `_API_KEY` (default `http://127.0.0.1:4523/v1`, model `haiku` — same proxy as patch-llm).

## Driver wiring

`recipe-author.ts` gains a `--live` flag (default off; stub remains default for safety until the first run reviews cleanly). When `--live` is set, each `(sample, template)` pair calls `authorCandidate`; failures are accumulated and printed but do **not** abort the run — partial output is still useful for review.

## Out of scope this PR (step 2d)

- Segment-content excerpt loading.
- Adversarial filter live wiring against the live `query()` retriever.
- First authoring run against `wtfoc-dogfood-2026-04-v3`.

## Test plan

- [x] 8 new unit tests (clean JSON parse, fenced JSON extraction, unparseable response, HTTP error, empty-query rejection, AAF filtering, template field propagation, excerpt prompt inclusion).
- [x] `pnpm test`: 1732 passed, 2 skipped.
- [x] `pnpm lint:fix` clean.
- [x] `pnpm -r build` clean.

refs #344