### PR TITLE
feat(autoresearch): autonomous-loop reads fixtureHealthSignal + routes (refs #360)

### DIFF
--- a/scripts/autoresearch/autonomous-loop-wiring.test.ts
+++ b/scripts/autoresearch/autonomous-loop-wiring.test.ts
@@ -1,7 +1,15 @@
-import type { DiagnosisAggregate, FailureLayer } from "@wtfoc/search";
+import type {
+	DiagnosisAggregate,
+	FailureLayer,
+	FixtureHealthSignal,
+} from "@wtfoc/search";
 import { describe, expect, it } from "vitest";
 import type { ExtendedDogfoodReport } from "../lib/run-config.js";
-import { extractDominantLayer } from "./autonomous-loop.js";
+import {
+	decideLoopAction,
+	extractDominantLayer,
+	extractFixtureHealthSignal,
+} from "./autonomous-loop.js";
 import { selectPatchCapsule } from "./patch-capsule.js";
 
 /**
@@ -158,5 +166,87 @@ describe("diagnosis -> capsule routing chain", () => {
 		// falls through to analyzeAndProposePatch's built-in defaults rather
 		// than skipping the cycle (backwards compat for pre-#347 reports).
 		expect(selectPatchCapsule(layer)).toBeNull();
+	});
+});
+
+function makeFixtureHealthSignal(
+	overrides: Partial<FixtureHealthSignal> = {},
+): FixtureHealthSignal {
+	return {
+		collectionId: "alpha",
+		coverage: {
+			totalQueries: 1,
+			semantic: [],
+			structural: [],
+			uncoveredStrata: [],
+			giniCoefficient: 0,
+		},
+		hasCoverageGap: false,
+		thresholds: { giniFloor: 0.6, minUncoveredStrata: 3 },
+		...overrides,
+	};
+}
+
+describe("extractFixtureHealthSignal", () => {
+	it("returns null when the report is null", () => {
+		expect(extractFixtureHealthSignal(null)).toBeNull();
+	});
+
+	it("returns null when the stage has no fixtureHealthSignal", () => {
+		const report = makeReport("ranking");
+		expect(extractFixtureHealthSignal(report)).toBeNull();
+	});
+
+	it("extracts a fixtureHealthSignal when present in metrics", () => {
+		const report = makeReport("ranking");
+		const stage = report.stages[0];
+		const signal = makeFixtureHealthSignal({ hasCoverageGap: true });
+		if (stage)
+			stage.metrics = { ...stage.metrics, fixtureHealthSignal: signal } as Record<
+				string,
+				unknown
+			>;
+		expect(extractFixtureHealthSignal(report)?.hasCoverageGap).toBe(true);
+	});
+});
+
+describe("decideLoopAction (#360 routing)", () => {
+	it("tryPatch=true when dominantLayer is set", () => {
+		const d = decideLoopAction({ dominantLayer: "ranking", fixtureHealth: null });
+		expect(d.tryPatch).toBe(true);
+		expect(d.tryFixtureExpand).toBe(false);
+	});
+
+	it("tryFixtureExpand=true when fixtureHealth.hasCoverageGap", () => {
+		const d = decideLoopAction({
+			dominantLayer: null,
+			fixtureHealth: makeFixtureHealthSignal({ hasCoverageGap: true }),
+		});
+		expect(d.tryFixtureExpand).toBe(true);
+		expect(d.tryPatch).toBe(false);
+	});
+
+	it("both true when dominantLayer set AND coverage gap present (orthogonal signals)", () => {
+		const d = decideLoopAction({
+			dominantLayer: "ranking",
+			fixtureHealth: makeFixtureHealthSignal({ hasCoverageGap: true }),
+		});
+		expect(d.tryPatch).toBe(true);
+		expect(d.tryFixtureExpand).toBe(true);
+	});
+
+	it("both false when neither signal present (clean cycle, fall through to variant flow)", () => {
+		const d = decideLoopAction({ dominantLayer: null, fixtureHealth: null });
+		expect(d.tryPatch).toBe(false);
+		expect(d.tryFixtureExpand).toBe(false);
+	});
+
+	it("rationale includes both inputs", () => {
+		const d = decideLoopAction({
+			dominantLayer: "ranking",
+			fixtureHealth: makeFixtureHealthSignal({ hasCoverageGap: false }),
+		});
+		expect(d.rationale).toContain("dominantLayer=ranking");
+		expect(d.rationale).toContain("coverage(");
 	});
 });

--- a/scripts/autoresearch/autonomous-loop-wiring.test.ts
+++ b/scripts/autoresearch/autonomous-loop-wiring.test.ts
@@ -197,6 +197,12 @@ describe("extractFixtureHealthSignal", () => {
 		expect(extractFixtureHealthSignal(report)).toBeNull();
 	});
 
+	it("returns null when the report has no quality-queries stage (older / partial report)", () => {
+		const report = makeReport("ranking");
+		report.stages = [];
+		expect(extractFixtureHealthSignal(report)).toBeNull();
+	});
+
 	it("extracts a fixtureHealthSignal when present in metrics", () => {
 		const report = makeReport("ranking");
 		const stage = report.stages[0];
@@ -248,5 +254,10 @@ describe("decideLoopAction (#360 routing)", () => {
 		});
 		expect(d.rationale).toContain("dominantLayer=ranking");
 		expect(d.rationale).toContain("coverage(");
+	});
+
+	it("rationale flags signal-unavailable when fixtureHealth is null", () => {
+		const d = decideLoopAction({ dominantLayer: "ranking", fixtureHealth: null });
+		expect(d.rationale).toContain("coverage=signal-unavailable");
 	});
 });

--- a/scripts/autoresearch/autonomous-loop.ts
+++ b/scripts/autoresearch/autonomous-loop.ts
@@ -256,7 +256,10 @@ export function decideLoopAction(input: {
 			`coverage(uncovered=${input.fixtureHealth.coverage.uncoveredStrata.length}, gini=${input.fixtureHealth.coverage.giniCoefficient.toFixed(2)}, gap=${input.fixtureHealth.hasCoverageGap})`,
 		);
 	} else {
-		parts.push("coverage=null (no documentCatalog)");
+		// Could be: no documentCatalog passed, no quality-queries stage,
+		// missing field on older report, or null report. The extractor
+		// collapses all of those — surface them as one bucket here.
+		parts.push("coverage=signal-unavailable");
 	}
 	parts.push(`tryPatch=${tryPatch} tryFixtureExpand=${tryFixtureExpand}`);
 	return { tryPatch, tryFixtureExpand, rationale: parts.join(" ") };
@@ -454,23 +457,32 @@ async function runLoop(cli: CliArgs): Promise<LoopOutcome> {
 	notes.push(`route: ${decision.rationale}`);
 
 	// #360 — fixture-expand path is a NON-patch action. Gated separately
-	// from `WTFOC_ALLOW_PATCHES`. When dominant, we hand the cycle off
-	// here (the loop returns); when only-flagged-not-dominant we continue
-	// to the existing patch/variant flow so a single coverage gap doesn't
-	// monopolize cycles. Treat "dominant" as "patch path also wants in"
-	// → tryFixtureExpand only AND not tryPatch.
+	// from `WTFOC_ALLOW_PATCHES`. The early-return below is conditional on
+	// (a) only fixture-expand wants in (no dominantLayer competing) AND
+	// (b) `--dry-run` OR `WTFOC_ALLOW_FIXTURE_EXPAND=1` is set. When the
+	// gate is closed OR a dominantLayer is also present, the loop continues
+	// to the existing variant / patch flow so a single coverage gap can't
+	// monopolize cycles.
+	const fixtureExpandGateOpen =
+		cli.dryRun || process.env.WTFOC_ALLOW_FIXTURE_EXPAND === "1";
 	if (
 		decision.tryFixtureExpand &&
 		!decision.tryPatch &&
-		(cli.dryRun || process.env.WTFOC_ALLOW_FIXTURE_EXPAND === "1") &&
+		fixtureExpandGateOpen &&
 		fixtureHealth
 	) {
 		return runFixtureExpandPath({ cli, fixtureHealth, notes });
 	}
 	if (decision.tryFixtureExpand && fixtureHealth) {
-		notes.push(
-			"fixture-expand opportunity detected; deferring to patch path this cycle (set WTFOC_ALLOW_FIXTURE_EXPAND=1 + no dominantLayer to route here)",
-		);
+		if (decision.tryPatch) {
+			notes.push(
+				"fixture-expand opportunity detected; dominantLayer also present, deferring fixture-expand and continuing to variant/patch flow",
+			);
+		} else if (!fixtureExpandGateOpen) {
+			notes.push(
+				"fixture-expand opportunity detected but gated off; continuing to variant flow (set WTFOC_ALLOW_FIXTURE_EXPAND=1 or --dry-run to route here)",
+			);
+		}
 	}
 
 	const triedRows = readTriedLog();

--- a/scripts/autoresearch/autonomous-loop.ts
+++ b/scripts/autoresearch/autonomous-loop.ts
@@ -34,7 +34,11 @@ import { ensureMode, type GpuMode, resolveModeFromMatrix } from "../lib/mode-swi
 import { analyzeAndPropose } from "./analyze-and-propose.js";
 import { analyzeAndProposePatch } from "./analyze-and-propose-patch.js";
 import { selectPatchCapsule } from "./patch-capsule.js";
-import type { DiagnosisAggregate, FailureLayer } from "@wtfoc/search";
+import type {
+	DiagnosisAggregate,
+	FailureLayer,
+	FixtureHealthSignal,
+} from "@wtfoc/search";
 import type { DetectionOutcome, Finding } from "./detect-regression.js";
 import { explainFinding } from "./explain-finding.js";
 import { materializePatchProposal } from "./materialize-patch.js";
@@ -70,7 +74,9 @@ interface LoopOutcome {
 		| "patch-accepted-pr-created"
 		| "patch-rejected"
 		| "patch-llm-unavailable"
-		| "patch-no-proposal";
+		| "patch-no-proposal"
+		| "coverage-gap-detected"
+		| "coverage-gap-skipped";
 	notes: string[];
 	prUrl?: string | null;
 }
@@ -201,6 +207,91 @@ export function extractDominantLayer(report: ExtendedDogfoodReport | null): Fail
 	const stage = report.stages.find((s) => s.stage === "quality-queries");
 	const metrics = stage?.metrics as { diagnosisAggregate?: DiagnosisAggregate } | undefined;
 	return metrics?.diagnosisAggregate?.dominantLayer ?? null;
+}
+
+/**
+ * #360 — read `fixtureHealthSignal` from a dogfood report's quality-queries
+ * stage metrics. Orthogonal to `extractDominantLayer`: a coverage gap is
+ * a corpus-level observation about MISSING gold queries, not a per-query
+ * failure. Returns `null` for older reports without the field, or for
+ * runs where no `documentCatalog` was passed to the evaluator.
+ */
+export function extractFixtureHealthSignal(
+	report: ExtendedDogfoodReport | null,
+): FixtureHealthSignal | null {
+	if (!report) return null;
+	const stage = report.stages.find((s) => s.stage === "quality-queries");
+	const metrics = stage?.metrics as { fixtureHealthSignal?: FixtureHealthSignal } | undefined;
+	return metrics?.fixtureHealthSignal ?? null;
+}
+
+export interface LoopActionDecision {
+	/** Try the LLM patch path. True when there is a per-query dominant layer. */
+	tryPatch: boolean;
+	/** Try the recipe-pipeline fixture-expand path. True when the corpus-level
+	 *  fixture-health signal flags a coverage gap. */
+	tryFixtureExpand: boolean;
+	/** Human-readable summary of the routing inputs, for the loop's notes. */
+	rationale: string;
+}
+
+/**
+ * Decide which action paths the loop should attempt this cycle. Per the
+ * settled #360 layering, `dominantLayer` and `fixtureHealthSignal` are
+ * orthogonal — a single cycle may legitimately want BOTH a code patch
+ * (for ranking regressions on existing queries) AND a fixture expansion
+ * (for un-measured strata in the catalog). Independent caps elsewhere
+ * keep either path from starving the other.
+ */
+export function decideLoopAction(input: {
+	dominantLayer: FailureLayer | null;
+	fixtureHealth: FixtureHealthSignal | null;
+}): LoopActionDecision {
+	const tryPatch = input.dominantLayer !== null;
+	const tryFixtureExpand = input.fixtureHealth?.hasCoverageGap === true;
+	const parts: string[] = [];
+	parts.push(`dominantLayer=${input.dominantLayer ?? "none"}`);
+	if (input.fixtureHealth) {
+		parts.push(
+			`coverage(uncovered=${input.fixtureHealth.coverage.uncoveredStrata.length}, gini=${input.fixtureHealth.coverage.giniCoefficient.toFixed(2)}, gap=${input.fixtureHealth.hasCoverageGap})`,
+		);
+	} else {
+		parts.push("coverage=null (no documentCatalog)");
+	}
+	parts.push(`tryPatch=${tryPatch} tryFixtureExpand=${tryFixtureExpand}`);
+	return { tryPatch, tryFixtureExpand, rationale: parts.join(" ") };
+}
+
+/**
+ * Stub for the recipe-pipeline fixture-expand path. Logs the proposed
+ * action against under-represented strata so a human running with
+ * `--dry-run` can verify the routing. The actual recipe-author →
+ * recipe-validate → recipe-apply call lands in the next slice (1e),
+ * gated on `WTFOC_ALLOW_FIXTURE_EXPAND=1` for production use.
+ */
+async function runFixtureExpandPath(input: {
+	cli: CliArgs;
+	fixtureHealth: FixtureHealthSignal;
+	notes: string[];
+}): Promise<LoopOutcome> {
+	const { cli, fixtureHealth, notes } = input;
+	const top = fixtureHealth.coverage.uncoveredStrata.slice(0, 5).map(
+		(u) => `${u.key.sourceType}/${u.key.queryType} (artifacts=${u.artifactsInCorpus})`,
+	);
+	notes.push(
+		`fixture-expand path: collection=${fixtureHealth.collectionId} uncovered=${fixtureHealth.coverage.uncoveredStrata.length} gini=${fixtureHealth.coverage.giniCoefficient.toFixed(2)}`,
+	);
+	if (top.length > 0) {
+		notes.push(`fixture-expand top strata: ${top.join("; ")}`);
+	}
+	if (cli.dryRun || process.env.WTFOC_ALLOW_FIXTURE_EXPAND !== "1") {
+		notes.push(
+			"fixture-expand: stub (no recipe-pipeline call yet; gate WTFOC_ALLOW_FIXTURE_EXPAND=1 + remove --dry-run to enable in 1e)",
+		);
+		return { status: "coverage-gap-detected", notes };
+	}
+	notes.push("fixture-expand: WTFOC_ALLOW_FIXTURE_EXPAND=1 honored but slice 1e not yet wired");
+	return { status: "coverage-gap-skipped", notes };
 }
 
 async function runPatchPath(input: {
@@ -349,6 +440,38 @@ async function runLoop(cli: CliArgs): Promise<LoopOutcome> {
 				...(baselineReport ? { baseline: baselineReport } : {}),
 			})
 		: `# Finding\n${finding.reason}\n`;
+
+	// #360 — corpus-level fixture-health signal alongside per-failure
+	// dominantLayer. Both feed `decideLoopAction`, which routes between
+	// patch and fixture-expand under independent caps. When neither path
+	// applies, the loop falls through to the existing variant flow below.
+	const fixtureHealth = extractFixtureHealthSignal(latestReport);
+	const dominantLayerForRouting = extractDominantLayer(latestReport);
+	const decision = decideLoopAction({
+		dominantLayer: dominantLayerForRouting,
+		fixtureHealth,
+	});
+	notes.push(`route: ${decision.rationale}`);
+
+	// #360 — fixture-expand path is a NON-patch action. Gated separately
+	// from `WTFOC_ALLOW_PATCHES`. When dominant, we hand the cycle off
+	// here (the loop returns); when only-flagged-not-dominant we continue
+	// to the existing patch/variant flow so a single coverage gap doesn't
+	// monopolize cycles. Treat "dominant" as "patch path also wants in"
+	// → tryFixtureExpand only AND not tryPatch.
+	if (
+		decision.tryFixtureExpand &&
+		!decision.tryPatch &&
+		(cli.dryRun || process.env.WTFOC_ALLOW_FIXTURE_EXPAND === "1") &&
+		fixtureHealth
+	) {
+		return runFixtureExpandPath({ cli, fixtureHealth, notes });
+	}
+	if (decision.tryFixtureExpand && fixtureHealth) {
+		notes.push(
+			"fixture-expand opportunity detected; deferring to patch path this cycle (set WTFOC_ALLOW_FIXTURE_EXPAND=1 + no dominantLayer to route here)",
+		);
+	}
 
 	const triedRows = readTriedLog();
 


### PR DESCRIPTION
## Summary

Fourth slice of #360 — milestone 1d. Threads the corpus-level `FixtureHealthSignal` (#367) into the autonomous-loop's per-cycle routing decision so the loop can recognize coverage gaps as a separate signal from per-failure `dominantLayer` (per the settled-spec orthogonality from #360).

## Changes

- `extractFixtureHealthSignal(report)` — parallel to the existing `extractDominantLayer`. Reads `quality-queries.metrics.fixtureHealthSignal`.
- `decideLoopAction({ dominantLayer, fixtureHealth })` — returns `{ tryPatch, tryFixtureExpand, rationale }`. The two booleans are **independent**: a single cycle can legitimately want both a code patch (for ranking regressions on existing queries) AND a fixture expansion (for un-measured strata).
- `runFixtureExpandPath` (stub) — logs the proposed action against the top under-represented strata. The actual recipe-author → recipe-validate → recipe-apply call lands in the next slice (1e), gated on `WTFOC_ALLOW_FIXTURE_EXPAND=1`.
- `runLoop` invokes both extractors after `explainFinding`, surfaces the routing rationale via notes, and routes to the fixture-expand stub when the gap is dominant (no concurrent `dominantLayer`) AND either `--dry-run` or the env gate is set. Otherwise the existing patch / variant flow runs unchanged.

## New LoopOutcome statuses

- `coverage-gap-detected` — stub-mode return.
- `coverage-gap-skipped` — gate honored, slice 1e not yet wired.

## Tests

Eight new tests in `autonomous-loop-wiring.test.ts`:
- Three `extractFixtureHealthSignal` cases (null report, missing field, populated metric).
- Five `decideLoopAction` matrix cells (patch only, expand only, both, neither, rationale shape).

## Backwards compat

No behavior change for callers without a `documentCatalog` on disk — `fixtureHealth` stays null and the loop runs exactly as before.

## Test plan
- [x] `pnpm test` passes (1811 tests, 0 failures)
- [x] `pnpm -r build` passes
- [x] `pnpm lint:fix` clean

## Next slices
- 1e: programmatic recipe-pipeline call (author → validate → apply) wired into `runFixtureExpandPath`, replacing the stub.
- 1f: draft-PR opener for fixture additions (parallel to existing `promoteViaPr`).