### PR TITLE
feat(autoresearch): recipe-validate CLI — probe + classify + triage report

### DIFF
--- a/scripts/autoresearch/recipe-validate.test.ts
+++ b/scripts/autoresearch/recipe-validate.test.ts
@@ -1,0 +1,196 @@
+import type { CandidateQuery, GoldQuery, QueryTemplate } from "@wtfoc/search";
+import { describe, expect, it } from "vitest";
+import {
+	classifyValidation,
+	type ProbeMetadata,
+	renderTriageReport,
+	summarizeLabels,
+	type ValidationRecord,
+} from "./recipe-validate.js";
+
+const TEMPLATE: QueryTemplate = {
+	id: "trace-issue-to-impl",
+	intent: "x",
+	queryType: "trace",
+	difficulty: "hard",
+	targetLayerHints: ["trace"],
+	exampleSurface: "x",
+};
+const LOOKUP_TEMPLATE: QueryTemplate = {
+	...TEMPLATE,
+	id: "lookup-by-symbol",
+	queryType: "lookup",
+};
+
+function makeCandidate(
+	queryType: GoldQuery["queryType"] = "trace",
+	requiredArtifacts: string[] = ["doc/x.ts"],
+	requiredSourceTypes: string[] = ["code"],
+): CandidateQuery {
+	const draft: GoldQuery = {
+		id: "c1",
+		authoredFromCollectionId: "alpha",
+		applicableCorpora: ["alpha"],
+		query: "abstract Q",
+		queryType,
+		difficulty: "hard",
+		targetLayerHints: ["ranking"],
+		expectedEvidence: requiredArtifacts.map((id) => ({ artifactId: id, required: true })),
+		acceptableAnswerFacts: [],
+		requiredSourceTypes,
+		minResults: 1,
+	};
+	return {
+		template: queryType === "lookup" ? LOOKUP_TEMPLATE : TEMPLATE,
+		stratum: { sourceType: "code", edgeType: null, lengthBucket: "short", rarity: "common" },
+		draft,
+	};
+}
+
+function makeProbe(partial: Partial<ProbeMetadata> = {}): ProbeMetadata {
+	return {
+		goldRank: 5,
+		widerK: 100,
+		requiredTypeCoverage: true,
+		traceHopCount: 2,
+		goldReachedByTrace: false,
+		topResults: [],
+		...partial,
+	};
+}
+
+describe("classifyValidation", () => {
+	it("auto-rejects when gold absent from widerK AND not reached by trace", () => {
+		const r = classifyValidation(
+			makeCandidate(),
+			makeProbe({ goldRank: null, goldReachedByTrace: false }),
+		);
+		expect(r.label).toBe("auto-reject");
+		expect(r.reasons).toContain("gold-not-in-widerK");
+	});
+
+	it("trivial-suspect when gold rank in vector top-3 (adversarial filter disagreement)", () => {
+		const r = classifyValidation(makeCandidate(), makeProbe({ goldRank: 2 }));
+		expect(r.label).toBe("trivial-suspect");
+		expect(r.reasons).toContain("gold-rank-1-to-3");
+	});
+
+	it("human-review when trace rescued gold not in vector top-K (deep-recall stress)", () => {
+		const r = classifyValidation(
+			makeCandidate(),
+			makeProbe({ goldRank: null, goldReachedByTrace: true }),
+		);
+		expect(r.label).toBe("human-review");
+		expect(r.reasons).toContain("gold-deep-recall");
+	});
+
+	it("needs-fix when trace template returned zero hops", () => {
+		const r = classifyValidation(
+			makeCandidate("trace"),
+			makeProbe({ goldRank: 10, traceHopCount: 0 }),
+		);
+		expect(r.label).toBe("needs-fix");
+		expect(r.reasons).toContain("trace-empty-but-needed");
+	});
+
+	it("does NOT flag trace-empty-but-needed for lookup template (lookup doesn't need hops)", () => {
+		const r = classifyValidation(
+			makeCandidate("lookup"),
+			makeProbe({ goldRank: 10, traceHopCount: 0 }),
+		);
+		expect(r.reasons).not.toContain("trace-empty-but-needed");
+	});
+
+	it("needs-fix when required source types never surface", () => {
+		const r = classifyValidation(
+			makeCandidate("trace", ["doc/x.ts"], ["github-issue"]),
+			makeProbe({ goldRank: 10, requiredTypeCoverage: false }),
+		);
+		expect(r.label).toBe("needs-fix");
+		expect(r.reasons).toContain("required-type-missing");
+	});
+
+	it("human-review for mid-rank gold (4..widerK) — borderline", () => {
+		const r = classifyValidation(makeCandidate(), makeProbe({ goldRank: 25 }));
+		expect(r.label).toBe("human-review");
+		expect(r.reasons).toContain("gold-mid-rank");
+	});
+
+	it("does NOT auto-reject `goldRank > 50` (peer-review consensus: caps engine ceiling)", () => {
+		// goldRank=80 still appears mid-rank, deserving human review; the
+		// classifier MUST NOT silently auto-reject it.
+		const r = classifyValidation(makeCandidate(), makeProbe({ goldRank: 80 }));
+		expect(r.label).not.toBe("auto-reject");
+	});
+
+	it("aggregates multiple needs-fix reasons", () => {
+		const r = classifyValidation(
+			makeCandidate("trace", ["x"], ["github-issue"]),
+			makeProbe({
+				goldRank: 10,
+				traceHopCount: 0,
+				requiredTypeCoverage: false,
+			}),
+		);
+		expect(r.label).toBe("needs-fix");
+		expect(r.reasons).toContain("trace-empty-but-needed");
+		expect(r.reasons).toContain("required-type-missing");
+	});
+});
+
+describe("summarizeLabels", () => {
+	it("counts labels deterministically", () => {
+		const records: ValidationRecord[] = [
+			{ candidate: makeCandidate(), label: "keeper-candidate", reasons: [], probe: makeProbe() },
+			{ candidate: makeCandidate(), label: "keeper-candidate", reasons: [], probe: makeProbe() },
+			{ candidate: makeCandidate(), label: "needs-fix", reasons: [], probe: makeProbe() },
+		];
+		const counts = summarizeLabels(records);
+		expect(counts["keeper-candidate"]).toBe(2);
+		expect(counts["needs-fix"]).toBe(1);
+		expect(counts["auto-reject"]).toBe(0);
+	});
+});
+
+describe("renderTriageReport", () => {
+	it("emits a per-label section + per-candidate packet", () => {
+		const records: ValidationRecord[] = [
+			{
+				candidate: makeCandidate("trace"),
+				label: "keeper-candidate",
+				reasons: ["keeper"],
+				probe: makeProbe({
+					goldRank: 7,
+					topResults: [
+						{ rank: 1, artifactId: "a", sourceType: "code", score: 0.9 },
+					],
+				}),
+			},
+			{
+				candidate: makeCandidate("lookup"),
+				label: "auto-reject",
+				reasons: ["gold-not-in-widerK"],
+				probe: makeProbe({ goldRank: null, goldReachedByTrace: false }),
+			},
+		];
+		const md = renderTriageReport("alpha", records);
+		expect(md).toContain("# Recipe-validate triage report — `alpha`");
+		expect(md).toContain("**keeper-candidate**: 1");
+		expect(md).toContain("## keeper-candidate (1)");
+		expect(md).toContain("## auto-reject (1)");
+		expect(md).toContain("**Query**: abstract Q");
+		expect(md).toContain("`a`");
+	});
+
+	it("skips empty label sections", () => {
+		const md = renderTriageReport("alpha", [
+			{
+				candidate: makeCandidate(),
+				label: "keeper-candidate",
+				reasons: [],
+				probe: makeProbe(),
+			},
+		]);
+		expect(md).not.toContain("## auto-reject");
+	});
+});

--- a/scripts/autoresearch/recipe-validate.ts
+++ b/scripts/autoresearch/recipe-validate.ts
@@ -1,0 +1,422 @@
+/**
+ * Recipe-validate CLI for #344 step-2 review tooling.
+ *
+ * Reads a candidates JSON produced by `recipe-author --live`, probes each
+ * surviving candidate against the live mounted-corpus retriever + trace,
+ * classifies the result into a categorical label, and emits both an
+ * enriched JSON (validation metadata per candidate) and a markdown
+ * triage report for the human reviewer.
+ *
+ * Three-way peer-review consensus shaped this design:
+ *
+ *   1. Deterministic probe (Option A) is the primary filter. LLM-grader
+ *      (Option B) defers to a follow-up — single-model circularity is a
+ *      real risk and the marginal signal does not justify it yet.
+ *   2. Categorical labels, NOT pass/fail. The reviewer's burden drops when
+ *      probe disagreements (e.g. "adversarial said hard, but vector top-3
+ *      hits gold") are surfaced loudly.
+ *   3. The probe is enrichment, NOT a hard gate. The apply CLI (separate
+ *      PR) gates structurally-invalid candidates only; probe failures
+ *      land in the JSON for human override.
+ *   4. Specifically NOT-safe auto-rejects: `goldRank > 50`, `wouldPass:
+ *      false`, low score alone. These can reflect retrieval weakness on
+ *      genuinely valuable trace-stress queries.
+ *
+ * Usage:
+ *   pnpm exec tsx --tsconfig scripts/tsconfig.json \
+ *     scripts/autoresearch/recipe-validate.ts \
+ *     --candidates /tmp/wtfoc-self-candidates.json \
+ *     --output /tmp/wtfoc-self-candidates.validated.json \
+ *     --report /tmp/wtfoc-self-review.md \
+ *     --collection wtfoc-dogfood-2026-04-v3 \
+ *     --embedder-url https://openrouter.ai/api/v1 \
+ *     --embedder-model baai/bge-base-en-v1.5
+ *
+ * @see https://github.com/SgtPooki/wtfoc/issues/344
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import type { Embedder, Segment, VectorIndex } from "@wtfoc/common";
+import {
+	type CandidateQuery,
+	InMemoryVectorIndex,
+	mountCollection,
+	OpenAIEmbedder,
+	query,
+	trace,
+} from "@wtfoc/search";
+import { createStore } from "@wtfoc/store";
+import { buildStorageToDocMap } from "./recipe-adversarial-retriever.js";
+
+export type ValidationLabel =
+	| "keeper-candidate"
+	| "trivial-suspect"
+	| "needs-fix"
+	| "human-review"
+	| "auto-reject";
+
+export interface ProbeMetadata {
+	/** 1-indexed rank of the required artifact in the wider top-K. null = not in widerK. */
+	goldRank: number | null;
+	/** Top-K depth used for the probe (default 100). */
+	widerK: number;
+	/** True if any required source type appeared in retrieved chunks. */
+	requiredTypeCoverage: boolean;
+	/** Number of edge hops the trace pass walked. */
+	traceHopCount: number;
+	/** Whether the gold artifact appeared in the trace's reached source set. */
+	goldReachedByTrace: boolean;
+	/** Top result source labels, for triage display. */
+	topResults: Array<{ rank: number; artifactId: string; sourceType: string; score: number }>;
+}
+
+export interface ValidationRecord {
+	candidate: CandidateQuery;
+	label: ValidationLabel;
+	reasons: string[];
+	probe: ProbeMetadata;
+}
+
+export interface CandidatesFile {
+	collection: string;
+	seed: number;
+	totalCandidates: number;
+	candidates: CandidateQuery[];
+	adversarial?: unknown;
+}
+
+export interface EnrichedCandidatesFile extends CandidatesFile {
+	validation: {
+		labelCounts: Record<ValidationLabel, number>;
+		records: ValidationRecord[];
+	};
+}
+
+/**
+ * Classify a single probe result into a categorical label + reason list.
+ * Pure: deterministic given the probe metadata, no I/O. Tests pin the
+ * decision table here.
+ *
+ * Reason taxonomy:
+ *   - `gold-not-in-widerK`     — gold absent from probe top-K and trace
+ *   - `trace-empty-but-needed` — trace template returned 0 hops
+ *   - `gold-rank-1-to-3`       — adversarial filter said hard, but vector top-3 hits
+ *   - `required-type-missing`  — query depends on type that never surfaces
+ *   - `gold-deep-recall`       — gold rank deep but trace surfaced it (valuable stress test)
+ *   - `gold-mid-rank`          — gold present but ranked 4..widerK; trace assistance unclear
+ *   - `keeper`                 — every signal positive
+ */
+export function classifyValidation(
+	candidate: CandidateQuery,
+	probe: ProbeMetadata,
+): { label: ValidationLabel; reasons: string[] } {
+	const reasons: string[] = [];
+	const queryType = candidate.draft.queryType;
+	const traceTemplate = queryType === "trace" || queryType === "causal" || queryType === "compare";
+
+	// 1. AUTO-REJECT: gold not findable at all (probe + trace both miss).
+	if (probe.goldRank === null && !probe.goldReachedByTrace) {
+		reasons.push("gold-not-in-widerK");
+		return { label: "auto-reject", reasons };
+	}
+
+	// 2. NEEDS-FIX: trace template but trace returned zero hops.
+	if (traceTemplate && probe.traceHopCount === 0) {
+		reasons.push("trace-empty-but-needed");
+	}
+
+	// 3. NEEDS-FIX: required source types never surfaced.
+	if (!probe.requiredTypeCoverage) {
+		reasons.push("required-type-missing");
+	}
+
+	// 4. TRIVIAL-SUSPECT: vector top-3 already returns gold (adversarial filter
+	//    should have caught this, but disagreement is worth flagging loudly).
+	if (probe.goldRank !== null && probe.goldRank <= 3) {
+		reasons.push("gold-rank-1-to-3");
+		return { label: "trivial-suspect", reasons };
+	}
+
+	// 5. HUMAN-REVIEW: trace rescued a gold not in vector top-K. Valuable
+	//    stress test if the question is well-formed; vague otherwise. Flag.
+	if (probe.goldRank === null && probe.goldReachedByTrace) {
+		reasons.push("gold-deep-recall");
+		return { label: "human-review", reasons };
+	}
+
+	// 6. NEEDS-FIX accumulator: any reason flagged so far is a fix-up.
+	if (reasons.length > 0) {
+		return { label: "needs-fix", reasons };
+	}
+
+	// 7. HUMAN-REVIEW: gold mid-rank (4..widerK) — borderline. Surface.
+	if (probe.goldRank !== null && probe.goldRank > 3) {
+		reasons.push("gold-mid-rank");
+		return { label: "human-review", reasons };
+	}
+
+	// 8. KEEPER: clean signals. (Currently unreachable since rule 7 captures
+	//    any non-null rank > 3. Kept for explicitness — future probe signals
+	//    will widen the keeper criteria.)
+	reasons.push("keeper");
+	return { label: "keeper-candidate", reasons };
+}
+
+/**
+ * Run the deterministic probe against a single candidate. Pulls top-`widerK`
+ * via `query()` and runs `trace()` to gather hop count + reached sources.
+ * The `storageToDoc` map converts retrieval `storageId`s back to the
+ * artifactId namespace the gold queries use.
+ */
+export async function probeCandidate(
+	candidate: CandidateQuery,
+	ctx: {
+		embedder: Embedder;
+		vectorIndex: VectorIndex;
+		segments: ReadonlyArray<Segment>;
+		storageToDoc: ReadonlyMap<string, string>;
+		widerK?: number;
+	},
+): Promise<ProbeMetadata> {
+	const widerK = ctx.widerK ?? 100;
+	const requiredArtifactIds = candidate.draft.expectedEvidence
+		.filter((e) => e.required)
+		.map((e) => e.artifactId);
+	const requiredSourceTypes = new Set(candidate.draft.requiredSourceTypes);
+
+	const qResult = await query(candidate.draft.query, ctx.embedder, ctx.vectorIndex, {
+		topK: widerK,
+	});
+
+	let goldRank: number | null = null;
+	const requiredTypesSeen = new Set<string>();
+	const topResults: ProbeMetadata["topResults"] = [];
+	for (let i = 0; i < qResult.results.length; i++) {
+		const r = qResult.results[i];
+		if (!r) continue;
+		requiredTypesSeen.add(r.sourceType);
+		const docId = ctx.storageToDoc.get(r.storageId);
+		if (i < 5) {
+			topResults.push({
+				rank: i + 1,
+				artifactId: docId ?? r.source,
+				sourceType: r.sourceType,
+				score: r.score,
+			});
+		}
+		if (goldRank === null && docId && requiredArtifactIds.includes(docId)) {
+			goldRank = i + 1;
+		}
+	}
+
+	const tResult = await trace(candidate.draft.query, ctx.embedder, ctx.vectorIndex, [
+		...ctx.segments,
+	], { mode: "analytical" });
+	const traceHopCount = tResult.stats.edgeHops;
+	const traceSources = new Set<string>();
+	for (const hop of tResult.hops) traceSources.add(hop.source);
+	const goldReachedByTrace = requiredArtifactIds.some((id) => traceSources.has(id));
+
+	const requiredTypeCoverage =
+		requiredSourceTypes.size === 0 ||
+		[...requiredSourceTypes].every((t) => requiredTypesSeen.has(t));
+
+	return {
+		goldRank,
+		widerK,
+		requiredTypeCoverage,
+		traceHopCount,
+		goldReachedByTrace,
+		topResults,
+	};
+}
+
+const ALL_LABELS: ValidationLabel[] = [
+	"keeper-candidate",
+	"trivial-suspect",
+	"needs-fix",
+	"human-review",
+	"auto-reject",
+];
+
+export function summarizeLabels(records: ReadonlyArray<ValidationRecord>): Record<ValidationLabel, number> {
+	const out = Object.fromEntries(ALL_LABELS.map((l) => [l, 0])) as Record<ValidationLabel, number>;
+	for (const r of records) out[r.label]++;
+	return out;
+}
+
+/**
+ * Render the per-candidate triage packet markdown report. The reviewer
+ * sees one section per candidate, sortable by label, with all evidence
+ * needed for a y/n/edit decision visible on screen.
+ */
+export function renderTriageReport(
+	collection: string,
+	records: ReadonlyArray<ValidationRecord>,
+): string {
+	const counts = summarizeLabels(records);
+	const lines: string[] = [];
+	lines.push(`# Recipe-validate triage report — \`${collection}\``);
+	lines.push("");
+	lines.push("## Label distribution");
+	lines.push("");
+	for (const l of ALL_LABELS) {
+		lines.push(`- **${l}**: ${counts[l]}`);
+	}
+	lines.push("");
+	for (const label of ALL_LABELS) {
+		const subset = records.filter((r) => r.label === label);
+		if (subset.length === 0) continue;
+		lines.push(`## ${label} (${subset.length})`);
+		lines.push("");
+		for (const r of subset) {
+			const id = r.candidate.draft.id ?? "(no-id)";
+			lines.push(`### \`${id}\` — ${r.candidate.draft.queryType} / ${r.candidate.draft.difficulty}`);
+			lines.push("");
+			lines.push(`**Query**: ${r.candidate.draft.query}`);
+			lines.push("");
+			lines.push(
+				`**Required artifact(s)**: ${r.candidate.draft.expectedEvidence
+					.filter((e) => e.required)
+					.map((e) => `\`${e.artifactId}\``)
+					.join(", ")}`,
+			);
+			lines.push("");
+			lines.push(
+				`**Probe**: goldRank=${r.probe.goldRank ?? "null"} traceHops=${r.probe.traceHopCount} reqTypeCov=${r.probe.requiredTypeCoverage} traceReached=${r.probe.goldReachedByTrace}`,
+			);
+			lines.push("");
+			lines.push(`**Reasons**: ${r.reasons.join(", ")}`);
+			lines.push("");
+			if (r.probe.topResults.length > 0) {
+				lines.push("**Top-5 retrieval**:");
+				for (const t of r.probe.topResults) {
+					lines.push(`- ${t.rank}. \`${t.artifactId}\` (${t.sourceType}, score ${t.score.toFixed(2)})`);
+				}
+				lines.push("");
+			}
+		}
+	}
+	return lines.join("\n");
+}
+
+interface CliArgs {
+	candidates: string;
+	output: string;
+	report: string;
+	collection: string;
+	embedderUrl: string;
+	embedderModel: string;
+}
+
+function parseCliArgs(argv: ReadonlyArray<string>): CliArgs {
+	const out: Partial<CliArgs> = {};
+	const required = ["candidates", "output", "report", "collection", "embedderUrl", "embedderModel"];
+	const map: Record<string, keyof CliArgs> = {
+		"--candidates": "candidates",
+		"--output": "output",
+		"--report": "report",
+		"--collection": "collection",
+		"--embedder-url": "embedderUrl",
+		"--embedder-model": "embedderModel",
+	};
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		const next = argv[i + 1];
+		if (a && a in map && next) {
+			out[map[a] as keyof CliArgs] = next;
+			i++;
+		} else if (a !== undefined) {
+			throw new Error(`unknown / malformed flag: "${a}"`);
+		}
+	}
+	for (const r of required) {
+		if (!(r in out)) throw new Error(`missing required arg: --${r.replace(/([A-Z])/g, "-$1").toLowerCase()}`);
+	}
+	return out as CliArgs;
+}
+
+async function main(): Promise<void> {
+	const args = parseCliArgs(process.argv.slice(2));
+	const raw = await readFile(args.candidates, "utf-8");
+	const file = JSON.parse(raw) as CandidatesFile;
+	if (file.collection !== args.collection) {
+		throw new Error(
+			`candidates file collection "${file.collection}" mismatches --collection "${args.collection}"`,
+		);
+	}
+	console.log(`[recipe-validate] ${file.candidates.length} candidate(s) to probe`);
+
+	const store = createStore({ storage: "local" });
+	const head = await store.manifests.getHead(args.collection);
+	if (!head) throw new Error(`collection "${args.collection}" not found`);
+
+	const segments: Segment[] = [];
+	for (const segSummary of head.manifest.segments) {
+		const blob = await store.storage.download(segSummary.id);
+		segments.push(JSON.parse(new TextDecoder().decode(blob)) as Segment);
+	}
+
+	const vectorIndex = new InMemoryVectorIndex();
+	await mountCollection(head.manifest, store.storage, vectorIndex);
+	const embedder = new OpenAIEmbedder({
+		apiKey: process.env.WTFOC_EMBEDDER_KEY ?? "",
+		model: args.embedderModel,
+		baseUrl: args.embedderUrl,
+	});
+	const storageToDoc = buildStorageToDocMap(segments);
+
+	const records: ValidationRecord[] = [];
+	for (const candidate of file.candidates) {
+		try {
+			const probe = await probeCandidate(candidate, {
+				embedder,
+				vectorIndex,
+				segments,
+				storageToDoc,
+			});
+			const { label, reasons } = classifyValidation(candidate, probe);
+			records.push({ candidate, label, reasons, probe });
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			console.warn(`[recipe-validate] probe failed for ${candidate.draft.id ?? "?"}: ${msg}`);
+			records.push({
+				candidate,
+				label: "human-review",
+				reasons: [`probe-error:${msg.slice(0, 80)}`],
+				probe: {
+					goldRank: null,
+					widerK: 100,
+					requiredTypeCoverage: false,
+					traceHopCount: 0,
+					goldReachedByTrace: false,
+					topResults: [],
+				},
+			});
+		}
+	}
+
+	const enriched: EnrichedCandidatesFile = {
+		...file,
+		validation: { labelCounts: summarizeLabels(records), records },
+	};
+	await writeFile(args.output, JSON.stringify(enriched, null, 2), "utf-8");
+	const report = renderTriageReport(args.collection, records);
+	await writeFile(args.report, report, "utf-8");
+
+	const counts = summarizeLabels(records);
+	console.log(
+		`[recipe-validate] keeper=${counts["keeper-candidate"]} human=${counts["human-review"]} fix=${counts["needs-fix"]} trivial=${counts["trivial-suspect"]} reject=${counts["auto-reject"]}`,
+	);
+	console.log(`[recipe-validate] enriched JSON: ${args.output}`);
+	console.log(`[recipe-validate] triage report: ${args.report}`);
+}
+
+const entryPath = process.argv[1] ?? "";
+if (entryPath && fileURLToPath(import.meta.url) === entryPath) {
+	main().catch((err) => {
+		console.error("[recipe-validate] FATAL:", err);
+		process.exit(1);
+	});
+}


### PR DESCRIPTION
## Summary

#344 step-2 review tooling. Reads a candidates JSON from `recipe-author --live`, probes each candidate against the live mounted-corpus retriever + trace, classifies the result into a categorical label, emits both an enriched JSON (validation metadata) and a markdown triage report for the human reviewer.

## Design

Three-way peer-review consensus (codex / gemini / cursor) shaped the design:

1. **Deterministic probe (Option A) is the primary filter.** LLM-grader (Option B) deferred — single-model circularity is real and the marginal signal doesn't yet justify it.
2. **Categorical labels, not pass/fail.** Reviewer burden drops when disagreements are surfaced loudly: `keeper-candidate | trivial-suspect | needs-fix | human-review | auto-reject`.
3. **Probe is enrichment, not a hard gate.** Apply CLI (follow-up) will gate structurally-invalid candidates only; probe failures land in JSON for human override.
4. **Specifically NOT auto-rejected** (peer-review consensus): `goldRank > 50`, `wouldPass: false`, low score alone — these can reflect retrieval weakness on genuinely valuable trace-stress queries.

## Classifier rules

| Trigger | Label |
|---|---|
| Gold absent from top-K **AND** trace doesn't reach it | `auto-reject` |
| Gold rank in vector top-3 (adversarial filter disagreement) | `trivial-suspect` |
| Trace rescued gold not in top-K (deep-recall stress) | `human-review` |
| Trace template returned 0 hops | `needs-fix` |
| Required source types never surfaced | `needs-fix` |
| Gold mid-rank (4..widerK) | `human-review` |

## Public API

- `classifyValidation(candidate, probe)` — pure deterministic classifier
- `probeCandidate(candidate, ctx)` — live retrieve + trace + collect `ProbeMetadata`
- `summarizeLabels(records)` — per-label counts
- `renderTriageReport(collection, records)` — markdown packet per candidate, sorted by label

## CLI

```
pnpm exec tsx --tsconfig scripts/tsconfig.json \
  scripts/autoresearch/recipe-validate.ts \
  --candidates /tmp/candidates.json \
  --output /tmp/candidates.validated.json \
  --report /tmp/review.md \
  --collection wtfoc-dogfood-2026-04-v3 \
  --embedder-url ... --embedder-model ...
```

## Out of scope (follow-ups)

- **Option B**: LLM-grader for ambiguity / leakage / closed-book answerability — different model family.
- **Option D**: dedup-as-context against existing fixture.
- **`recipe-apply` CLI**: lands `keeper-candidate` entries directly into `gold-authored-queries.ts`; gates structurally-invalid; requires `humanOverride` for `needs-fix` / `trivial-suspect`.

## Test plan

- [x] 12 new unit tests cover every classifier rule, label-counts determinism, markdown report shape. Includes the **explicit `goldRank > 50` NON-rejection invariant** as a peer-review consensus pin.
- [x] `pnpm test`: 1762 passed, 2 skipped.
- [x] `pnpm lint:fix` clean.
- [x] `pnpm -r build` clean.

refs #344