### PR TITLE
feat(autoresearch): wire dogfood documentCatalog → evaluator (refs #360)

### DIFF
--- a/scripts/dogfood.ts
+++ b/scripts/dogfood.ts
@@ -570,6 +570,21 @@ async function main() {
 							...(Object.keys(retrievalOverrides).length > 0
 								? { retrievalOverrides }
 								: {}),
+							// #360 — feed the per-corpus document catalog so the
+							// evaluator emits coverageReport + fixtureHealthSignal
+							// alongside diagnosisAggregate. Knobs land via env so
+							// the autoresearch sweep can override per-cycle.
+							...(qqCatalog ? { documentCatalog: qqCatalog } : {}),
+							...(process.env.WTFOC_RECIPE_GINI_FLOOR
+								? { coverageGiniFloor: Number(process.env.WTFOC_RECIPE_GINI_FLOOR) }
+								: {}),
+							...(process.env.WTFOC_RECIPE_MIN_UNCOVERED_STRATA
+								? {
+										coverageMinUncoveredStrata: Number(
+											process.env.WTFOC_RECIPE_MIN_UNCOVERED_STRATA,
+										),
+									}
+								: {}),
 						},
 						values["diversity-enforce"] ?? false,
 					);


### PR DESCRIPTION
## Summary

Third slice of #360 — milestone 1c. **Stacked on #367 (which is stacked on #366).**

Threads the per-corpus document catalog from dogfood's quality-queries stage into the `QualityQueriesContext` so the evaluator emits `coverageReport` + `fixtureHealthSignal` alongside the `diagnosisAggregate` it already produced.

## Changes

- `scripts/dogfood.ts`: forwards the already-loaded `qqCatalog` (used for preflight) plus the env-tunable `WTFOC_RECIPE_GINI_FLOOR` / `WTFOC_RECIPE_MIN_UNCOVERED_STRATA` thresholds into the `evaluateQualityQueries` context.
- The autoresearch sweep harness shells out to dogfood with a forwarded env, so both knobs propagate naturally — no separate sweep.ts plumbing needed.

## Behavior

- No-op for callers without a catalog on disk (`metrics.coverageReport` stays null).
- When the catalog is present, `metrics.coverageReport` and `metrics.fixtureHealthSignal` populate in dogfood reports + sweep variant outputs.

## Test plan
- [x] `pnpm test` passes (1802 tests, 0 failures)
- [x] `pnpm -r build` passes
- [x] `pnpm lint:fix` clean

## Next slices
- 1d: autonomous-loop reads `metrics.fixtureHealthSignal` and routes between patch-ranking vs fixture-expand actions per cycle.
- 1e: programmatic recipe-pipeline call (author → validate → apply) when `hasCoverageGap` dominant.
- 1f: draft-PR opener for fixture additions.

## Merge order
#366 → #367 → this PR. Each rebases cleanly when its parent merges.