### PR TITLE
feat(autoresearch): FixtureHealthSignal + CoverageReport types (refs #360)

### DIFF
--- a/packages/search/src/eval/fixture-health.test.ts
+++ b/packages/search/src/eval/fixture-health.test.ts
@@ -1,0 +1,260 @@
+import type { DocumentCatalog, Segment } from "@wtfoc/common";
+import { describe, expect, it } from "vitest";
+import {
+	buildCoverageReport,
+	DEFAULT_GINI_FLOOR,
+	DEFAULT_MIN_UNCOVERED_STRATA,
+	deriveFixtureHealthSignal,
+	estimateHopCount,
+	giniCoefficient,
+	inferOperatorFamily,
+	isCrossSource,
+} from "./fixture-health.js";
+import type { GoldQuery } from "./gold-standard-queries.js";
+
+function makeQuery(overrides: Partial<GoldQuery> = {}): GoldQuery {
+	return {
+		id: overrides.id ?? "q1",
+		authoredFromCollectionId: "alpha",
+		applicableCorpora: ["alpha"],
+		query: "x",
+		queryType: "lookup",
+		difficulty: "easy",
+		targetLayerHints: ["ranking"],
+		expectedEvidence: [{ artifactId: "doc/x.ts", required: true }],
+		acceptableAnswerFacts: [],
+		requiredSourceTypes: ["code"],
+		minResults: 1,
+		...overrides,
+	};
+}
+
+function makeCatalog(docs: Array<{ id: string; sourceType: string }>): DocumentCatalog {
+	const documents: DocumentCatalog["documents"] = {};
+	for (const d of docs) {
+		documents[d.id] = {
+			documentId: d.id,
+			currentVersionId: "v1",
+			previousVersionIds: [],
+			chunkIds: [],
+			supersededChunkIds: [],
+			contentFingerprints: [],
+			state: "active",
+			mutability: "mutable-state",
+			sourceType: d.sourceType,
+			updatedAt: new Date().toISOString(),
+		};
+	}
+	return { schemaVersion: 1, collectionId: "alpha", documents };
+}
+
+function makeSegment(edgeTypes: string[] = []): Segment {
+	return {
+		schemaVersion: 1,
+		embeddingModel: "test",
+		embeddingDimensions: 1,
+		chunks: [],
+		edges: edgeTypes.map((type) => ({
+			type,
+			sourceId: "a",
+			targetType: "x",
+			targetId: "b",
+			evidence: "",
+			confidence: 1,
+		})),
+	};
+}
+
+describe("inferOperatorFamily", () => {
+	it("maps queryType 1:1", () => {
+		expect(inferOperatorFamily("lookup")).toBe("lookup");
+		expect(inferOperatorFamily("trace")).toBe("trace");
+		expect(inferOperatorFamily("entity-resolution")).toBe("entity-resolution");
+	});
+});
+
+describe("estimateHopCount", () => {
+	it("lookup with single artifact = 1", () => {
+		expect(estimateHopCount(makeQuery({ queryType: "lookup" }))).toBe(1);
+	});
+	it("trace with single artifact = 2 (min 2 for trace family)", () => {
+		expect(estimateHopCount(makeQuery({ queryType: "trace" }))).toBe(2);
+	});
+	it("compare with 3 required artifacts = 3", () => {
+		expect(
+			estimateHopCount(
+				makeQuery({
+					queryType: "compare",
+					expectedEvidence: [
+						{ artifactId: "a", required: true },
+						{ artifactId: "b", required: true },
+						{ artifactId: "c", required: true },
+					],
+				}),
+			),
+		).toBe(3);
+	});
+});
+
+describe("isCrossSource", () => {
+	it("false for single source type", () => {
+		expect(isCrossSource(makeQuery({ requiredSourceTypes: ["code"] }))).toBe(false);
+	});
+	it("true for >1 source types", () => {
+		expect(isCrossSource(makeQuery({ requiredSourceTypes: ["code", "github-issue"] }))).toBe(true);
+	});
+});
+
+describe("giniCoefficient", () => {
+	it("returns 0 for empty input", () => {
+		expect(giniCoefficient([])).toBe(0);
+	});
+	it("returns 0 for all-equal counts", () => {
+		expect(giniCoefficient([5, 5, 5, 5])).toBe(0);
+	});
+	it("returns 0 for all-zero counts", () => {
+		expect(giniCoefficient([0, 0, 0])).toBe(0);
+	});
+	it("approaches 1 for max-skew", () => {
+		// Single bucket carries all mass; n=10 → gini = (n-1)/n = 0.9.
+		const arr = Array.from({ length: 10 }, (_, i) => (i === 0 ? 100 : 0));
+		expect(giniCoefficient(arr)).toBeCloseTo(0.9, 2);
+	});
+	it("monotonic in skew", () => {
+		const even = giniCoefficient([10, 10, 10, 10]);
+		const skew = giniCoefficient([1, 2, 3, 30]);
+		expect(skew).toBeGreaterThan(even);
+	});
+});
+
+describe("buildCoverageReport", () => {
+	it("counts semantic strata per (sourceType, queryType)", () => {
+		const queries = [
+			makeQuery({ id: "a", queryType: "lookup", requiredSourceTypes: ["code"] }),
+			makeQuery({ id: "b", queryType: "lookup", requiredSourceTypes: ["code"] }),
+			makeQuery({ id: "c", queryType: "trace", requiredSourceTypes: ["code"] }),
+		];
+		const report = buildCoverageReport({
+			queries,
+			catalog: makeCatalog([{ id: "d1", sourceType: "code" }]),
+			segments: [],
+		});
+		expect(report.totalQueries).toBe(3);
+		const codeLookup = report.semantic.find(
+			(c) => c.key.sourceType === "code" && c.key.queryType === "lookup",
+		);
+		expect(codeLookup?.count).toBe(2);
+	});
+
+	it("emits one cell per requiredSourceType for cross-source queries", () => {
+		const queries = [
+			makeQuery({ queryType: "trace", requiredSourceTypes: ["code", "github-issue"] }),
+		];
+		const report = buildCoverageReport({
+			queries,
+			catalog: makeCatalog([{ id: "d1", sourceType: "code" }]),
+			segments: [],
+		});
+		expect(report.semantic).toHaveLength(2);
+	});
+
+	it("flags uncovered (sourceType, queryType) cells from catalog", () => {
+		const report = buildCoverageReport({
+			queries: [makeQuery({ queryType: "lookup", requiredSourceTypes: ["code"] })],
+			catalog: makeCatalog([
+				{ id: "d1", sourceType: "code" },
+				{ id: "d2", sourceType: "github-issue" },
+			]),
+			segments: [],
+		});
+		expect(report.uncoveredStrata.length).toBeGreaterThan(0);
+		const ghIssueTrace = report.uncoveredStrata.find(
+			(u) => u.key.sourceType === "github-issue" && u.key.queryType === "trace",
+		);
+		expect(ghIssueTrace).toBeDefined();
+		expect(ghIssueTrace?.artifactsInCorpus).toBe(1);
+		// `code/lookup` covered, must NOT appear:
+		const codeLookup = report.uncoveredStrata.find(
+			(u) => u.key.sourceType === "code" && u.key.queryType === "lookup",
+		);
+		expect(codeLookup).toBeUndefined();
+	});
+
+	it("structural strata bucket by (hopCount, crossSource, operatorFamily)", () => {
+		const queries = [
+			makeQuery({ id: "a", queryType: "lookup", requiredSourceTypes: ["code"] }),
+			makeQuery({
+				id: "b",
+				queryType: "trace",
+				requiredSourceTypes: ["code", "github-issue"],
+			}),
+		];
+		const report = buildCoverageReport({
+			queries,
+			catalog: makeCatalog([{ id: "d1", sourceType: "code" }]),
+			segments: [],
+		});
+		const traceCross = report.structural.find(
+			(c) => c.key.operatorFamily === "trace" && c.key.crossSource === true,
+		);
+		expect(traceCross).toBeDefined();
+		expect(traceCross?.key.hopCount).toBe(2);
+	});
+
+	it("gini = 0 when all strata equally populated", () => {
+		const queries = [
+			makeQuery({ id: "a", queryType: "lookup", requiredSourceTypes: ["code"] }),
+			makeQuery({ id: "b", queryType: "trace", requiredSourceTypes: ["github-issue"] }),
+		];
+		const report = buildCoverageReport({
+			queries,
+			catalog: makeCatalog([{ id: "d1", sourceType: "code" }]),
+			segments: [],
+		});
+		expect(report.giniCoefficient).toBe(0);
+	});
+
+	it("ingests segment edge types without throwing (reserved for future structural axis)", () => {
+		const report = buildCoverageReport({
+			queries: [makeQuery()],
+			catalog: makeCatalog([{ id: "d1", sourceType: "code" }]),
+			segments: [makeSegment(["closes", "references"])],
+		});
+		expect(report.totalQueries).toBe(1);
+	});
+});
+
+describe("deriveFixtureHealthSignal", () => {
+	it("flags coverage gap when uncovered strata exceed min", () => {
+		const report = buildCoverageReport({
+			queries: [makeQuery()],
+			catalog: makeCatalog([
+				{ id: "d1", sourceType: "code" },
+				{ id: "d2", sourceType: "github-issue" },
+				{ id: "d3", sourceType: "slack-message" },
+			]),
+			segments: [],
+		});
+		const sig = deriveFixtureHealthSignal({ collectionId: "alpha", coverage: report });
+		expect(sig.hasCoverageGap).toBe(true);
+		expect(sig.thresholds.giniFloor).toBe(DEFAULT_GINI_FLOOR);
+		expect(sig.thresholds.minUncoveredStrata).toBe(DEFAULT_MIN_UNCOVERED_STRATA);
+	});
+
+	it("respects custom thresholds", () => {
+		const report = buildCoverageReport({
+			queries: [makeQuery()],
+			catalog: makeCatalog([{ id: "d1", sourceType: "code" }]),
+			segments: [],
+		});
+		const sig = deriveFixtureHealthSignal({
+			collectionId: "alpha",
+			coverage: report,
+			minUncoveredStrata: 999,
+			giniFloor: 0.99,
+		});
+		// One source type * 7 queryTypes = 7 cells - 1 covered (code/lookup) = 6 uncovered;
+		// below threshold of 999, and gini=0 below 0.99.
+		expect(sig.hasCoverageGap).toBe(false);
+	});
+});

--- a/packages/search/src/eval/fixture-health.test.ts
+++ b/packages/search/src/eval/fixture-health.test.ts
@@ -80,7 +80,7 @@ describe("estimateHopCount", () => {
 	it("trace with single artifact = 2 (min 2 for trace family)", () => {
 		expect(estimateHopCount(makeQuery({ queryType: "trace" }))).toBe(2);
 	});
-	it("compare with 3 required artifacts = 3", () => {
+	it("compare stays at 2 even with 3 required-evidence rows (OR semantics)", () => {
 		expect(
 			estimateHopCount(
 				makeQuery({
@@ -92,7 +92,11 @@ describe("estimateHopCount", () => {
 					],
 				}),
 			),
-		).toBe(3);
+		).toBe(2);
+	});
+
+	it("minResults raises hopCount above family default", () => {
+		expect(estimateHopCount(makeQuery({ queryType: "lookup", minResults: 5 }))).toBe(5);
 	});
 });
 

--- a/packages/search/src/eval/fixture-health.ts
+++ b/packages/search/src/eval/fixture-health.ts
@@ -1,0 +1,323 @@
+/**
+ * Fixture-health signals — corpus-level observations about what the gold
+ * fixture can and cannot measure on a given collection. Orthogonal to
+ * `FailureClass` (which is per-failed-query). The autonomous loop reads
+ * both per cycle and decides whether to (a) patch ranking, (b) expand
+ * fixture, or (c) both — independent caps.
+ *
+ * Layering (per #360 settled-spec synthesis):
+ *
+ *   Generation layer:
+ *     `Stratum` (semantic + structural) → `recipe-author` → `CandidateQuery`
+ *
+ *   Validation-outcomes layer:
+ *     `RejectReason` (#362) — populated by `recipe-validate` probe.
+ *     `answerabilityState` — future LLM-grader; not in this slice.
+ *
+ *   Aggregation layer (this file):
+ *     `CoverageReport` — per-stratum counts + uncovered strata + Gini.
+ *     `FixtureHealthSignal` — corpus-level signal the loop routes on.
+ *
+ * Pure: no I/O. The eval runner computes `buildCoverageReport(...)` from
+ * `(GOLD_STANDARD_QUERIES, DocumentCatalog, segments)` and emits it
+ * alongside `DiagnosisAggregate`. Loop wiring + recipe-pipeline
+ * integration land in subsequent slices.
+ *
+ * @see https://github.com/SgtPooki/wtfoc/issues/360
+ */
+
+import type { DocumentCatalog, Segment } from "@wtfoc/common";
+import type { GoldQuery, QueryType } from "./gold-standard-queries.js";
+
+/**
+ * Operator family for structural-coverage analysis. Currently 1:1 with
+ * `QueryType` plus `aggregation` (reserved; not in the gold set yet).
+ * Kept as a separate type so the structural axis can evolve independently
+ * from the on-disk fixture schema.
+ */
+export type OperatorFamily =
+	| "lookup"
+	| "trace"
+	| "compare"
+	| "temporal"
+	| "causal"
+	| "howto"
+	| "entity-resolution"
+	| "aggregation";
+
+export interface SemanticStratumKey {
+	sourceType: string;
+	/** null = no edge requirement (lookup-style queries). */
+	edgeType: string | null;
+	queryType: QueryType;
+}
+
+export interface StructuralStratumKey {
+	/** Estimated minimum hops the query exercises. 1 for lookup, ≥2 for trace family. */
+	hopCount: number;
+	/** True when the query requires evidence from >1 source type. */
+	crossSource: boolean;
+	operatorFamily: OperatorFamily;
+}
+
+export interface SemanticStratumCount {
+	key: SemanticStratumKey;
+	count: number;
+}
+
+export interface StructuralStratumCount {
+	key: StructuralStratumKey;
+	count: number;
+}
+
+export interface UncoveredStratum {
+	key: SemanticStratumKey;
+	/** Catalog artifacts in this stratum that have no gold query. */
+	artifactsInCorpus: number;
+}
+
+export interface CoverageReport {
+	/** Total gold queries scoped to this corpus. */
+	totalQueries: number;
+	/** Per-(sourceType, edgeType, queryType) cell counts. */
+	semantic: SemanticStratumCount[];
+	/** Per-(hopCount, crossSource, operatorFamily) cell counts. */
+	structural: StructuralStratumCount[];
+	/** Strata occupied by the corpus catalog/edges but absent from the fixture. */
+	uncoveredStrata: UncoveredStratum[];
+	/**
+	 * Gini coefficient over per-semantic-stratum query counts. 0 = perfectly
+	 * even distribution; 1 = all queries in one stratum. Empty fixture
+	 * returns 0 (well-defined edge case, not a coverage failure).
+	 */
+	giniCoefficient: number;
+}
+
+export interface FixtureHealthSignal {
+	collectionId: string;
+	coverage: CoverageReport;
+	/**
+	 * True when `uncoveredStrata.length >= minUncovered` OR `gini >= giniFloor`.
+	 * The autonomous loop reads this as "expand-fixture candidate," NOT a
+	 * failure-class value (the layering distinction matters per #360).
+	 */
+	hasCoverageGap: boolean;
+	thresholds: {
+		giniFloor: number;
+		minUncoveredStrata: number;
+	};
+}
+
+/**
+ * Map a `QueryType` to its `OperatorFamily`. Currently 1:1 (the families
+ * superset the fixture-level enum), kept as a function so future families
+ * (`aggregation`) can route via different `queryType` shapes without
+ * rippling through call sites.
+ */
+export function inferOperatorFamily(queryType: QueryType): OperatorFamily {
+	return queryType;
+}
+
+/**
+ * Estimate the minimum edge-hop count a query exercises. `lookup` is 1
+ * (single retrieval). `trace`/`causal` are ≥2 (one edge walk minimum).
+ * `compare` is ≥2 (must surface ≥2 artifacts). Others default to 1 unless
+ * the query carries multiple required artifacts, in which case the min is
+ * `requiredArtifacts.length`.
+ */
+export function estimateHopCount(query: GoldQuery): number {
+	const requiredArtifacts = query.expectedEvidence.filter((e) => e.required).length;
+	const baseline = requiredArtifacts >= 2 ? requiredArtifacts : 1;
+	switch (query.queryType) {
+		case "lookup":
+		case "entity-resolution":
+		case "howto":
+			return baseline;
+		case "trace":
+		case "causal":
+		case "compare":
+		case "temporal":
+			return Math.max(2, baseline);
+		default:
+			return baseline;
+	}
+}
+
+/** Whether a query requires evidence from more than one source type. */
+export function isCrossSource(query: GoldQuery): boolean {
+	return query.requiredSourceTypes.length > 1;
+}
+
+/**
+ * Gini coefficient over a non-negative count distribution. Implemented via
+ * the sorted formulation `G = (sum_i (2i - n - 1) * x_i) / (n * sum(x))`
+ * where `x` is sorted ascending and `i` is 1-indexed. Returns 0 for empty
+ * or all-zero inputs (no inequality definable).
+ */
+export function giniCoefficient(counts: ReadonlyArray<number>): number {
+	if (counts.length === 0) return 0;
+	const sorted = [...counts].sort((a, b) => a - b);
+	const n = sorted.length;
+	let total = 0;
+	let weighted = 0;
+	for (let i = 0; i < n; i++) {
+		const v = sorted[i] ?? 0;
+		total += v;
+		weighted += (2 * (i + 1) - n - 1) * v;
+	}
+	if (total <= 0) return 0;
+	return weighted / (n * total);
+}
+
+function semanticKeyEquals(a: SemanticStratumKey, b: SemanticStratumKey): boolean {
+	return a.sourceType === b.sourceType && a.edgeType === b.edgeType && a.queryType === b.queryType;
+}
+
+function structuralKeyEquals(a: StructuralStratumKey, b: StructuralStratumKey): boolean {
+	return (
+		a.hopCount === b.hopCount &&
+		a.crossSource === b.crossSource &&
+		a.operatorFamily === b.operatorFamily
+	);
+}
+
+/**
+ * Derive the semantic stratum cell(s) a query occupies. A query may name
+ * multiple required source types; emit one cell per (sourceType,
+ * queryType) pair. `edgeType` is currently null (the gold schema does not
+ * carry an explicit edge-type field); future schema bumps may surface it.
+ */
+function semanticStrataForQuery(query: GoldQuery): SemanticStratumKey[] {
+	const sourceTypes =
+		query.requiredSourceTypes.length > 0 ? query.requiredSourceTypes : ["unknown"];
+	return sourceTypes.map((sourceType) => ({
+		sourceType,
+		edgeType: null,
+		queryType: query.queryType,
+	}));
+}
+
+function structuralStratumForQuery(query: GoldQuery): StructuralStratumKey {
+	return {
+		hopCount: estimateHopCount(query),
+		crossSource: isCrossSource(query),
+		operatorFamily: inferOperatorFamily(query.queryType),
+	};
+}
+
+/**
+ * Compute the coverage report for a corpus. Inputs:
+ *
+ *   - `queries` — gold queries scoped to this corpus (caller filters by
+ *     `applicableCorpora` BEFORE calling; this function is corpus-agnostic).
+ *   - `catalog` — corpus document catalog. Surfaces source-type cells
+ *     present in the corpus that the fixture may not measure.
+ *   - `segments` — surfaces edge-type cells via aggregated `Edge.type`.
+ *
+ * Pure: no I/O, deterministic given the inputs.
+ */
+export function buildCoverageReport(input: {
+	queries: ReadonlyArray<GoldQuery>;
+	catalog: DocumentCatalog;
+	segments: ReadonlyArray<Segment>;
+}): CoverageReport {
+	const { queries, catalog, segments } = input;
+
+	const semantic: SemanticStratumCount[] = [];
+	const structural: StructuralStratumCount[] = [];
+
+	for (const q of queries) {
+		for (const key of semanticStrataForQuery(q)) {
+			const existing = semantic.find((c) => semanticKeyEquals(c.key, key));
+			if (existing) existing.count++;
+			else semantic.push({ key, count: 1 });
+		}
+		const sKey = structuralStratumForQuery(q);
+		const existing = structural.find((c) => structuralKeyEquals(c.key, sKey));
+		if (existing) existing.count++;
+		else structural.push({ key: sKey, count: 1 });
+	}
+
+	// Catalog occupancy: count documents per sourceType. Edge types come
+	// from segments. The corpus "shape" is the cross-product of catalog
+	// sourceTypes × {null, ...edgeTypes} × all queryTypes — that's an
+	// over-broad upper bound, so we only flag uncovered cells where the
+	// corpus actually has artifacts of the source type.
+	const catalogSourceTypeCounts = new Map<string, number>();
+	for (const doc of Object.values(catalog.documents)) {
+		catalogSourceTypeCounts.set(
+			doc.sourceType,
+			(catalogSourceTypeCounts.get(doc.sourceType) ?? 0) + 1,
+		);
+	}
+
+	const corpusEdgeTypes = new Set<string>();
+	for (const seg of segments) {
+		for (const edge of seg.edges) corpusEdgeTypes.add(edge.type);
+	}
+
+	// Per #360 acceptance criterion: surface uncovered (sourceType,
+	// queryType) cells where the catalog has artifacts but the fixture has
+	// zero gold queries. Edge dimension stays null in this slice — adding
+	// it would require gold queries to carry an explicit `edgeType` field.
+	const uncoveredStrata: UncoveredStratum[] = [];
+	const allQueryTypes: QueryType[] = [
+		"lookup",
+		"trace",
+		"compare",
+		"temporal",
+		"causal",
+		"howto",
+		"entity-resolution",
+	];
+	for (const [sourceType, artifactsInCorpus] of catalogSourceTypeCounts) {
+		for (const queryType of allQueryTypes) {
+			const key: SemanticStratumKey = { sourceType, edgeType: null, queryType };
+			const covered = semantic.some((c) => semanticKeyEquals(c.key, key));
+			if (!covered) uncoveredStrata.push({ key, artifactsInCorpus });
+		}
+	}
+
+	const gini = giniCoefficient(semantic.map((c) => c.count));
+
+	// `corpusEdgeTypes` is captured for future structural-edge expansion;
+	// surfacing it now keeps the contract stable without a schema change.
+	void corpusEdgeTypes;
+
+	return {
+		totalQueries: queries.length,
+		semantic,
+		structural,
+		uncoveredStrata,
+		giniCoefficient: gini,
+	};
+}
+
+export const DEFAULT_GINI_FLOOR = 0.6;
+export const DEFAULT_MIN_UNCOVERED_STRATA = 3;
+
+/**
+ * Wrap a `CoverageReport` in a routing-friendly signal. The autonomous
+ * loop checks `hasCoverageGap` to decide whether to invoke the
+ * recipe-author pipeline this cycle. Thresholds are env-tunable per
+ * #360 spec (knob defaults match `WTFOC_RECIPE_GINI_FLOOR` /
+ * `WTFOC_RECIPE_MIN_UNCOVERED_STRATA`).
+ */
+export function deriveFixtureHealthSignal(input: {
+	collectionId: string;
+	coverage: CoverageReport;
+	giniFloor?: number;
+	minUncoveredStrata?: number;
+}): FixtureHealthSignal {
+	const giniFloor = input.giniFloor ?? DEFAULT_GINI_FLOOR;
+	const minUncoveredStrata = input.minUncoveredStrata ?? DEFAULT_MIN_UNCOVERED_STRATA;
+	const hasCoverageGap =
+		input.coverage.uncoveredStrata.length >= minUncoveredStrata ||
+		input.coverage.giniCoefficient >= giniFloor;
+	return {
+		collectionId: input.collectionId,
+		coverage: input.coverage,
+		hasCoverageGap,
+		thresholds: { giniFloor, minUncoveredStrata },
+	};
+}

--- a/packages/search/src/eval/fixture-health.ts
+++ b/packages/search/src/eval/fixture-health.ts
@@ -119,28 +119,30 @@ export function inferOperatorFamily(queryType: QueryType): OperatorFamily {
 }
 
 /**
- * Estimate the minimum edge-hop count a query exercises. `lookup` is 1
- * (single retrieval). `trace`/`causal` are ≥2 (one edge walk minimum).
- * `compare` is ≥2 (must surface ≥2 artifacts). Others default to 1 unless
- * the query carries multiple required artifacts, in which case the min is
- * `requiredArtifacts.length`.
+ * Estimate the minimum edge-hop count a query exercises. `lookup` and
+ * `howto` are 1 (single retrieval / single synthesis pass).
+ * `trace` / `causal` / `compare` / `temporal` are ≥2 because they require
+ * either multiple evidence artifacts or a graph walk to satisfy. The
+ * `expectedEvidence[].required` rows are OR-semantics (any one row can
+ * satisfy the query — the multi-row case is alternate fallback artifacts
+ * from the legacy substring migration), so they are NOT counted as
+ * additional hops here. `minResults` is treated as the per-query
+ * lower bound when greater than the family default.
  */
 export function estimateHopCount(query: GoldQuery): number {
-	const requiredArtifacts = query.expectedEvidence.filter((e) => e.required).length;
-	const baseline = requiredArtifacts >= 2 ? requiredArtifacts : 1;
-	switch (query.queryType) {
-		case "lookup":
-		case "entity-resolution":
-		case "howto":
-			return baseline;
-		case "trace":
-		case "causal":
-		case "compare":
-		case "temporal":
-			return Math.max(2, baseline);
-		default:
-			return baseline;
-	}
+	const familyMin = (() => {
+		switch (query.queryType) {
+			case "trace":
+			case "causal":
+			case "compare":
+			case "temporal":
+				return 2;
+			default:
+				return 1;
+		}
+	})();
+	const minResults = typeof query.minResults === "number" ? query.minResults : 1;
+	return Math.max(familyMin, minResults);
 }
 
 /** Whether a query requires evidence from more than one source type. */
@@ -212,7 +214,10 @@ function structuralStratumForQuery(query: GoldQuery): StructuralStratumKey {
  *     `applicableCorpora` BEFORE calling; this function is corpus-agnostic).
  *   - `catalog` — corpus document catalog. Surfaces source-type cells
  *     present in the corpus that the fixture may not measure.
- *   - `segments` — surfaces edge-type cells via aggregated `Edge.type`.
+ *   - `segments` — segment inventory. Reserved for the structural
+ *     edge-type axis in a future slice; not consumed in this slice (the
+ *     gold schema does not yet carry an explicit `edgeType` field, so
+ *     edges-from-segments would have nothing to cross-reference against).
  *
  * Pure: no I/O, deterministic given the inputs.
  */
@@ -221,7 +226,7 @@ export function buildCoverageReport(input: {
 	catalog: DocumentCatalog;
 	segments: ReadonlyArray<Segment>;
 }): CoverageReport {
-	const { queries, catalog, segments } = input;
+	const { queries, catalog } = input;
 
 	const semantic: SemanticStratumCount[] = [];
 	const structural: StructuralStratumCount[] = [];
@@ -251,11 +256,6 @@ export function buildCoverageReport(input: {
 		);
 	}
 
-	const corpusEdgeTypes = new Set<string>();
-	for (const seg of segments) {
-		for (const edge of seg.edges) corpusEdgeTypes.add(edge.type);
-	}
-
 	// Per #360 acceptance criterion: surface uncovered (sourceType,
 	// queryType) cells where the catalog has artifacts but the fixture has
 	// zero gold queries. Edge dimension stays null in this slice — adding
@@ -279,10 +279,6 @@ export function buildCoverageReport(input: {
 	}
 
 	const gini = giniCoefficient(semantic.map((c) => c.count));
-
-	// `corpusEdgeTypes` is captured for future structural-edge expansion;
-	// surfacing it now keeps the contract stable without a schema change.
-	void corpusEdgeTypes;
 
 	return {
 		totalQueries: queries.length,

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -37,6 +37,26 @@ export {
 	aggregateDiagnoses,
 	diagnoseFailure,
 } from "./eval/failure-diagnosis.js";
+export type {
+	CoverageReport,
+	FixtureHealthSignal,
+	OperatorFamily,
+	SemanticStratumCount,
+	SemanticStratumKey,
+	StructuralStratumCount,
+	StructuralStratumKey,
+	UncoveredStratum,
+} from "./eval/fixture-health.js";
+export {
+	buildCoverageReport,
+	DEFAULT_GINI_FLOOR,
+	DEFAULT_MIN_UNCOVERED_STRATA,
+	deriveFixtureHealthSignal,
+	estimateHopCount,
+	giniCoefficient,
+	inferOperatorFamily,
+	isCrossSource,
+} from "./eval/fixture-health.js";
 export {
 	type Difficulty,
 	type ExpectedEvidence,


### PR DESCRIPTION
## Summary

First slice of #360 — coverage-gap detector. Pure types + builder, no wiring yet. Eval-runner emission + autonomous-loop routing + programmatic recipe pipeline land in subsequent PRs.

## Layering (per #360 settled spec)

`coverage-gap` is **orthogonal to `FailureClass`**, not another value. The autonomous loop reads BOTH per cycle and decides whether to (a) patch ranking, (b) expand fixture, or (c) both — independent caps.

```
Generation layer:
  Stratum (semantic + structural) → recipe-author → CandidateQuery

Validation-outcomes layer (post-eval):
  RejectReason (#362)        ← detected by probe / grader / dedup
  AnswerabilityState         ← future, observed from validation
  DiagnosticYield            ← future, advisory until stable

Aggregation layer (THIS PR):
  CoverageReport             ← orthogonal to FailureClass
  FixtureHealthSignal        ← what the loop routes on
```

## Changes

- New `packages/search/src/eval/fixture-health.ts`:
  - `OperatorFamily` — currently 1:1 with `QueryType` plus reserved `aggregation`. Decoupled so the structural axis can evolve independently from the on-disk schema.
  - `SemanticStratumKey` — `(sourceType, edgeType, queryType)`.
  - `StructuralStratumKey` — `(hopCount, crossSource, operatorFamily)` per the synthesis-comment refinement (semantic ≠ structural axes).
  - `CoverageReport` — totalQueries, semantic[], structural[], uncoveredStrata[], giniCoefficient.
  - `FixtureHealthSignal` — wraps the report with `hasCoverageGap` + thresholds; matches the `WTFOC_RECIPE_GINI_FLOOR` / `WTFOC_RECIPE_MIN_UNCOVERED_STRATA` env knobs the loop will read.
  - `buildCoverageReport({ queries, catalog, segments })` — pure builder.
  - Helpers: `inferOperatorFamily`, `estimateHopCount`, `isCrossSource`, `giniCoefficient` (sorted formulation; safe for empty/all-zero).
  - `deriveFixtureHealthSignal` — thresholds default to 0.6 / 3.

`answerabilityState` and `diagnosticYield` are deliberately deferred to the validation-outcomes layer per the 2nd-round refinement comment; they live alongside `RejectReason` (#362), not in the structural axis.

## Tests

19 unit tests in `fixture-health.test.ts`:
- Gini edge cases (empty / all-equal / all-zero / max-skew / monotonicity).
- Hop-count inference per `queryType` family.
- Cross-source detection.
- Semantic + structural bucketing.
- Uncovered-cell emission against the catalog (fixture has `code/lookup`, catalog has `github-issue` → `github-issue/{trace,causal,...}` flagged uncovered).
- Threshold-driven signal derivation.

## Test plan
- [x] `pnpm test` passes (1800 tests, 0 failures)
- [x] `pnpm -r build` passes
- [x] `pnpm lint:fix` clean

## Next slices
- 1b: Eval runner emits `coverageReport` alongside `diagnosisAggregate`.
- 1c: Autonomous loop reads both, routing decision (patch vs fixture-expand vs both).
- 1d: Programmatic recipe-pipeline integration when `hasCoverageGap` dominant.
- 1e: Draft-PR opener for fixture additions.