### PR TITLE
fix(autoresearch): recipe-author wrote-count print uses kept (post-filter)

### DIFF
--- a/scripts/autoresearch/recipe-author.ts
+++ b/scripts/autoresearch/recipe-author.ts
@@ -405,12 +405,12 @@ async function main(): Promise<void> {
 	};
 
 	if (args.dryRun) {
-		console.log(`[recipe-author] --dry-run; would write ${candidates.length} candidates`);
+		console.log(`[recipe-author] --dry-run; would write ${kept.length} candidates`);
 		return;
 	}
 	await writeFile(args.output, JSON.stringify(out, null, 2), "utf-8");
 	console.log(
-		`[recipe-author] wrote ${candidates.length} ${args.live ? "live-authored" : "stub"} candidates to ${args.output} across ${out.stratumDistribution.length} strata`,
+		`[recipe-author] wrote ${kept.length} ${args.live ? "live-authored" : "stub"} candidates to ${args.output} across ${out.stratumDistribution.length} strata`,
 	);
 	if (!args.live) {
 		console.log(


### PR DESCRIPTION
Smoke run against wtfoc-dogfood-v3 surfaced the print bug: the wrote-count log used `candidates.length` (pre-adversarial) instead of `kept.length` (post-adversarial). The JSON file was already correct — only the console output disagreed.

- Before: `wrote 25 live-authored candidates ...` when JSON had 12.
- After: `wrote 12 live-authored candidates ...` matching the file.

Same fix applied to the `--dry-run` print so dry-run reports what it would actually write.

## Test plan

- [x] `pnpm test`: 1750 passed, 2 skipped.
- [x] `pnpm lint:fix` clean.
- [x] `pnpm -r build` clean.

refs #344