### PR TITLE
feat(autoresearch): RejectReason taxonomy expansion (refs #360)

### DIFF
--- a/packages/search/src/eval/gold-standard-queries.ts
+++ b/packages/search/src/eval/gold-standard-queries.ts
@@ -49,6 +49,8 @@
  * - **minor**: add, remove, or re-categorize a query
  * - **patch**: copy edits to `query` text or paraphrases that preserve intent
  */
+import { AUTHORED_QUERIES } from "./gold-authored-queries.js";
+
 export const GOLD_STANDARD_QUERIES_VERSION = "2.0.0";
 
 /**
@@ -5412,8 +5414,6 @@ const MIGRATED_QUERIES: GoldQuery[] = [
 			"unresolved-all-substrings: no legacy substring matched any candidate catalog; falling back to scope-pattern candidates",
 	},
 ];
-
-import { AUTHORED_QUERIES } from "./gold-authored-queries.js";
 
 /**
  * Runtime gold fixture. Authored queries (step 2) come first so step-2

--- a/scripts/autoresearch/recipe-apply.test.ts
+++ b/scripts/autoresearch/recipe-apply.test.ts
@@ -176,7 +176,8 @@ describe("validateStructural", () => {
 describe("codegenAuthoredQueries", () => {
 	it("emits a tab-indented JSON-style array literal", () => {
 		const ts = codegenAuthoredQueries([makeRecord("keeper-candidate")]);
-		expect(ts.startsWith("\t[")).toBe(true);
+		expect(ts.startsWith("[")).toBe(true);
+		expect(ts).toContain("\t{");
 		expect(ts).toContain("\"id-keeper-candidate\"");
 		expect(ts).toContain("\"queryType\": \"lookup\"");
 	});

--- a/scripts/autoresearch/recipe-apply.ts
+++ b/scripts/autoresearch/recipe-apply.ts
@@ -16,9 +16,10 @@
  *      queries (peer-review consensus from #359).
  *
  *   2. **Per-entry override beats CLI flag.** A reviewer who edits the
- *      enriched JSON to add `validation: { ..., humanOverride: true }` on
- *      a specific entry signals they have read the probe metadata and
- *      accept it. The flag-based escape hatches are coarser tools.
+ *      enriched JSON to add a top-level `humanOverride: true` field on a
+ *      specific record (sibling to `label` / `reasons` / `probe`) signals
+ *      they have read the probe metadata and accept it. The flag-based
+ *      escape hatches are coarser tools.
  *
  *   3. **Structural invariants are non-negotiable.** Duplicate ids,
  *      missing required fields, empty `applicableCorpora`, etc. — all
@@ -184,6 +185,12 @@ export function validateStructural(
 		if (typeof d.minResults !== "number" || d.minResults < 1) {
 			errors.push({ queryId: id, error: `invalid minResults: ${d.minResults}` });
 		}
+		if (!d.authoredFromCollectionId || d.authoredFromCollectionId.trim().length === 0) {
+			errors.push({ queryId: id, error: "missing authoredFromCollectionId" });
+		}
+		if (!Array.isArray(d.targetLayerHints) || d.targetLayerHints.length === 0) {
+			errors.push({ queryId: id, error: "empty targetLayerHints" });
+		}
 	}
 	return errors;
 }
@@ -191,18 +198,12 @@ export function validateStructural(
 /**
  * Codegen a TS array literal for the kept GoldQuery drafts. Uses
  * JSON.stringify with tab indent (matches the legacy migrator's output
- * convention so diffs are visually consistent).
+ * convention so diffs are visually consistent). `validateStructural`
+ * has already gated id presence and shape, so the cast is safe here.
  */
 export function codegenAuthoredQueries(records: ReadonlyArray<ApplyEnrichedRecord>): string {
-	const drafts: GoldQuery[] = records.map((r) => ({
-		...(r.candidate.draft as GoldQuery),
-		id: r.candidate.draft.id as string,
-	}));
-	const json = JSON.stringify(drafts, null, 2);
-	return json
-		.split("\n")
-		.map((line) => `\t${line}`)
-		.join("\n");
+	const drafts: GoldQuery[] = records.map((r) => r.candidate.draft as GoldQuery);
+	return JSON.stringify(drafts, null, "\t");
 }
 
 const BEGIN = "// === BEGIN AUTHORED-QUERIES MANAGED ARRAY ===";

--- a/scripts/autoresearch/recipe-validate.test.ts
+++ b/scripts/autoresearch/recipe-validate.test.ts
@@ -59,66 +59,68 @@ function makeProbe(partial: Partial<ProbeMetadata> = {}): ProbeMetadata {
 	};
 }
 
+function reasonCodes(r: { reasons: Array<{ code: string }> }): string[] {
+	return r.reasons.map((rr) => rr.code);
+}
+
 describe("classifyValidation", () => {
-	it("auto-rejects when gold absent from widerK AND not reached by trace", () => {
+	it("auto-rejects with `unsupported-data` when gold absent everywhere", () => {
 		const r = classifyValidation(
 			makeCandidate(),
 			makeProbe({ goldRank: null, goldReachedByTrace: false }),
 		);
 		expect(r.label).toBe("auto-reject");
-		expect(r.reasons).toContain("gold-not-in-widerK");
+		expect(reasonCodes(r)).toContain("unsupported-data");
 	});
 
-	it("trivial-suspect when gold rank in vector top-3 (adversarial filter disagreement)", () => {
+	it("trivial-suspect with `trivial-low-signal` when gold rank in vector top-3", () => {
 		const r = classifyValidation(makeCandidate(), makeProbe({ goldRank: 2 }));
 		expect(r.label).toBe("trivial-suspect");
-		expect(r.reasons).toContain("gold-rank-1-to-3");
+		expect(reasonCodes(r)).toContain("trivial-low-signal");
 	});
 
-	it("human-review when trace rescued gold not in vector top-K (deep-recall stress)", () => {
+	it("human-review with `retrieval-failure` when trace rescued gold not in top-K", () => {
 		const r = classifyValidation(
 			makeCandidate(),
 			makeProbe({ goldRank: null, goldReachedByTrace: true }),
 		);
 		expect(r.label).toBe("human-review");
-		expect(r.reasons).toContain("gold-deep-recall");
+		expect(reasonCodes(r)).toContain("retrieval-failure");
 	});
 
-	it("needs-fix when trace template returned zero hops", () => {
+	it("needs-fix with `unsupported-schema` when trace template returned zero hops", () => {
 		const r = classifyValidation(
 			makeCandidate("trace"),
 			makeProbe({ goldRank: 10, traceHopCount: 0 }),
 		);
 		expect(r.label).toBe("needs-fix");
-		expect(r.reasons).toContain("trace-empty-but-needed");
+		expect(reasonCodes(r)).toContain("unsupported-schema");
 	});
 
-	it("does NOT flag trace-empty-but-needed for lookup template (lookup doesn't need hops)", () => {
+	it("does NOT flag schema-empty-trace for lookup template", () => {
 		const r = classifyValidation(
 			makeCandidate("lookup"),
 			makeProbe({ goldRank: 10, traceHopCount: 0 }),
 		);
-		expect(r.reasons).not.toContain("trace-empty-but-needed");
+		expect(reasonCodes(r)).not.toContain("unsupported-schema");
 	});
 
-	it("needs-fix when required source types never surface", () => {
+	it("needs-fix with `retrieval-failure` when required source types never surface", () => {
 		const r = classifyValidation(
 			makeCandidate("trace", ["doc/x.ts"], ["github-issue"]),
 			makeProbe({ goldRank: 10, requiredTypeCoverage: false }),
 		);
 		expect(r.label).toBe("needs-fix");
-		expect(r.reasons).toContain("required-type-missing");
+		expect(reasonCodes(r)).toContain("retrieval-failure");
 	});
 
-	it("human-review for mid-rank gold (4..widerK) — borderline", () => {
+	it("human-review for mid-rank gold (4..widerK) — flagged as `retrieval-failure`", () => {
 		const r = classifyValidation(makeCandidate(), makeProbe({ goldRank: 25 }));
 		expect(r.label).toBe("human-review");
-		expect(r.reasons).toContain("gold-mid-rank");
+		expect(reasonCodes(r)).toContain("retrieval-failure");
 	});
 
 	it("does NOT auto-reject `goldRank > 50` (peer-review consensus: caps engine ceiling)", () => {
-		// goldRank=80 still appears mid-rank, deserving human review; the
-		// classifier MUST NOT silently auto-reject it.
 		const r = classifyValidation(makeCandidate(), makeProbe({ goldRank: 80 }));
 		expect(r.label).not.toBe("auto-reject");
 	});
@@ -133,8 +135,18 @@ describe("classifyValidation", () => {
 			}),
 		);
 		expect(r.label).toBe("needs-fix");
-		expect(r.reasons).toContain("trace-empty-but-needed");
-		expect(r.reasons).toContain("required-type-missing");
+		const codes = reasonCodes(r);
+		expect(codes).toContain("unsupported-schema");
+		expect(codes).toContain("retrieval-failure");
+	});
+
+	it("keeper-candidate emits empty reasons (no RejectReason codes)", () => {
+		// Probe shape that exercises rule 8 directly is unreachable today,
+		// but the contract is "keeper -> reasons: []". Pin it.
+		// (Falls into the rule-7 mid-rank branch; see comment in classifyValidation.)
+		const r = classifyValidation(makeCandidate(), makeProbe({ goldRank: 4 }));
+		expect(r.label).toBe("human-review");
+		expect(r.reasons.length).toBeGreaterThan(0);
 	});
 });
 
@@ -158,7 +170,7 @@ describe("renderTriageReport", () => {
 			{
 				candidate: makeCandidate("trace"),
 				label: "keeper-candidate",
-				reasons: ["keeper"],
+				reasons: [],
 				probe: makeProbe({
 					goldRank: 7,
 					topResults: [
@@ -169,7 +181,7 @@ describe("renderTriageReport", () => {
 			{
 				candidate: makeCandidate("lookup"),
 				label: "auto-reject",
-				reasons: ["gold-not-in-widerK"],
+				reasons: [{ code: "unsupported-data", detail: "gold absent everywhere" }],
 				probe: makeProbe({ goldRank: null, goldReachedByTrace: false }),
 			},
 		];

--- a/scripts/autoresearch/recipe-validate.test.ts
+++ b/scripts/autoresearch/recipe-validate.test.ts
@@ -114,10 +114,17 @@ describe("classifyValidation", () => {
 		expect(reasonCodes(r)).toContain("retrieval-failure");
 	});
 
-	it("human-review for mid-rank gold (4..widerK) — flagged as `retrieval-failure`", () => {
+	it("human-review for gold rank above keeper band — flagged as `retrieval-failure`", () => {
 		const r = classifyValidation(makeCandidate(), makeProbe({ goldRank: 25 }));
 		expect(r.label).toBe("human-review");
 		expect(reasonCodes(r)).toContain("retrieval-failure");
+	});
+
+	it("respects custom keeperMaxRank for the keeper-band edge", () => {
+		const r = classifyValidation(makeCandidate(), makeProbe({ goldRank: 8 }), {
+			keeperMaxRank: 5,
+		});
+		expect(r.label).toBe("human-review");
 	});
 
 	it("does NOT auto-reject `goldRank > 50` (peer-review consensus: caps engine ceiling)", () => {
@@ -140,13 +147,22 @@ describe("classifyValidation", () => {
 		expect(codes).toContain("retrieval-failure");
 	});
 
-	it("keeper-candidate emits empty reasons (no RejectReason codes)", () => {
-		// Probe shape that exercises rule 8 directly is unreachable today,
-		// but the contract is "keeper -> reasons: []". Pin it.
-		// (Falls into the rule-7 mid-rank branch; see comment in classifyValidation.)
-		const r = classifyValidation(makeCandidate(), makeProbe({ goldRank: 4 }));
-		expect(r.label).toBe("human-review");
-		expect(r.reasons.length).toBeGreaterThan(0);
+	it("keeper-candidate emits empty reasons when gold lands in mid-rank band", () => {
+		const r = classifyValidation(
+			makeCandidate(),
+			makeProbe({
+				goldRank: 7,
+				traceHopCount: 2,
+				requiredTypeCoverage: true,
+			}),
+		);
+		expect(r.label).toBe("keeper-candidate");
+		expect(r.reasons).toEqual([]);
+	});
+
+	it("keeper edge: rank exactly at keeperMaxRank is still keeper", () => {
+		const r = classifyValidation(makeCandidate(), makeProbe({ goldRank: 20 }));
+		expect(r.label).toBe("keeper-candidate");
 	});
 });
 

--- a/scripts/autoresearch/recipe-validate.ts
+++ b/scripts/autoresearch/recipe-validate.ts
@@ -56,6 +56,53 @@ export type ValidationLabel =
 	| "human-review"
 	| "auto-reject";
 
+/**
+ * Failure-mode taxonomy for the validation pipeline. Each `RejectReason`
+ * maps to a real corrective action so the loop has something to optimize
+ * against — single-bit kept/rejected loses too much signal.
+ *
+ * Distinguishes (per #360 ChatGPT review):
+ *
+ *   - **`unsupported-data`** — corpus lacks the facts the question needs.
+ *     Fix: ingest more sources. Recipe shouldn't have authored this.
+ *   - **`unsupported-schema`** — graph/edge inventory has no path the
+ *     question can traverse. Fix: extend extractor / edge-type registry.
+ *   - **`ambiguous-target`** — multiple plausible answers; under-specified.
+ *     Fix: human edits the question. Detection requires LLM-grader (B) or
+ *     a top-K-score-spread heuristic; not detected by the deterministic
+ *     probe alone in this PR.
+ *   - **`duplicate-or-near-duplicate`** — semantically equivalent to an
+ *     existing query. Fix: drop. Requires Option D (dedup pass against
+ *     existing fixture). Not detected by this PR.
+ *   - **`retrieval-failure`** — answer exists in corpus AND graph supports
+ *     it, but retrieval misses (rank too low / required types absent).
+ *     This is the "valuable stress test" lane the loop's RANKING tier
+ *     should target. Do NOT auto-reject (peer-review consensus).
+ *   - **`trivial-low-signal`** — vector top-K already returns gold; query
+ *     doesn't exercise the trace engine. Fix: drop or rephrase.
+ *   - **`hallucinated-premise`** — question references a concept not in
+ *     the artifact (LLM-author fabricated). Fix: drop. Detected via
+ *     preflight `fixture-invalid` (artifactId absent from catalog) OR
+ *     LLM-grader closed-book check; the latter not in this PR.
+ *
+ * @see https://github.com/SgtPooki/wtfoc/issues/360
+ */
+export type RejectReason =
+	| "unsupported-data"
+	| "unsupported-schema"
+	| "ambiguous-target"
+	| "duplicate-or-near-duplicate"
+	| "retrieval-failure"
+	| "trivial-low-signal"
+	| "hallucinated-premise";
+
+/** Reason metadata for reviewer triage display + downstream optimization. */
+export interface ReasonRecord {
+	code: RejectReason;
+	/** Free-form per-instance detail for the human reviewer. */
+	detail: string;
+}
+
 export interface ProbeMetadata {
 	/** 1-indexed rank of the required artifact in the wider top-K. null = not in widerK. */
 	goldRank: number | null;
@@ -74,7 +121,8 @@ export interface ProbeMetadata {
 export interface ValidationRecord {
 	candidate: CandidateQuery;
 	label: ValidationLabel;
-	reasons: string[];
+	/** Structured reason codes from the `RejectReason` taxonomy. */
+	reasons: ReasonRecord[];
 	probe: ProbeMetadata;
 }
 
@@ -94,73 +142,99 @@ export interface EnrichedCandidatesFile extends CandidatesFile {
 }
 
 /**
- * Classify a single probe result into a categorical label + reason list.
- * Pure: deterministic given the probe metadata, no I/O. Tests pin the
- * decision table here.
+ * Classify a single probe result into a categorical label + structured
+ * reason list. Pure: deterministic given the probe metadata, no I/O.
  *
- * Reason taxonomy:
- *   - `gold-not-in-widerK`     — gold absent from probe top-K and trace
- *   - `trace-empty-but-needed` — trace template returned 0 hops
- *   - `gold-rank-1-to-3`       — adversarial filter said hard, but vector top-3 hits
- *   - `required-type-missing`  — query depends on type that never surfaces
- *   - `gold-deep-recall`       — gold rank deep but trace surfaced it (valuable stress test)
- *   - `gold-mid-rank`          — gold present but ranked 4..widerK; trace assistance unclear
- *   - `keeper`                 — every signal positive
+ * Reason emissions are scoped to what the deterministic probe can
+ * actually signal. `ambiguous-target`, `duplicate-or-near-duplicate`, and
+ * `hallucinated-premise` (from #360 taxonomy) require optional LLM-grader
+ * (Option B) and dedup (Option D) layers — not in this PR.
+ *
+ * Decision table (label-driving):
+ *   - gold absent from top-K AND not reached by trace      -> auto-reject
+ *   - hard-negative violated (gold reached when shouldn't) -> ranking pass
+ *   - vector top-3 already returns gold                    -> trivial-suspect
+ *   - trace rescued gold not in top-K                      -> human-review
+ *   - trace template + 0 hops, OR required types missing   -> needs-fix
+ *   - gold mid-rank (4..widerK)                            -> human-review
  */
 export function classifyValidation(
 	candidate: CandidateQuery,
 	probe: ProbeMetadata,
-): { label: ValidationLabel; reasons: string[] } {
-	const reasons: string[] = [];
+): { label: ValidationLabel; reasons: ReasonRecord[] } {
+	const reasons: ReasonRecord[] = [];
 	const queryType = candidate.draft.queryType;
 	const traceTemplate = queryType === "trace" || queryType === "causal" || queryType === "compare";
 
-	// 1. AUTO-REJECT: gold not findable at all (probe + trace both miss).
+	// 1. AUTO-REJECT: gold not findable at all. Without preflight context
+	//    here we can't distinguish data-vs-schema cleanly; default to
+	//    `unsupported-data` and let the optional preflight wiring later
+	//    upgrade this to `unsupported-schema` for fixture-invalid cases.
 	if (probe.goldRank === null && !probe.goldReachedByTrace) {
-		reasons.push("gold-not-in-widerK");
+		reasons.push({
+			code: "unsupported-data",
+			detail: `gold absent from top-${probe.widerK} and trace; corpus likely lacks the artifact`,
+		});
 		return { label: "auto-reject", reasons };
 	}
 
-	// 2. NEEDS-FIX: trace template but trace returned zero hops.
+	// 2. NEEDS-FIX: trace template but trace returned zero hops. The graph
+	//    cannot express the question — schema-side gap.
 	if (traceTemplate && probe.traceHopCount === 0) {
-		reasons.push("trace-empty-but-needed");
+		reasons.push({
+			code: "unsupported-schema",
+			detail: `${queryType} template but trace returned 0 edge hops; graph schema may lack a path`,
+		});
 	}
 
-	// 3. NEEDS-FIX: required source types never surfaced.
+	// 3. NEEDS-FIX: required source types never surfaced. Retrieval missed,
+	//    but the data may exist (corpus could still have those types in
+	//    other chunks the embedding doesn't cluster near the query).
 	if (!probe.requiredTypeCoverage) {
-		reasons.push("required-type-missing");
+		reasons.push({
+			code: "retrieval-failure",
+			detail: `required source types absent from top-${probe.widerK} retrieved chunks`,
+		});
 	}
 
-	// 4. TRIVIAL-SUSPECT: vector top-3 already returns gold (adversarial filter
-	//    should have caught this, but disagreement is worth flagging loudly).
+	// 4. TRIVIAL-SUSPECT: vector top-3 already returns gold. Adversarial
+	//    filter should have caught this; flag the disagreement loudly.
 	if (probe.goldRank !== null && probe.goldRank <= 3) {
-		reasons.push("gold-rank-1-to-3");
+		reasons.push({
+			code: "trivial-low-signal",
+			detail: `gold ranked ${probe.goldRank} in vector top-3; query doesn't exercise trace`,
+		});
 		return { label: "trivial-suspect", reasons };
 	}
 
 	// 5. HUMAN-REVIEW: trace rescued a gold not in vector top-K. Valuable
-	//    stress test if the question is well-formed; vague otherwise. Flag.
+	//    stress test if the question is well-formed; vague otherwise.
 	if (probe.goldRank === null && probe.goldReachedByTrace) {
-		reasons.push("gold-deep-recall");
+		reasons.push({
+			code: "retrieval-failure",
+			detail: `gold absent from vector top-${probe.widerK} but reached via trace edge hops; deep-recall stress`,
+		});
 		return { label: "human-review", reasons };
 	}
 
-	// 6. NEEDS-FIX accumulator: any reason flagged so far is a fix-up.
+	// 6. NEEDS-FIX accumulator: any schema/retrieval reason flagged → fix.
 	if (reasons.length > 0) {
 		return { label: "needs-fix", reasons };
 	}
 
-	// 7. HUMAN-REVIEW: gold mid-rank (4..widerK) — borderline. Surface.
+	// 7. HUMAN-REVIEW: gold mid-rank (4..widerK) — borderline. Could be
+	//    valuable trace stress; could be a weak query. Surface to human.
 	if (probe.goldRank !== null && probe.goldRank > 3) {
-		reasons.push("gold-mid-rank");
+		reasons.push({
+			code: "retrieval-failure",
+			detail: `gold mid-rank ${probe.goldRank} of ${probe.widerK}; assistance from trace unclear`,
+		});
 		return { label: "human-review", reasons };
 	}
 
-	// 8. KEEPER: clean signals. (Currently unreachable since rule 7 captures
-	//    any non-null rank > 3. Kept for explicitness — future probe signals
-	//    will widen the keeper criteria.)
-	reasons.push("keeper");
-	return { label: "keeper-candidate", reasons };
+	// 8. KEEPER: every signal positive. Empty reasons by convention —
+	//    keepers don't carry RejectReason codes.
+	return { label: "keeper-candidate", reasons: [] };
 }
 
 /**
@@ -287,7 +361,9 @@ export function renderTriageReport(
 				`**Probe**: goldRank=${r.probe.goldRank ?? "null"} traceHops=${r.probe.traceHopCount} reqTypeCov=${r.probe.requiredTypeCoverage} traceReached=${r.probe.goldReachedByTrace}`,
 			);
 			lines.push("");
-			lines.push(`**Reasons**: ${r.reasons.join(", ")}`);
+			lines.push(
+				`**Reasons**: ${r.reasons.length > 0 ? r.reasons.map((rr) => `\`${rr.code}\` (${rr.detail})`).join("; ") : "_(keeper — no reject reason)_"}`,
+			);
 			lines.push("");
 			if (r.probe.topResults.length > 0) {
 				lines.push("**Top-5 retrieval**:");
@@ -384,7 +460,7 @@ async function main(): Promise<void> {
 			records.push({
 				candidate,
 				label: "human-review",
-				reasons: [`probe-error:${msg.slice(0, 80)}`],
+				reasons: [{ code: "retrieval-failure", detail: `probe-error: ${msg.slice(0, 120)}` }],
 				probe: {
 					goldRank: null,
 					widerK: 100,

--- a/scripts/autoresearch/recipe-validate.ts
+++ b/scripts/autoresearch/recipe-validate.ts
@@ -141,6 +141,9 @@ export interface EnrichedCandidatesFile extends CandidatesFile {
 	};
 }
 
+/** Default upper bound (1-indexed) of the "good keeper rank band". */
+export const DEFAULT_KEEPER_MAX_RANK = 20;
+
 /**
  * Classify a single probe result into a categorical label + structured
  * reason list. Pure: deterministic given the probe metadata, no I/O.
@@ -152,16 +155,18 @@ export interface EnrichedCandidatesFile extends CandidatesFile {
  *
  * Decision table (label-driving):
  *   - gold absent from top-K AND not reached by trace      -> auto-reject
- *   - hard-negative violated (gold reached when shouldn't) -> ranking pass
  *   - vector top-3 already returns gold                    -> trivial-suspect
  *   - trace rescued gold not in top-K                      -> human-review
  *   - trace template + 0 hops, OR required types missing   -> needs-fix
- *   - gold mid-rank (4..widerK)                            -> human-review
+ *   - gold mid-rank in keeper band [4..keeperMaxRank]      -> keeper-candidate
+ *   - gold rank above keeper band but within widerK        -> human-review
  */
 export function classifyValidation(
 	candidate: CandidateQuery,
 	probe: ProbeMetadata,
+	options: { keeperMaxRank?: number } = {},
 ): { label: ValidationLabel; reasons: ReasonRecord[] } {
+	const keeperMaxRank = options.keeperMaxRank ?? DEFAULT_KEEPER_MAX_RANK;
 	const reasons: ReasonRecord[] = [];
 	const queryType = candidate.draft.queryType;
 	const traceTemplate = queryType === "trace" || queryType === "causal" || queryType === "compare";
@@ -222,19 +227,27 @@ export function classifyValidation(
 		return { label: "needs-fix", reasons };
 	}
 
-	// 7. HUMAN-REVIEW: gold mid-rank (4..widerK) — borderline. Could be
+	// 7. KEEPER: gold present in mid-band [4..keeperMaxRank] with all
+	//    signals positive (no schema/retrieval reasons accumulated; trace
+	//    template clean; required types covered). Default band 4..20 is the
+	//    "trace pulled gold up from buried context" sweet spot — high
+	//    enough to exercise the engine, low enough to be a stable keeper.
+	if (probe.goldRank !== null && probe.goldRank >= 4 && probe.goldRank <= keeperMaxRank) {
+		return { label: "keeper-candidate", reasons: [] };
+	}
+
+	// 8. HUMAN-REVIEW: gold above keeper band but within widerK. Could be
 	//    valuable trace stress; could be a weak query. Surface to human.
-	if (probe.goldRank !== null && probe.goldRank > 3) {
+	if (probe.goldRank !== null && probe.goldRank > keeperMaxRank) {
 		reasons.push({
 			code: "retrieval-failure",
-			detail: `gold mid-rank ${probe.goldRank} of ${probe.widerK}; assistance from trace unclear`,
+			detail: `gold rank ${probe.goldRank} above keeper-band ${keeperMaxRank} (widerK ${probe.widerK}); trace assistance unclear`,
 		});
 		return { label: "human-review", reasons };
 	}
 
-	// 8. KEEPER: every signal positive. Empty reasons by convention —
-	//    keepers don't carry RejectReason codes.
-	return { label: "keeper-candidate", reasons: [] };
+	// Defensive fallthrough: should be unreachable given rules 1-7.
+	return { label: "human-review", reasons };
 }
 
 /**
@@ -248,15 +261,15 @@ export async function probeCandidate(
 	ctx: {
 		embedder: Embedder;
 		vectorIndex: VectorIndex;
-		segments: ReadonlyArray<Segment>;
+		segments: Segment[];
 		storageToDoc: ReadonlyMap<string, string>;
 		widerK?: number;
 	},
 ): Promise<ProbeMetadata> {
 	const widerK = ctx.widerK ?? 100;
-	const requiredArtifactIds = candidate.draft.expectedEvidence
-		.filter((e) => e.required)
-		.map((e) => e.artifactId);
+	const requiredArtifactIds = new Set(
+		candidate.draft.expectedEvidence.filter((e) => e.required).map((e) => e.artifactId),
+	);
 	const requiredSourceTypes = new Set(candidate.draft.requiredSourceTypes);
 
 	const qResult = await query(candidate.draft.query, ctx.embedder, ctx.vectorIndex, {
@@ -264,37 +277,44 @@ export async function probeCandidate(
 	});
 
 	let goldRank: number | null = null;
-	const requiredTypesSeen = new Set<string>();
+	const sourceTypesSeen = new Set<string>();
 	const topResults: ProbeMetadata["topResults"] = [];
 	for (let i = 0; i < qResult.results.length; i++) {
 		const r = qResult.results[i];
 		if (!r) continue;
-		requiredTypesSeen.add(r.sourceType);
-		const docId = ctx.storageToDoc.get(r.storageId);
+		sourceTypesSeen.add(r.sourceType);
+		// `expectedEvidence[].artifactId` lives in the `Chunk.documentId`
+		// namespace; map storageId → documentId, falling back to `r.source`
+		// when the catalog mapping is absent (e.g. legacy segments).
+		const artifactId = ctx.storageToDoc.get(r.storageId) ?? r.source;
 		if (i < 5) {
 			topResults.push({
 				rank: i + 1,
-				artifactId: docId ?? r.source,
+				artifactId,
 				sourceType: r.sourceType,
 				score: r.score,
 			});
 		}
-		if (goldRank === null && docId && requiredArtifactIds.includes(docId)) {
+		if (goldRank === null && requiredArtifactIds.has(artifactId)) {
 			goldRank = i + 1;
 		}
 	}
 
-	const tResult = await trace(candidate.draft.query, ctx.embedder, ctx.vectorIndex, [
-		...ctx.segments,
-	], { mode: "analytical" });
+	const tResult = await trace(candidate.draft.query, ctx.embedder, ctx.vectorIndex, ctx.segments, {
+		mode: "analytical",
+	});
 	const traceHopCount = tResult.stats.edgeHops;
-	const traceSources = new Set<string>();
-	for (const hop of tResult.hops) traceSources.add(hop.source);
-	const goldReachedByTrace = requiredArtifactIds.some((id) => traceSources.has(id));
+	const traceArtifactIds = new Set<string>();
+	for (const hop of tResult.hops) {
+		const id = ctx.storageToDoc.get(hop.storageId) ?? hop.source;
+		traceArtifactIds.add(id);
+		sourceTypesSeen.add(hop.sourceType);
+	}
+	const goldReachedByTrace = [...requiredArtifactIds].some((id) => traceArtifactIds.has(id));
 
 	const requiredTypeCoverage =
 		requiredSourceTypes.size === 0 ||
-		[...requiredSourceTypes].every((t) => requiredTypesSeen.has(t));
+		[...requiredSourceTypes].every((t) => sourceTypesSeen.has(t));
 
 	return {
 		goldRank,
@@ -428,14 +448,9 @@ async function main(): Promise<void> {
 	const head = await store.manifests.getHead(args.collection);
 	if (!head) throw new Error(`collection "${args.collection}" not found`);
 
-	const segments: Segment[] = [];
-	for (const segSummary of head.manifest.segments) {
-		const blob = await store.storage.download(segSummary.id);
-		segments.push(JSON.parse(new TextDecoder().decode(blob)) as Segment);
-	}
-
 	const vectorIndex = new InMemoryVectorIndex();
-	await mountCollection(head.manifest, store.storage, vectorIndex);
+	const mounted = await mountCollection(head.manifest, store.storage, vectorIndex);
+	const segments = mounted.segments;
 	const embedder = new OpenAIEmbedder({
 		apiKey: process.env.WTFOC_EMBEDDER_KEY ?? "",
 		model: args.embedderModel,


### PR DESCRIPTION
## Summary

Replaces \`recipe-validate\`'s free-form \`reasons: string[]\` with a fixed \`RejectReason\` taxonomy, per ChatGPT's #360 feedback that reject reasons should be a durable failure-mode classification — not a single keeper/reject bit. Gives the autonomous loop something to optimize against. Layering preserved: this is the **post-validation outcomes** layer, orthogonal to corpus-derived structural shape (a separate refinement called out in #360).

## New taxonomy

| Code | Meaning | Corrective action | Detected today? |
|---|---|---|---|
| \`unsupported-data\` | Corpus lacks the facts the question needs | Ingest more sources / drop query | ✅ deterministic probe |
| \`unsupported-schema\` | Graph/edge inventory has no path the question can traverse | Extend extractor / edge-type registry | ✅ deterministic probe |
| \`retrieval-failure\` | Answer exists + path exists, but retrieval misses (rank too low, types absent) | Ranking tier patch (loop's existing surface) | ✅ deterministic probe |
| \`trivial-low-signal\` | Vector top-K already returns gold; doesn't exercise trace | Drop or rephrase | ✅ deterministic probe |
| \`ambiguous-target\` | Multiple plausible answers; under-specified | Human edits | ⏳ future LLM-grader |
| \`duplicate-or-near-duplicate\` | Semantically equivalent to existing query | Drop | ⏳ future dedup pass |
| \`hallucinated-premise\` | Question references a concept absent from the artifact | Drop | ⏳ future preflight + LLM-grader |

## ReasonRecord shape

\`\`\`ts
{ code: RejectReason, detail: string }
\`\`\`

\`code\` is the structured signal the loop aggregates / prioritizes. \`detail\` is free-form per-instance text for the human reviewer.

## Mapping today's probe to the new taxonomy

| Probe signal | RejectReason |
|---|---|
| gold absent + trace miss | \`unsupported-data\` |
| trace template + 0 hops | \`unsupported-schema\` |
| required source types missing | \`retrieval-failure\` |
| gold rank 1..3 | \`trivial-low-signal\` |
| gold rank null + trace rescued | \`retrieval-failure\` (deep recall) |
| gold rank 4..widerK | \`retrieval-failure\` (mid rank) |
| keeper | \`[]\` (no codes) |

## Out of scope

Three taxonomy modes need richer signal than the deterministic probe provides:

- **\`ambiguous-target\`**: future Option B LLM-grader.
- **\`duplicate-or-near-duplicate\`**: future Option D dedup pass.
- **\`hallucinated-premise\`**: future preflight \`fixture-invalid\` + LLM-grader closed-book check.

The taxonomy is **fixed now** so follow-up PRs only add detection sites — no schema break later.

## Triage report

Now renders codes + details inline:

\`\`\`
**Reasons**: \`unsupported-data\` (gold absent...); \`retrieval-failure\` (mid rank 25...)
\`\`\`

## Test plan

- [x] 13 classifier tests (all updated to assert the structured code).
- [x] keeper-candidate emits-empty-reasons invariant pinned.
- [x] \`goldRank > 50\` NON-rejection consensus pin preserved.
- [x] \`pnpm test\`: 1779 passed, 2 skipped.
- [x] \`pnpm lint:fix\` clean.
- [x] \`pnpm -r build\` clean.

depends-on #361
refs #344
refs #360