### PR TITLE
feat(autoresearch): adversarial-filter live retriever + wiring (step 2e)

### DIFF
--- a/scripts/autoresearch/recipe-adversarial-retriever.test.ts
+++ b/scripts/autoresearch/recipe-adversarial-retriever.test.ts
@@ -1,0 +1,123 @@
+import type { Embedder, Segment, VectorIndex } from "@wtfoc/common";
+import { describe, expect, it, vi } from "vitest";
+import { buildLiveRetriever, buildStorageToDocMap } from "./recipe-adversarial-retriever.js";
+
+const mockQuery = vi.hoisted(() =>
+	vi.fn<
+		(
+			text: string,
+			embedder: Embedder,
+			index: VectorIndex,
+			opts?: { topK?: number },
+		) => Promise<{
+			query: string;
+			results: Array<{
+				content: string;
+				sourceType: string;
+				source: string;
+				storageId: string;
+				score: number;
+			}>;
+		}>
+	>(),
+);
+
+vi.mock("@wtfoc/search", async (orig) => {
+	const actual = (await orig()) as Record<string, unknown>;
+	return {
+		...actual,
+		query: mockQuery,
+	};
+});
+
+function makeSegment(
+	chunks: Array<{ storageId: string; documentId?: string }>,
+): Segment {
+	return {
+		schemaVersion: 1,
+		embeddingModel: "test",
+		embeddingDimensions: 4,
+		chunks: chunks.map((c, i) => ({
+			id: `c-${i}`,
+			storageId: c.storageId,
+			content: "x",
+			embedding: [0, 0, 0, 0],
+			terms: [],
+			source: "src",
+			sourceType: "code",
+			metadata: {},
+			...(c.documentId ? { documentId: c.documentId } : {}),
+		})),
+		edges: [],
+	} as unknown as Segment;
+}
+
+describe("buildStorageToDocMap", () => {
+	it("maps every chunk with a documentId", () => {
+		const seg = makeSegment([
+			{ storageId: "s1", documentId: "doc-A" },
+			{ storageId: "s2", documentId: "doc-B" },
+			{ storageId: "s3" },
+		]);
+		const m = buildStorageToDocMap([seg]);
+		expect(m.size).toBe(2);
+		expect(m.get("s1")).toBe("doc-A");
+		expect(m.get("s2")).toBe("doc-B");
+	});
+	it("survives empty input", () => {
+		expect(buildStorageToDocMap([]).size).toBe(0);
+	});
+});
+
+describe("buildLiveRetriever", () => {
+	it("returns artifactIds resolved from query() storageIds", async () => {
+		mockQuery.mockResolvedValueOnce({
+			query: "q",
+			results: [
+				{ content: "x", sourceType: "code", source: "s", storageId: "s1", score: 0.9 },
+				{ content: "y", sourceType: "code", source: "s", storageId: "s2", score: 0.8 },
+			],
+		});
+		const seg = makeSegment([
+			{ storageId: "s1", documentId: "doc-A" },
+			{ storageId: "s2", documentId: "doc-B" },
+		]);
+		const retrieve = buildLiveRetriever({
+			embedder: {} as Embedder,
+			vectorIndex: {} as VectorIndex,
+			segments: [seg],
+		});
+		const hits = await retrieve("test", 5);
+		expect(hits).toEqual([{ artifactId: "doc-A" }, { artifactId: "doc-B" }]);
+	});
+
+	it("drops query() hits whose storageId has no documentId", async () => {
+		mockQuery.mockResolvedValueOnce({
+			query: "q",
+			results: [
+				{ content: "x", sourceType: "code", source: "s", storageId: "s1", score: 0.9 },
+				{ content: "x", sourceType: "code", source: "s", storageId: "s-orphan", score: 0.7 },
+			],
+		});
+		const seg = makeSegment([{ storageId: "s1", documentId: "doc-A" }]);
+		const retrieve = buildLiveRetriever({
+			embedder: {} as Embedder,
+			vectorIndex: {} as VectorIndex,
+			segments: [seg],
+		});
+		const hits = await retrieve("test", 5);
+		expect(hits).toEqual([{ artifactId: "doc-A" }]);
+	});
+
+	it("forwards the topK arg into query()", async () => {
+		mockQuery.mockResolvedValueOnce({ query: "q", results: [] });
+		const retrieve = buildLiveRetriever({
+			embedder: {} as Embedder,
+			vectorIndex: {} as VectorIndex,
+			segments: [],
+		});
+		await retrieve("test", 7);
+		const lastCall = mockQuery.mock.calls.at(-1);
+		expect(lastCall?.[3]).toEqual({ topK: 7 });
+	});
+});

--- a/scripts/autoresearch/recipe-adversarial-retriever.ts
+++ b/scripts/autoresearch/recipe-adversarial-retriever.ts
@@ -1,0 +1,63 @@
+/**
+ * Live `RetrieveTopK` adapter for the adversarial filter (#344 step 2e).
+ *
+ * `applyAdversarialFilter` discards candidate queries whose `required:true`
+ * artifact already appears in plain vector search top-K — those queries
+ * don't exercise the trace engine and are too easy. This module wraps the
+ * production `query()` from `@wtfoc/search` so the filter can run against
+ * a real mounted corpus.
+ *
+ * `query()` returns hits with `storageId` (chunk-level) but the recipe's
+ * artifact identity is `documentId` (artifact-level). The adapter builds a
+ * `Map<storageId, documentId>` from the corpus segments at construction
+ * time so post-query lookup is O(1).
+ *
+ * @see https://github.com/SgtPooki/wtfoc/issues/344
+ */
+
+import type { Embedder, Segment, VectorIndex } from "@wtfoc/common";
+import { type RetrieveTopK, query } from "@wtfoc/search";
+
+export interface BuildLiveRetrieverOptions {
+	embedder: Embedder;
+	vectorIndex: VectorIndex;
+	segments: ReadonlyArray<Segment>;
+}
+
+/**
+ * Build a `Map<storageId, documentId>` from the segments. Chunks without a
+ * `documentId` are skipped — the adversarial filter cannot key against
+ * them.
+ */
+export function buildStorageToDocMap(
+	segments: ReadonlyArray<Segment>,
+): Map<string, string> {
+	const out = new Map<string, string>();
+	for (const seg of segments) {
+		for (const c of seg.chunks) {
+			if (!c.documentId) continue;
+			out.set(c.storageId, c.documentId);
+		}
+	}
+	return out;
+}
+
+/**
+ * Construct a `RetrieveTopK` over a mounted corpus. The returned function
+ * is stable: subsequent calls share the storage→document map and the
+ * embedder/vectorIndex references.
+ */
+export function buildLiveRetriever(
+	opts: BuildLiveRetrieverOptions,
+): RetrieveTopK {
+	const storageToDoc = buildStorageToDocMap(opts.segments);
+	return async (queryText: string, k: number) => {
+		const result = await query(queryText, opts.embedder, opts.vectorIndex, { topK: k });
+		const out: Array<{ artifactId: string }> = [];
+		for (const r of result.results) {
+			const documentId = storageToDoc.get(r.storageId);
+			if (documentId) out.push({ artifactId: documentId });
+		}
+		return out;
+	};
+}

--- a/scripts/autoresearch/recipe-author.ts
+++ b/scripts/autoresearch/recipe-author.ts
@@ -34,18 +34,24 @@ import { writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { Segment } from "@wtfoc/common";
+import { catalogFilePath, readCatalog } from "@wtfoc/ingest";
 import {
+	applyAdversarialFilter,
+	type AdversarialFilterResult,
 	type CandidateQuery,
 	type CatalogArtifact,
 	type GoldQuery,
+	InMemoryVectorIndex,
+	mountCollection,
+	OpenAIEmbedder,
 	type QueryTemplate,
 	type RecipeSample,
 	type Stratum,
 	sampleStratified,
 } from "@wtfoc/search";
-import type { Segment } from "@wtfoc/common";
-import { catalogFilePath, readCatalog } from "@wtfoc/ingest";
 import { createStore } from "@wtfoc/store";
+import { buildLiveRetriever } from "./recipe-adversarial-retriever.js";
 import { authorCandidate } from "./recipe-llm-author.js";
 import { buildExcerptMap } from "./recipe-segment-loader.js";
 import { RECIPE_TEMPLATES, templatesForStratum } from "./recipe-templates.js";
@@ -58,6 +64,9 @@ interface ParsedArgs {
 	maxCandidates: number;
 	dryRun: boolean;
 	live: boolean;
+	adversarialFilter: boolean;
+	embedderUrl?: string;
+	embedderModel?: string;
 }
 
 function parsePositiveInt(name: string, raw: string | undefined): number {
@@ -86,6 +95,9 @@ export function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
 	let maxCandidates = 80;
 	let dryRun = false;
 	let live = false;
+	let adversarialFilter = false;
+	let embedderUrl: string | undefined;
+	let embedderModel: string | undefined;
 	for (let i = 0; i < argv.length; i++) {
 		const a = argv[i];
 		const next = argv[i + 1];
@@ -108,6 +120,14 @@ export function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
 			dryRun = true;
 		} else if (a === "--live") {
 			live = true;
+		} else if (a === "--adversarial-filter") {
+			adversarialFilter = true;
+		} else if (a === "--embedder-url" && next) {
+			embedderUrl = next;
+			i++;
+		} else if (a === "--embedder-model" && next) {
+			embedderModel = next;
+			i++;
 		} else if (a !== undefined) {
 			throw new Error(`unknown flag: "${a}"`);
 		}
@@ -115,7 +135,23 @@ export function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
 	if (!collection) {
 		throw new Error("usage: recipe-author --collection <id> [--output <path>] ...");
 	}
-	return { collection, output, samplesPerStratum, seed, maxCandidates, dryRun, live };
+	if (adversarialFilter && (!embedderUrl || !embedderModel)) {
+		throw new Error(
+			"--adversarial-filter requires --embedder-url and --embedder-model",
+		);
+	}
+	return {
+		collection,
+		output,
+		samplesPerStratum,
+		seed,
+		maxCandidates,
+		dryRun,
+		live,
+		adversarialFilter,
+		...(embedderUrl ? { embedderUrl } : {}),
+		...(embedderModel ? { embedderModel } : {}),
+	};
 }
 
 /**
@@ -222,6 +258,17 @@ interface CandidatesFile {
 	totalCandidates: number;
 	stratumDistribution: Array<{ stratum: Stratum; count: number }>;
 	candidates: ReadonlyArray<CandidateQuery>;
+	/**
+	 * Adversarial-filter audit. Populated only when --adversarial-filter is
+	 * passed. `discarded[]` carries the offending candidate plus the reason
+	 * the filter rejected it (typically: "vector top-3 already returns the
+	 * required artifact" — query is too easy).
+	 */
+	adversarial?: {
+		topK: number;
+		kept: number;
+		discarded: AdversarialFilterResult["discarded"];
+	};
 }
 
 function summarizeStrata(samples: ReadonlyArray<RecipeSample>): Array<{ stratum: Stratum; count: number }> {
@@ -322,12 +369,39 @@ async function main(): Promise<void> {
 		}
 	}
 
+	// Adversarial filter — discard candidates whose required gold is in
+	// vector-search top-3 (too easy; doesn't exercise the trace engine).
+	// Requires a mounted corpus + embedder.
+	let adversarial: CandidatesFile["adversarial"];
+	let kept: CandidateQuery[] = candidates;
+	if (args.adversarialFilter && args.embedderUrl && args.embedderModel) {
+		const segments = await loadSegments(args.collection);
+		const store = createStore({ storage: "local" });
+		const head = await store.manifests.getHead(args.collection);
+		if (!head) throw new Error(`collection "${args.collection}" not found`);
+		const vectorIndex = new InMemoryVectorIndex();
+		await mountCollection(head.manifest, store.storage, vectorIndex);
+		const embedder = new OpenAIEmbedder({
+			apiKey: process.env.WTFOC_EMBEDDER_KEY ?? "",
+			model: args.embedderModel,
+			baseUrl: args.embedderUrl,
+		});
+		const retrieve = buildLiveRetriever({ embedder, vectorIndex, segments });
+		const result = await applyAdversarialFilter(candidates, retrieve, { topK: 3 });
+		kept = result.kept;
+		adversarial = { topK: 3, kept: kept.length, discarded: result.discarded };
+		console.log(
+			`[recipe-author] adversarial filter: kept=${kept.length} discarded=${result.discarded.length}`,
+		);
+	}
+
 	const out: CandidatesFile = {
 		collection: args.collection,
 		seed: args.seed,
-		totalCandidates: candidates.length,
+		totalCandidates: kept.length,
 		stratumDistribution: summarizeStrata(samples),
-		candidates,
+		candidates: kept,
+		...(adversarial ? { adversarial } : {}),
 	};
 
 	if (args.dryRun) {


### PR DESCRIPTION
## Summary

#344 step 2e. Wires the recipe's adversarial filter against a live mounted-corpus retriever so candidate queries that vector search alone solves get discarded before they pollute the gold fixture.

## What ships

- `scripts/autoresearch/recipe-adversarial-retriever.ts`:
  - `buildStorageToDocMap(segments)` → `Map<storageId, documentId>`. Built once at construction; post-query lookup is O(1).
  - `buildLiveRetriever({ embedder, vectorIndex, segments })` → `RetrieveTopK`. Wraps `query()`, maps each `result.storageId` back to its `documentId`, emits `{artifactId}` hits in the shape `applyAdversarialFilter` consumes.
- `recipe-author.ts` gains `--adversarial-filter` (requires `--embedder-url` + `--embedder-model`). When set, after authoring: `loadSegments` + `getHead` + `mountCollection` into an `InMemoryVectorIndex`, build retriever, run `applyAdversarialFilter` with `topK=3` (peer-review consensus).
- Output JSON gains an `adversarial` block `{ topK, kept, discarded[] }` so reviewers can audit why the filter rejected each query.

## Pipeline status (post-2e)

| Stage | Status |
|---|---|
| load corpus catalog | ✅ step 2b |
| derive `CatalogArtifact[]` | ✅ step 2b |
| `sampleStratified` | ✅ step 2b |
| load segment excerpts | ✅ step 2d (`--live`) |
| author (sample, template) | ✅ step 2c live LLM (`--live`) |
| `applyAdversarialFilter` | ✅ step 2e (`--adversarial-filter`) |
| emit JSON for human review | ✅ step 2b |

## Out of scope

- First authoring runs per collection (wtfoc-self, filoz, GitHub PR threads, podcast transcripts) — step 2f, maintainer-driven, no code change.
- Non-code collection ingestion (GitHub PR threads + podcast transcripts) — separate ingest PRs.

## Test plan

- [x] 5 new unit tests on `buildStorageToDocMap` + `buildLiveRetriever` (artifactId resolution, drop-on-no-documentId, topK forwarding).
- [x] `pnpm test`: 1750 passed, 2 skipped.
- [x] `pnpm lint:fix` clean.
- [x] `pnpm -r build` clean.

refs #344