### PR TITLE
feat(autoresearch): segment-content excerpt loader for recipe author (step 2d)

### DIFF
--- a/scripts/autoresearch/recipe-author.ts
+++ b/scripts/autoresearch/recipe-author.ts
@@ -1,25 +1,20 @@
 /**
  * Recipe-author CLI driver for #344 step 2 (gold-query regeneration).
  *
- * Pipeline (target end-state — most stages are stubbed in step 2b):
+ * Pipeline (status as of step 2d):
  *
  *   load corpus catalog            [WIRED — step 2b]
  *     -> derive CatalogArtifact[]  [WIRED — step 2b]
  *     -> sampleStratified          [WIRED — step 2b, deterministic with --seed]
- *     -> author (sample, template) [STUB — step 2c replaces with live LLM]
- *     -> applyAdversarialFilter    [DEFERRED — step 2c wires live retriever]
+ *     -> load segment excerpts     [WIRED — step 2d, --live only]
+ *     -> author (sample, template) [WIRED — step 2c live LLM under --live]
+ *     -> applyAdversarialFilter    [DEFERRED — step 2e wires live retriever]
  *     -> emit JSON for human review[WIRED — step 2b]
  *
- * Step 2b ships the driver shell + 12 templates so the pipeline shape is
- * reviewable end-to-end. Step 2c+ replaces the stub author with a live
- * LLM call against the homelab patch-llm endpoint, wires the adversarial
- * filter against the live `query()` retriever, and runs the first
- * authoring round per collection (wtfoc-self, filoz, GitHub PR threads,
- * podcast transcripts).
- *
- * Segment content (the LLM prompt context) is intentionally NOT loaded in
- * this PR — the stub has no use for it. Step 2c adds segment loading
- * alongside the live LLM call.
+ * Step 2e replaces the deferred adversarial filter with a live `query()`
+ * retriever (mounts the corpus's vector index in-memory) and runs the
+ * first authoring rounds per collection (wtfoc-self, filoz, GitHub PR
+ * threads, podcast transcripts).
  *
  * Usage:
  *   pnpm exec tsx --tsconfig scripts/tsconfig.json \
@@ -48,8 +43,11 @@ import {
 	type Stratum,
 	sampleStratified,
 } from "@wtfoc/search";
+import type { Segment } from "@wtfoc/common";
 import { catalogFilePath, readCatalog } from "@wtfoc/ingest";
+import { createStore } from "@wtfoc/store";
 import { authorCandidate } from "./recipe-llm-author.js";
+import { buildExcerptMap } from "./recipe-segment-loader.js";
 import { RECIPE_TEMPLATES, templatesForStratum } from "./recipe-templates.js";
 
 interface ParsedArgs {
@@ -237,6 +235,21 @@ function summarizeStrata(samples: ReadonlyArray<RecipeSample>): Array<{ stratum:
 	return Array.from(m.values());
 }
 
+async function loadSegments(collectionId: string): Promise<Segment[]> {
+	const store = createStore({ storage: "local" });
+	const head = await store.manifests.getHead(collectionId);
+	if (!head) {
+		throw new Error(`collection "${collectionId}" not found`);
+	}
+	const segments: Segment[] = [];
+	for (const segSummary of head.manifest.segments) {
+		const raw = await store.storage.download(segSummary.id);
+		const text = new TextDecoder().decode(raw);
+		segments.push(JSON.parse(text) as Segment);
+	}
+	return segments;
+}
+
 async function main(): Promise<void> {
 	const args = parseArgs(process.argv.slice(2));
 	const manifestDir = process.env.WTFOC_MANIFEST_DIR ?? join(homedir(), ".wtfoc/projects");
@@ -249,6 +262,18 @@ async function main(): Promise<void> {
 	console.log(
 		`[recipe-author] collection=${args.collection} active artifacts=${artifacts.length}`,
 	);
+
+	// Load segment content only when we'll actually use it. Stub authoring
+	// has no use for excerpts and segment download is several seconds on a
+	// large corpus.
+	let excerpts: ReadonlyMap<string, string> = new Map();
+	if (args.live) {
+		const segments = await loadSegments(args.collection);
+		excerpts = buildExcerptMap(segments);
+		console.log(
+			`[recipe-author] loaded segments: ${segments.length}; excerpts indexed for ${excerpts.size} artifactIds`,
+		);
+	}
 
 	const samples = sampleStratified(artifacts, {
 		samplesPerStratum: args.samplesPerStratum,
@@ -269,7 +294,11 @@ async function main(): Promise<void> {
 	for (const { sample, templates } of plan) {
 		for (const t of templates) {
 			if (args.live) {
-				const r = await authorCandidate(sample, t, { collectionId: args.collection });
+				const excerpt = excerpts.get(sample.artifact.artifactId);
+				const r = await authorCandidate(sample, t, {
+					collectionId: args.collection,
+					...(excerpt ? { excerpt } : {}),
+				});
 				if (r.ok && r.candidate) {
 					candidates.push(r.candidate);
 				} else {

--- a/scripts/autoresearch/recipe-segment-loader.test.ts
+++ b/scripts/autoresearch/recipe-segment-loader.test.ts
@@ -1,0 +1,85 @@
+import type { Segment } from "@wtfoc/common";
+import { describe, expect, it } from "vitest";
+import { buildExcerptMap, getExcerpt } from "./recipe-segment-loader.js";
+
+function makeSegment(
+	chunks: Array<{ documentId?: string; content: string; id?: string }>,
+): Segment {
+	return {
+		schemaVersion: 1,
+		embeddingModel: "test",
+		embeddingDimensions: 4,
+		chunks: chunks.map((c, i) => ({
+			id: c.id ?? `chunk-${i}`,
+			storageId: `s-${i}`,
+			content: c.content,
+			embedding: [0, 0, 0, 0],
+			terms: [],
+			source: "src",
+			sourceType: "code",
+			metadata: {},
+			...(c.documentId ? { documentId: c.documentId } : {}),
+		})),
+		edges: [],
+	} as unknown as Segment;
+}
+
+describe("buildExcerptMap", () => {
+	it("groups chunks by documentId and concatenates in order", () => {
+		const seg = makeSegment([
+			{ documentId: "doc-A", content: "first" },
+			{ documentId: "doc-B", content: "B-only" },
+			{ documentId: "doc-A", content: "second" },
+		]);
+		const m = buildExcerptMap([seg]);
+		expect(m.get("doc-A")).toBe("first\n\nsecond");
+		expect(m.get("doc-B")).toBe("B-only");
+	});
+
+	it("skips chunks without a documentId", () => {
+		const seg = makeSegment([
+			{ content: "no-doc" },
+			{ documentId: "doc-A", content: "with-doc" },
+		]);
+		const m = buildExcerptMap([seg]);
+		expect(m.size).toBe(1);
+		expect(m.get("doc-A")).toBe("with-doc");
+	});
+
+	it("caps excerpt at maxChars and appends an ellipsis", () => {
+		const big = "x".repeat(5000);
+		const seg = makeSegment([{ documentId: "doc", content: big }]);
+		const m = buildExcerptMap([seg], { maxChars: 100 });
+		const e = m.get("doc");
+		expect(e?.length).toBe(101); // 100 chars + 1 ellipsis char
+		expect(e?.endsWith("…")).toBe(true);
+	});
+
+	it("returns no entry for empty content", () => {
+		const seg = makeSegment([{ documentId: "doc", content: "" }]);
+		const m = buildExcerptMap([seg]);
+		expect(m.has("doc")).toBe(false);
+	});
+
+	it("merges chunks across multiple segments under the same documentId", () => {
+		const segA = makeSegment([{ documentId: "doc", content: "from-A" }]);
+		const segB = makeSegment([{ documentId: "doc", content: "from-B" }]);
+		const m = buildExcerptMap([segA, segB]);
+		expect(m.get("doc")).toContain("from-A");
+		expect(m.get("doc")).toContain("from-B");
+	});
+
+	it("returns an empty map for empty input", () => {
+		expect(buildExcerptMap([]).size).toBe(0);
+	});
+});
+
+describe("getExcerpt", () => {
+	it("returns undefined for unknown artifactIds", () => {
+		expect(getExcerpt(new Map(), "missing")).toBeUndefined();
+	});
+	it("returns the stored excerpt for known artifactIds", () => {
+		const m = new Map([["doc", "content"]]);
+		expect(getExcerpt(m, "doc")).toBe("content");
+	});
+});

--- a/scripts/autoresearch/recipe-segment-loader.ts
+++ b/scripts/autoresearch/recipe-segment-loader.ts
@@ -1,0 +1,76 @@
+/**
+ * Segment-content excerpt loader for the gold-query recipe (#344 step 2d).
+ *
+ * Given a corpus's segments, build a `Map<artifactId, string>` keyed by the
+ * stable `Chunk.documentId`. Used by the recipe-author CLI to inject a
+ * sample artifact's content into the LLM prompt as `excerpt`, so the
+ * authored query can reference real concepts in the artifact instead of
+ * hallucinating from the artifactId alone.
+ *
+ * Excerpt strategy:
+ *   - Concatenate all chunks belonging to the same documentId in
+ *     `chunkIndex` order so the excerpt reads top-to-bottom of the
+ *     document, not interleaved.
+ *   - Cap at `maxChars` (default 4000) to fit the prompt budget; any
+ *     chunks past the cap are dropped silently.
+ *   - When a documentId has zero chunks (unlikely but possible mid-
+ *     ingest), the loader returns no entry — callers fall back to id-only
+ *     prompts.
+ *
+ * @see https://github.com/SgtPooki/wtfoc/issues/344
+ */
+
+import type { Segment } from "@wtfoc/common";
+
+export interface ExcerptLoaderOptions {
+	/** Max characters per excerpt. Default 4000 (matches LLM author prompt). */
+	maxChars?: number;
+}
+
+interface PerDocChunk {
+	chunkIndex: number;
+	content: string;
+}
+
+/**
+ * Build the artifactId → excerpt map from a list of segments. Time
+ * complexity: O(total chunks). Space: O(unique documentIds * maxChars).
+ */
+export function buildExcerptMap(
+	segments: ReadonlyArray<Segment>,
+	opts: ExcerptLoaderOptions = {},
+): Map<string, string> {
+	const maxChars = opts.maxChars ?? 4000;
+	const byDoc = new Map<string, PerDocChunk[]>();
+	for (const seg of segments) {
+		for (let i = 0; i < seg.chunks.length; i++) {
+			const c = seg.chunks[i];
+			if (!c?.documentId) continue;
+			const list = byDoc.get(c.documentId) ?? [];
+			// segment-builder doesn't carry chunkIndex on Segment.chunks; use the
+			// position within the segment as a stable order proxy.
+			list.push({ chunkIndex: i, content: c.content });
+			byDoc.set(c.documentId, list);
+		}
+	}
+	const out = new Map<string, string>();
+	for (const [documentId, chunks] of byDoc) {
+		chunks.sort((a, b) => a.chunkIndex - b.chunkIndex);
+		const joined = chunks.map((c) => c.content).join("\n\n");
+		if (joined.length === 0) continue;
+		out.set(documentId, joined.length <= maxChars ? joined : `${joined.slice(0, maxChars)}…`);
+	}
+	return out;
+}
+
+/**
+ * Lookup helper. Returns `undefined` when the artifact has no chunks
+ * (cold ingest, schema mismatch, etc.). Callers fall back to id-only
+ * prompts in that case.
+ */
+export function getExcerpt(
+	excerpts: ReadonlyMap<string, string>,
+	artifactId: string,
+): string | undefined {
+	return excerpts.get(artifactId);
+}


### PR DESCRIPTION
## Summary

#344 step 2d. New module `scripts/autoresearch/recipe-segment-loader.ts` exports `buildExcerptMap(segments, opts)` which returns a `Map<artifactId, excerpt>` keyed by stable `Chunk.documentId`. Used by `recipe-author --live` to inject real artifact content into the LLM prompt as `excerpt`, so authored queries can reference concepts that actually exist in the artifact instead of hallucinating from the artifactId alone.

## Excerpt strategy

- Concatenate all chunks belonging to the same `documentId` in position-within-segment order (segments don't carry `chunkIndex`).
- Cap at `maxChars` (default 4000) to fit the LLM author prompt budget; overflow is sliced and an ellipsis appended.
- Skip chunks without a `documentId` (cold-ingest schema gaps).
- Skip empty-content documents (no signal to inject).

## Wiring

- `recipe-author.ts` loads segments via `@wtfoc/store` + `buildExcerptMap` **only** when `--live` is set. Stub mode skips the segment download entirely (saves several seconds on large corpora).
- `excerpt` is threaded into `authorCandidate`'s `AuthorContext` per `(sample, template)` call. Falls back to id-only prompts when the artifact has no chunks.

## Pipeline status (post-2d)

| Stage | Status |
|---|---|
| load corpus catalog | ✅ step 2b |
| derive `CatalogArtifact[]` | ✅ step 2b |
| `sampleStratified` | ✅ step 2b |
| load segment excerpts | ✅ step 2d (this PR, `--live`) |
| author (sample, template) | ✅ step 2c live LLM (`--live`) |
| `applyAdversarialFilter` | ⏳ step 2e |
| emit JSON for human review | ✅ step 2b |

## Out of scope

- Adversarial filter live retriever wiring (step 2e — needs in-memory mount of the corpus's vector index).
- First authoring run against `wtfoc-dogfood-2026-04-v3` (step 2e — homelab compute).

## Test plan

- [x] 8 new unit tests on `buildExcerptMap` + `getExcerpt`.
- [x] `pnpm test`: 1745 passed, 2 skipped.
- [x] `pnpm lint:fix` clean.
- [x] `pnpm -r build` clean.

refs #344