### PR TITLE
feat(autoresearch): programmatic recipe-pipeline + loop wiring (refs #360)

### DIFF
--- a/scripts/autoresearch/autonomous-loop.ts
+++ b/scripts/autoresearch/autonomous-loop.ts
@@ -76,7 +76,10 @@ interface LoopOutcome {
 		| "patch-llm-unavailable"
 		| "patch-no-proposal"
 		| "coverage-gap-detected"
-		| "coverage-gap-skipped";
+		| "coverage-gap-skipped"
+		| "coverage-gap-deferred"
+		| "coverage-gap-author-unavailable"
+		| "coverage-gap-error";
 	notes: string[];
 	prUrl?: string | null;
 }
@@ -280,6 +283,22 @@ export function decideLoopAction(input: {
  *     `runLoop` before calling).
  *   - `WTFOC_RECIPE_MAX_NEW_QUERIES_PER_RUN` (default 5) → cap.
  */
+/**
+ * Validate `WTFOC_RECIPE_MAX_NEW_QUERIES_PER_RUN`. Returns the parsed
+ * positive integer or null when unset / malformed. Falls back to the
+ * pipeline default when null.
+ *
+ * Codex peer-review flagged a `Number(env)` path that produced NaN and
+ * silently bypassed the headroom cap.
+ */
+function parseMaxNewEnv(): number | null {
+	const raw = process.env.WTFOC_RECIPE_MAX_NEW_QUERIES_PER_RUN;
+	if (!raw) return null;
+	const n = Number(raw);
+	if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) return null;
+	return n;
+}
+
 async function runFixtureExpandPath(input: {
 	cli: CliArgs;
 	fixtureHealth: FixtureHealthSignal;
@@ -296,68 +315,109 @@ async function runFixtureExpandPath(input: {
 		notes.push(`fixture-expand top strata: ${top.join("; ")}`);
 	}
 
-	// Pull the heavy deps + helpers lazily so the rest of the loop (and
-	// its unit tests) doesn't pay the import cost on cycles that never
-	// route here. `runRecipePipeline` itself is the orchestrator built in
-	// slice 1e (#360); see `recipe-pipeline.ts`.
-	const [{ runRecipePipeline, DEFAULT_MAX_NEW_QUERIES_PER_RUN }, { createStore }, search] =
-		await Promise.all([
-			import("./recipe-pipeline.js"),
-			import("@wtfoc/store"),
-			import("@wtfoc/search"),
-		]);
-	const { catalogFilePath, readCatalog } = await import("@wtfoc/ingest");
-
-	const store = createStore({ storage: "local" });
-	const head = await store.manifests.getHead(fixtureHealth.collectionId);
-	if (!head) {
-		notes.push(`fixture-expand: collection "${fixtureHealth.collectionId}" not found in store`);
-		return { status: "coverage-gap-skipped", notes };
-	}
-	const manifestDir =
-		(store.manifests as { dir?: string }).dir ?? `${process.env.HOME ?? "."}/.wtfoc/projects`;
-	const catalogPath = catalogFilePath(manifestDir, fixtureHealth.collectionId);
-	const catalog = await readCatalog(catalogPath);
-	if (!catalog) {
-		notes.push(`fixture-expand: catalog missing at ${catalogPath} — skipping`);
-		return { status: "coverage-gap-skipped", notes };
-	}
-
-	const embedderUrl = process.env.WTFOC_EMBEDDER_URL ?? "";
-	const embedderModel = process.env.WTFOC_EMBEDDER_MODEL ?? "";
-	if (!embedderUrl || !embedderModel) {
+	// Gini-only gaps with no uncovered strata: the planner has nothing to
+	// target. Skip cleanly so cron logs don't fill with empty-cycle noise.
+	// (Peer-review: this case fires when the fixture is balanced-but-skewed.
+	// Slice 1f / later: extend the planner to target underrepresented
+	// covered strata so this branch becomes actionable.)
+	if (fixtureHealth.coverage.uncoveredStrata.length === 0) {
 		notes.push(
-			"fixture-expand: WTFOC_EMBEDDER_URL / WTFOC_EMBEDDER_MODEL unset; cannot author candidates",
+			"fixture-expand: gini-only gap with no uncovered strata; planner has no actionable target",
 		);
 		return { status: "coverage-gap-skipped", notes };
 	}
-	const embedder = new search.OpenAIEmbedder({
-		apiKey: process.env.WTFOC_EMBEDDER_KEY ?? "",
-		model: embedderModel,
-		baseUrl: embedderUrl,
-	});
-	const vectorIndex = new search.InMemoryVectorIndex();
-	const mounted = await search.mountCollection(head.manifest, store.storage, vectorIndex);
 
-	const maxNew = process.env.WTFOC_RECIPE_MAX_NEW_QUERIES_PER_RUN
-		? Number(process.env.WTFOC_RECIPE_MAX_NEW_QUERIES_PER_RUN)
-		: DEFAULT_MAX_NEW_QUERIES_PER_RUN;
+	// Validate env knob BEFORE doing any I/O; fail-soft to default.
+	const maxNewEnv = parseMaxNewEnv();
+	if (process.env.WTFOC_RECIPE_MAX_NEW_QUERIES_PER_RUN && maxNewEnv === null) {
+		notes.push(
+			`fixture-expand: WTFOC_RECIPE_MAX_NEW_QUERIES_PER_RUN="${process.env.WTFOC_RECIPE_MAX_NEW_QUERIES_PER_RUN}" not a positive integer; falling back to default`,
+		);
+	}
 
-	const result = await runRecipePipeline({
-		collectionId: fixtureHealth.collectionId,
-		fixtureHealth,
-		catalog,
-		segments: mounted.segments,
-		vectorIndex,
-		embedder,
-		maxNew,
-	});
+	// Pull the heavy deps + helpers lazily so the rest of the loop (and
+	// its unit tests) doesn't pay the import cost on cycles that never
+	// route here. `runRecipePipeline` itself is the orchestrator built in
+	// slice 1e (#360); see `recipe-pipeline.ts`. Wrapped in try/catch per
+	// the loop's "no fatal exit" policy — peer-review flagged that
+	// mountCollection + readCatalog could otherwise crash the cron chain.
+	let result: Awaited<ReturnType<typeof import("./recipe-pipeline.js").runRecipePipeline>>;
+	try {
+		const [{ runRecipePipeline, DEFAULT_MAX_NEW_QUERIES_PER_RUN }, { createStore }, search] =
+			await Promise.all([
+				import("./recipe-pipeline.js"),
+				import("@wtfoc/store"),
+				import("@wtfoc/search"),
+			]);
+		const { catalogFilePath, readCatalog } = await import("@wtfoc/ingest");
+
+		const store = createStore({ storage: "local" });
+		const head = await store.manifests.getHead(fixtureHealth.collectionId);
+		if (!head) {
+			notes.push(
+				`fixture-expand: collection "${fixtureHealth.collectionId}" not found in store`,
+			);
+			return { status: "coverage-gap-skipped", notes };
+		}
+		const manifestDir =
+			(store.manifests as { dir?: string }).dir ?? `${process.env.HOME ?? "."}/.wtfoc/projects`;
+		const catalogPath = catalogFilePath(manifestDir, fixtureHealth.collectionId);
+		const catalog = await readCatalog(catalogPath);
+		if (!catalog) {
+			notes.push(`fixture-expand: catalog missing at ${catalogPath} — skipping`);
+			return { status: "coverage-gap-skipped", notes };
+		}
+
+		const embedderUrl = process.env.WTFOC_EMBEDDER_URL ?? "";
+		const embedderModel = process.env.WTFOC_EMBEDDER_MODEL ?? "";
+		if (!embedderUrl || !embedderModel) {
+			notes.push(
+				"fixture-expand: WTFOC_EMBEDDER_URL / WTFOC_EMBEDDER_MODEL unset; cannot author candidates",
+			);
+			return { status: "coverage-gap-skipped", notes };
+		}
+		const embedder = new search.OpenAIEmbedder({
+			apiKey: process.env.WTFOC_EMBEDDER_KEY ?? "",
+			model: embedderModel,
+			baseUrl: embedderUrl,
+		});
+		const vectorIndex = new search.InMemoryVectorIndex();
+		const mounted = await search.mountCollection(head.manifest, store.storage, vectorIndex);
+
+		const maxNew = maxNewEnv ?? DEFAULT_MAX_NEW_QUERIES_PER_RUN;
+		result = await runRecipePipeline({
+			collectionId: fixtureHealth.collectionId,
+			fixtureHealth,
+			catalog,
+			segments: mounted.segments,
+			vectorIndex,
+			embedder,
+			maxNew,
+		});
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		notes.push(`fixture-expand: error during pipeline setup or run: ${msg.slice(0, 200)}`);
+		return { status: "coverage-gap-error", notes };
+	}
 
 	notes.push(
 		`fixture-expand: targeted=${result.targetedStrata.length} authored=${result.authoredCount} adv-kept=${result.adversarialKept} kept=${result.kept.length} structural-errors=${result.structuralErrors.length}`,
 	);
 	if (result.authorErrors.length > 0) {
 		notes.push(`fixture-expand: ${result.authorErrors.length} author error(s)`);
+	}
+
+	// Distinguish 100%-author-failed from "no keepers" so cron can alert
+	// on transport / LLM-down separately from quiet quality cycles.
+	if (
+		result.targetedStrata.length > 0 &&
+		result.authoredCount === 0 &&
+		result.authorErrors.length > 0
+	) {
+		notes.push(
+			"fixture-expand: every author attempt failed (LLM unreachable or rejecting all prompts)",
+		);
+		return { status: "coverage-gap-author-unavailable", notes };
 	}
 
 	if (result.kept.length === 0 || !result.codegen) {
@@ -372,20 +432,28 @@ async function runFixtureExpandPath(input: {
 
 	// Slice 1e stops short of writing gold-authored-queries.ts + opening
 	// a PR — that's slice 1f. For now persist the codegen preview to an
-	// autoresearch artifact path so the maintainer can review.
-	const { writeFile, mkdir } = await import("node:fs/promises");
-	const { join } = await import("node:path");
-	const artifactDir =
-		process.env.WTFOC_AUTORESEARCH_DIR ?? `${process.env.HOME}/.wtfoc/autoresearch`;
-	const previewDir = join(artifactDir, "fixture-expand-previews");
-	await mkdir(previewDir, { recursive: true });
-	const previewPath = join(
-		previewDir,
-		`${fixtureHealth.collectionId}-${new Date().toISOString().replace(/[:.]/g, "-")}.preview.ts`,
-	);
-	const banner = `// Recipe-pipeline preview — review before splicing into\n// packages/search/src/eval/gold-authored-queries.ts.\n// Generated: ${new Date().toISOString()} collection=${fixtureHealth.collectionId}\n\nexport const RECIPE_PIPELINE_PREVIEW = ${result.codegen};\n`;
-	await writeFile(previewPath, banner, "utf-8");
-	notes.push(`fixture-expand: codegen preview written to ${previewPath} (slice 1f wires PR)`);
+	// autoresearch artifact path so the maintainer can review. Wrapped
+	// in try/catch so a permission-denied / disk-full does not crash the
+	// loop (cron's "no fatal exit" policy).
+	try {
+		const { writeFile, mkdir } = await import("node:fs/promises");
+		const { join } = await import("node:path");
+		const artifactDir =
+			process.env.WTFOC_AUTORESEARCH_DIR ?? `${process.env.HOME}/.wtfoc/autoresearch`;
+		const previewDir = join(artifactDir, "fixture-expand-previews");
+		await mkdir(previewDir, { recursive: true });
+		const previewPath = join(
+			previewDir,
+			`${fixtureHealth.collectionId}-${new Date().toISOString().replace(/[:.]/g, "-")}.preview.ts`,
+		);
+		const banner = `// Recipe-pipeline preview — review before splicing into\n// packages/search/src/eval/gold-authored-queries.ts.\n// Generated: ${new Date().toISOString()} collection=${fixtureHealth.collectionId}\n\nexport const RECIPE_PIPELINE_PREVIEW = ${result.codegen};\n`;
+		await writeFile(previewPath, banner, "utf-8");
+		notes.push(`fixture-expand: codegen preview written to ${previewPath} (slice 1f wires PR)`);
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		notes.push(`fixture-expand: failed to write codegen preview: ${msg.slice(0, 200)}`);
+		return { status: "coverage-gap-error", notes };
+	}
 	return { status: "coverage-gap-detected", notes };
 }
 
@@ -549,31 +617,40 @@ async function runLoop(cli: CliArgs): Promise<LoopOutcome> {
 	notes.push(`route: ${decision.rationale}`);
 
 	// #360 — fixture-expand path is a NON-patch action. Gated separately
-	// from `WTFOC_ALLOW_PATCHES`. The early-return below is conditional on
-	// (a) only fixture-expand wants in (no dominantLayer competing) AND
-	// (b) `--dry-run` OR `WTFOC_ALLOW_FIXTURE_EXPAND=1` is set. When the
-	// gate is closed OR a dominantLayer is also present, the loop continues
-	// to the existing variant / patch flow so a single coverage gap can't
-	// monopolize cycles.
+	// from `WTFOC_ALLOW_PATCHES`. Per the settled-spec orthogonality
+	// (independent caps), it runs ALONGSIDE the patch path, not instead
+	// of it. Codex peer-review flagged that "patch wins" deferral could
+	// indefinitely starve fixture-expansion when patch regressions are
+	// persistent.
+	//
+	// Implementation: when the gate is open and a coverage gap exists,
+	// run the fixture-expand path FIRST as a side effect (it writes a
+	// codegen preview to disk; slice 1f wires real PR creation).
+	//   - If only fixture-expand fires (no dominantLayer): return early
+	//     on its outcome — there's no patch work this cycle.
+	//   - If both fire: run fixture-expand for its side effect, append
+	//     its outcome to notes, then continue into the variant/patch
+	//     flow under independent caps.
 	const fixtureExpandGateOpen =
 		cli.dryRun || process.env.WTFOC_ALLOW_FIXTURE_EXPAND === "1";
-	if (
-		decision.tryFixtureExpand &&
-		!decision.tryPatch &&
-		fixtureExpandGateOpen &&
-		fixtureHealth
-	) {
-		return runFixtureExpandPath({ cli, fixtureHealth, notes });
-	}
 	if (decision.tryFixtureExpand && fixtureHealth) {
-		if (decision.tryPatch) {
-			notes.push(
-				"fixture-expand opportunity detected; dominantLayer also present, deferring fixture-expand and continuing to variant/patch flow",
-			);
-		} else if (!fixtureExpandGateOpen) {
+		if (!fixtureExpandGateOpen) {
 			notes.push(
 				"fixture-expand opportunity detected but gated off; continuing to variant flow (set WTFOC_ALLOW_FIXTURE_EXPAND=1 or --dry-run to route here)",
 			);
+		} else if (!decision.tryPatch) {
+			return runFixtureExpandPath({ cli, fixtureHealth, notes });
+		} else {
+			// Independent caps: run fixture-expand first, capture its
+			// outcome, then fall through to patch/variant flow.
+			const fxNotes: string[] = [];
+			const fxOutcome = await runFixtureExpandPath({
+				cli,
+				fixtureHealth,
+				notes: fxNotes,
+			});
+			notes.push(`fixture-expand (parallel): status=${fxOutcome.status}`);
+			for (const n of fxNotes) notes.push(`  ${n}`);
 		}
 	}
 

--- a/scripts/autoresearch/autonomous-loop.ts
+++ b/scripts/autoresearch/autonomous-loop.ts
@@ -266,11 +266,19 @@ export function decideLoopAction(input: {
 }
 
 /**
- * Stub for the recipe-pipeline fixture-expand path. Logs the proposed
- * action against under-represented strata so a human running with
- * `--dry-run` can verify the routing. The actual recipe-author →
- * recipe-validate → recipe-apply call lands in the next slice (1e),
- * gated on `WTFOC_ALLOW_FIXTURE_EXPAND=1` for production use.
+ * Recipe-pipeline fixture-expand path. Programmatically calls
+ * recipe-author → adversarial-filter → recipe-validate → recipe-apply
+ * against the top under-represented strata. Splicing into
+ * `gold-authored-queries.ts` and PR creation are deferred to slice 1f;
+ * this slice writes the proposed codegen to a per-cycle artifact and
+ * surfaces it via notes.
+ *
+ * Honors:
+ *   - `--dry-run` → never write anything; just report what would happen.
+ *   - `WTFOC_ALLOW_FIXTURE_EXPAND=1` → required for production runs;
+ *     when unset and not dry-run, this path is unreachable (gated by
+ *     `runLoop` before calling).
+ *   - `WTFOC_RECIPE_MAX_NEW_QUERIES_PER_RUN` (default 5) → cap.
  */
 async function runFixtureExpandPath(input: {
 	cli: CliArgs;
@@ -287,14 +295,98 @@ async function runFixtureExpandPath(input: {
 	if (top.length > 0) {
 		notes.push(`fixture-expand top strata: ${top.join("; ")}`);
 	}
-	if (cli.dryRun || process.env.WTFOC_ALLOW_FIXTURE_EXPAND !== "1") {
+
+	// Pull the heavy deps + helpers lazily so the rest of the loop (and
+	// its unit tests) doesn't pay the import cost on cycles that never
+	// route here. `runRecipePipeline` itself is the orchestrator built in
+	// slice 1e (#360); see `recipe-pipeline.ts`.
+	const [{ runRecipePipeline, DEFAULT_MAX_NEW_QUERIES_PER_RUN }, { createStore }, search] =
+		await Promise.all([
+			import("./recipe-pipeline.js"),
+			import("@wtfoc/store"),
+			import("@wtfoc/search"),
+		]);
+	const { catalogFilePath, readCatalog } = await import("@wtfoc/ingest");
+
+	const store = createStore({ storage: "local" });
+	const head = await store.manifests.getHead(fixtureHealth.collectionId);
+	if (!head) {
+		notes.push(`fixture-expand: collection "${fixtureHealth.collectionId}" not found in store`);
+		return { status: "coverage-gap-skipped", notes };
+	}
+	const manifestDir =
+		(store.manifests as { dir?: string }).dir ?? `${process.env.HOME ?? "."}/.wtfoc/projects`;
+	const catalogPath = catalogFilePath(manifestDir, fixtureHealth.collectionId);
+	const catalog = await readCatalog(catalogPath);
+	if (!catalog) {
+		notes.push(`fixture-expand: catalog missing at ${catalogPath} — skipping`);
+		return { status: "coverage-gap-skipped", notes };
+	}
+
+	const embedderUrl = process.env.WTFOC_EMBEDDER_URL ?? "";
+	const embedderModel = process.env.WTFOC_EMBEDDER_MODEL ?? "";
+	if (!embedderUrl || !embedderModel) {
 		notes.push(
-			"fixture-expand: stub (no recipe-pipeline call yet; gate WTFOC_ALLOW_FIXTURE_EXPAND=1 + remove --dry-run to enable in 1e)",
+			"fixture-expand: WTFOC_EMBEDDER_URL / WTFOC_EMBEDDER_MODEL unset; cannot author candidates",
 		);
+		return { status: "coverage-gap-skipped", notes };
+	}
+	const embedder = new search.OpenAIEmbedder({
+		apiKey: process.env.WTFOC_EMBEDDER_KEY ?? "",
+		model: embedderModel,
+		baseUrl: embedderUrl,
+	});
+	const vectorIndex = new search.InMemoryVectorIndex();
+	const mounted = await search.mountCollection(head.manifest, store.storage, vectorIndex);
+
+	const maxNew = process.env.WTFOC_RECIPE_MAX_NEW_QUERIES_PER_RUN
+		? Number(process.env.WTFOC_RECIPE_MAX_NEW_QUERIES_PER_RUN)
+		: DEFAULT_MAX_NEW_QUERIES_PER_RUN;
+
+	const result = await runRecipePipeline({
+		collectionId: fixtureHealth.collectionId,
+		fixtureHealth,
+		catalog,
+		segments: mounted.segments,
+		vectorIndex,
+		embedder,
+		maxNew,
+	});
+
+	notes.push(
+		`fixture-expand: targeted=${result.targetedStrata.length} authored=${result.authoredCount} adv-kept=${result.adversarialKept} kept=${result.kept.length} structural-errors=${result.structuralErrors.length}`,
+	);
+	if (result.authorErrors.length > 0) {
+		notes.push(`fixture-expand: ${result.authorErrors.length} author error(s)`);
+	}
+
+	if (result.kept.length === 0 || !result.codegen) {
+		notes.push("fixture-expand: no keeper candidates this cycle");
+		return { status: "coverage-gap-skipped", notes };
+	}
+
+	if (cli.dryRun) {
+		notes.push(`fixture-expand: --dry-run; would splice ${result.kept.length} new queries`);
 		return { status: "coverage-gap-detected", notes };
 	}
-	notes.push("fixture-expand: WTFOC_ALLOW_FIXTURE_EXPAND=1 honored but slice 1e not yet wired");
-	return { status: "coverage-gap-skipped", notes };
+
+	// Slice 1e stops short of writing gold-authored-queries.ts + opening
+	// a PR — that's slice 1f. For now persist the codegen preview to an
+	// autoresearch artifact path so the maintainer can review.
+	const { writeFile, mkdir } = await import("node:fs/promises");
+	const { join } = await import("node:path");
+	const artifactDir =
+		process.env.WTFOC_AUTORESEARCH_DIR ?? `${process.env.HOME}/.wtfoc/autoresearch`;
+	const previewDir = join(artifactDir, "fixture-expand-previews");
+	await mkdir(previewDir, { recursive: true });
+	const previewPath = join(
+		previewDir,
+		`${fixtureHealth.collectionId}-${new Date().toISOString().replace(/[:.]/g, "-")}.preview.ts`,
+	);
+	const banner = `// Recipe-pipeline preview — review before splicing into\n// packages/search/src/eval/gold-authored-queries.ts.\n// Generated: ${new Date().toISOString()} collection=${fixtureHealth.collectionId}\n\nexport const RECIPE_PIPELINE_PREVIEW = ${result.codegen};\n`;
+	await writeFile(previewPath, banner, "utf-8");
+	notes.push(`fixture-expand: codegen preview written to ${previewPath} (slice 1f wires PR)`);
+	return { status: "coverage-gap-detected", notes };
 }
 
 async function runPatchPath(input: {

--- a/scripts/autoresearch/recipe-pipeline.test.ts
+++ b/scripts/autoresearch/recipe-pipeline.test.ts
@@ -1,0 +1,133 @@
+import type { DocumentCatalog } from "@wtfoc/common";
+import type { FixtureHealthSignal } from "@wtfoc/search";
+import { describe, expect, it } from "vitest";
+import { planRecipeExpansion } from "./recipe-pipeline.js";
+
+function makeCatalog(
+	docs: Array<{ id: string; sourceType: string; chunkIds?: string[] }>,
+): DocumentCatalog {
+	const documents: DocumentCatalog["documents"] = {};
+	for (const d of docs) {
+		documents[d.id] = {
+			documentId: d.id,
+			currentVersionId: "v1",
+			previousVersionIds: [],
+			chunkIds: d.chunkIds ?? ["c1"],
+			supersededChunkIds: [],
+			contentFingerprints: [],
+			state: "active",
+			mutability: "mutable-state",
+			sourceType: d.sourceType,
+			updatedAt: new Date().toISOString(),
+		};
+	}
+	return { schemaVersion: 1, collectionId: "alpha", documents };
+}
+
+function makeFixtureHealth(
+	uncovered: Array<{
+		sourceType: string;
+		queryType: FixtureHealthSignal["coverage"]["uncoveredStrata"][number]["key"]["queryType"];
+		artifactsInCorpus: number;
+	}>,
+): FixtureHealthSignal {
+	return {
+		collectionId: "alpha",
+		coverage: {
+			totalQueries: 0,
+			semantic: [],
+			structural: [],
+			uncoveredStrata: uncovered.map((u) => ({
+				key: { sourceType: u.sourceType, edgeType: null, queryType: u.queryType },
+				artifactsInCorpus: u.artifactsInCorpus,
+			})),
+			giniCoefficient: 0,
+		},
+		hasCoverageGap: true,
+		thresholds: { giniFloor: 0.6, minUncoveredStrata: 3 },
+	};
+}
+
+describe("planRecipeExpansion", () => {
+	it("targets top-N uncovered strata by artifactsInCorpus desc", () => {
+		const fh = makeFixtureHealth([
+			{ sourceType: "code", queryType: "lookup", artifactsInCorpus: 100 },
+			{ sourceType: "github-issue", queryType: "trace", artifactsInCorpus: 5 },
+			{ sourceType: "doc-page", queryType: "howto", artifactsInCorpus: 50 },
+		]);
+		const catalog = makeCatalog([
+			{ id: "src/foo.ts", sourceType: "code" },
+			{ id: "owner/repo#1", sourceType: "github-issue" },
+			{ id: "docs/x.md", sourceType: "doc-page" },
+		]);
+		const { targetedStrata } = planRecipeExpansion({
+			fixtureHealth: fh,
+			catalog,
+			maxNew: 2,
+		});
+		// maxNew=2 → headroom 4; all three strata fit.
+		expect(targetedStrata).toHaveLength(3);
+		expect(targetedStrata[0]?.artifactsInCorpus).toBe(100);
+		expect(targetedStrata[1]?.artifactsInCorpus).toBe(50);
+		expect(targetedStrata[2]?.artifactsInCorpus).toBe(5);
+	});
+
+	it("caps planned pairs at maxNew * 2 (headroom for adversarial filter)", () => {
+		const uncovered = Array.from({ length: 20 }, (_, i) => ({
+			sourceType: `type-${i}`,
+			queryType: "lookup" as const,
+			artifactsInCorpus: 100 - i,
+		}));
+		const catalog = makeCatalog(
+			uncovered.map((u) => ({ id: `id-${u.sourceType}`, sourceType: u.sourceType })),
+		);
+		const fh = makeFixtureHealth(uncovered);
+		const { plannedPairs } = planRecipeExpansion({
+			fixtureHealth: fh,
+			catalog,
+			maxNew: 3,
+		});
+		expect(plannedPairs.length).toBeLessThanOrEqual(6);
+	});
+
+	it("skips strata whose sourceType has zero catalog artifacts", () => {
+		const fh = makeFixtureHealth([
+			{ sourceType: "missing", queryType: "lookup", artifactsInCorpus: 100 },
+			{ sourceType: "code", queryType: "lookup", artifactsInCorpus: 1 },
+		]);
+		const catalog = makeCatalog([{ id: "src/x.ts", sourceType: "code" }]);
+		const { targetedStrata } = planRecipeExpansion({
+			fixtureHealth: fh,
+			catalog,
+			maxNew: 5,
+		});
+		expect(targetedStrata).toHaveLength(1);
+		expect(targetedStrata[0]?.sourceType).toBe("code");
+	});
+
+	it("seed produces deterministic artifact pick within a stratum", () => {
+		const catalog = makeCatalog([
+			{ id: "a", sourceType: "code" },
+			{ id: "b", sourceType: "code" },
+			{ id: "c", sourceType: "code" },
+		]);
+		const fh = makeFixtureHealth([
+			{ sourceType: "code", queryType: "lookup", artifactsInCorpus: 3 },
+		]);
+		const a = planRecipeExpansion({ fixtureHealth: fh, catalog, maxNew: 1, seed: 42 });
+		const b = planRecipeExpansion({ fixtureHealth: fh, catalog, maxNew: 1, seed: 42 });
+		expect(a.plannedPairs[0]?.sample.artifact.artifactId).toBe(
+			b.plannedPairs[0]?.sample.artifact.artifactId,
+		);
+	});
+
+	it("emits an empty plan when uncoveredStrata is empty", () => {
+		const fh = makeFixtureHealth([]);
+		const { targetedStrata, plannedPairs } = planRecipeExpansion({
+			fixtureHealth: fh,
+			catalog: makeCatalog([{ id: "x", sourceType: "code" }]),
+		});
+		expect(targetedStrata).toEqual([]);
+		expect(plannedPairs).toEqual([]);
+	});
+});

--- a/scripts/autoresearch/recipe-pipeline.test.ts
+++ b/scripts/autoresearch/recipe-pipeline.test.ts
@@ -130,4 +130,37 @@ describe("planRecipeExpansion", () => {
 		expect(targetedStrata).toEqual([]);
 		expect(plannedPairs).toEqual([]);
 	});
+
+	it("picks a sourceType-applicable template (regression: codex peer-review)", () => {
+		// Pre-fix, github-issue/lookup paired with `lookup-by-symbol` (code-only).
+		// Post-fix, the picker selects `lookup-discussion` (issue/PR/slack).
+		const fh = makeFixtureHealth([
+			{ sourceType: "github-issue", queryType: "lookup", artifactsInCorpus: 10 },
+		]);
+		const catalog = makeCatalog([{ id: "owner/repo#42", sourceType: "github-issue" }]);
+		const { plannedPairs } = planRecipeExpansion({
+			fixtureHealth: fh,
+			catalog,
+			maxNew: 1,
+		});
+		expect(plannedPairs).toHaveLength(1);
+		expect(plannedPairs[0]?.template.id).toBe("lookup-discussion");
+	});
+
+	it("skips strata whose sourceType has no applicable template", () => {
+		// `compare-implementations` applies only to `code`. For a markdown
+		// stratum with queryType=compare, the picker returns null and the
+		// planner skips the stratum cleanly.
+		const fh = makeFixtureHealth([
+			{ sourceType: "markdown", queryType: "compare", artifactsInCorpus: 10 },
+		]);
+		const catalog = makeCatalog([{ id: "docs/x.md", sourceType: "markdown" }]);
+		const { targetedStrata, plannedPairs } = planRecipeExpansion({
+			fixtureHealth: fh,
+			catalog,
+			maxNew: 1,
+		});
+		expect(targetedStrata).toEqual([]);
+		expect(plannedPairs).toEqual([]);
+	});
 });

--- a/scripts/autoresearch/recipe-pipeline.ts
+++ b/scripts/autoresearch/recipe-pipeline.ts
@@ -1,0 +1,339 @@
+/**
+ * Programmatic recipe-pipeline orchestrator (#360 milestone 1e).
+ *
+ * Turns a `FixtureHealthSignal.uncoveredStrata` list into a concrete
+ * codegen-ready set of new gold queries by chaining the existing
+ * recipe-author + recipe-validate + recipe-apply primitives end-to-end.
+ *
+ * Designed for autonomous-loop's `runFixtureExpandPath` to call without
+ * spawning a subprocess. The CLI counterparts (`scripts/autoresearch/
+ * recipe-{author,validate,apply}.ts`) keep working unchanged for the
+ * end-user persona; this module is the maintainer-loop entry point.
+ *
+ * Pipeline:
+ *
+ *   1. Pick top-N uncovered strata by `artifactsInCorpus` desc (capped
+ *      at `2 * maxNew` for adversarial-filter headroom).
+ *   2. For each stratum: sample one catalog artifact of the matching
+ *      sourceType; pair with a `RECIPE_TEMPLATES` entry of the matching
+ *      `queryType`.
+ *   3. `authorCandidate` (live LLM) per pair.
+ *   4. `applyAdversarialFilter` against the live retriever.
+ *   5. `probeCandidate` + `classifyValidation` per surviving candidate.
+ *   6. `selectKeepers` (default policy: keeper-candidate only).
+ *   7. `validateStructural` + `codegenAuthoredQueries` for the splicer.
+ *
+ * The returned result is splice-ready when `structuralErrors.length === 0`
+ * AND `kept.length > 0`. Caller decides whether to actually write the
+ * file + open a draft PR (slice 1f).
+ *
+ * @see https://github.com/SgtPooki/wtfoc/issues/360
+ */
+
+import type { DocumentCatalog, Embedder, Segment, VectorIndex } from "@wtfoc/common";
+import {
+	applyAdversarialFilter,
+	type CandidateQuery,
+	type CatalogArtifact,
+	type FixtureHealthSignal,
+	type QueryTemplate,
+	type RecipeSample,
+	type Stratum,
+} from "@wtfoc/search";
+import { buildLiveRetriever, buildStorageToDocMap } from "./recipe-adversarial-retriever.js";
+import {
+	type ApplyEnrichedRecord,
+	codegenAuthoredQueries,
+	selectKeepers,
+	type StructuralError,
+	validateStructural,
+} from "./recipe-apply.js";
+import { authorCandidate } from "./recipe-llm-author.js";
+import { buildExcerptMap } from "./recipe-segment-loader.js";
+import { RECIPE_TEMPLATES } from "./recipe-templates.js";
+import {
+	classifyValidation,
+	probeCandidate,
+	summarizeLabels,
+	type ValidationLabel,
+	type ValidationRecord,
+} from "./recipe-validate.js";
+
+export const DEFAULT_MAX_NEW_QUERIES_PER_RUN = 5;
+const ADVERSARIAL_HEADROOM_FACTOR = 2;
+
+export interface TargetedStratum {
+	sourceType: string;
+	queryType: QueryTemplate["queryType"];
+	artifactsInCorpus: number;
+}
+
+export interface RunRecipePipelineInput {
+	collectionId: string;
+	fixtureHealth: FixtureHealthSignal;
+	catalog: DocumentCatalog;
+	segments: Segment[];
+	vectorIndex: VectorIndex;
+	embedder: Embedder;
+	/**
+	 * Cap on accepted queries per run. Defaults to
+	 * `DEFAULT_MAX_NEW_QUERIES_PER_RUN` (5); the loop reads
+	 * `WTFOC_RECIPE_MAX_NEW_QUERIES_PER_RUN` and threads it here.
+	 */
+	maxNew?: number;
+	/** Live-author LLM endpoint overrides; falls back to env in `authorCandidate`. */
+	authorOptions?: { llmUrl?: string; llmModel?: string; llmApiKey?: string };
+	/** Pre-built excerpt map; if absent, derived from `segments`. */
+	excerpts?: ReadonlyMap<string, string>;
+	/** Random seed for stable sampling within a stratum (default: clock-derived). */
+	seed?: number;
+}
+
+export interface RunRecipePipelineResult {
+	collectionId: string;
+	targetedStrata: TargetedStratum[];
+	authoredCount: number;
+	authorErrors: Array<{ template: string; artifactId: string; error: string }>;
+	adversarialKept: number;
+	adversarialDiscarded: number;
+	validationCounts: Record<ValidationLabel, number>;
+	records: ValidationRecord[];
+	kept: ApplyEnrichedRecord[];
+	structuralErrors: StructuralError[];
+	/** Splice-ready TS when `structuralErrors.length === 0 && kept.length > 0`. */
+	codegen: string | null;
+}
+
+interface ArtifactRow {
+	artifactId: string;
+	sourceType: string;
+	contentLength: number;
+}
+
+function indexArtifactsBySourceType(catalog: DocumentCatalog): Map<string, ArtifactRow[]> {
+	const out = new Map<string, ArtifactRow[]>();
+	for (const [artifactId, doc] of Object.entries(catalog.documents)) {
+		if (doc.state !== "active") continue;
+		const row: ArtifactRow = {
+			artifactId,
+			sourceType: doc.sourceType,
+			contentLength: doc.chunkIds.length * 1000,
+		};
+		const arr = out.get(doc.sourceType) ?? [];
+		arr.push(row);
+		out.set(doc.sourceType, arr);
+	}
+	return out;
+}
+
+function pickTemplateForQueryType(
+	queryType: QueryTemplate["queryType"],
+): QueryTemplate | null {
+	const exact = RECIPE_TEMPLATES.find((t) => t.queryType === queryType);
+	return exact ?? null;
+}
+
+function lengthBucketOf(length: number): Stratum["lengthBucket"] {
+	if (length < 2000) return "short";
+	if (length < 8000) return "medium";
+	return "long";
+}
+
+function buildSample(
+	artifact: ArtifactRow,
+	template: QueryTemplate,
+	rng: () => number,
+): RecipeSample {
+	void rng;
+	const stratum: Stratum = {
+		sourceType: artifact.sourceType,
+		// Author/validate paths today don't depend on edgeType for catalog
+		// authoring (templates filter by queryType). Leave null until the
+		// schema carries explicit edgeType per query.
+		edgeType: null,
+		lengthBucket: lengthBucketOf(artifact.contentLength),
+		rarity: "common",
+	};
+	void template;
+	const ca: CatalogArtifact = {
+		artifactId: artifact.artifactId,
+		sourceType: artifact.sourceType,
+		contentLength: artifact.contentLength,
+	};
+	return { stratum, artifact: ca };
+}
+
+/**
+ * Pure planner: maps `FixtureHealthSignal.uncoveredStrata` to concrete
+ * `(sample, template)` pairs with no I/O. Exported so unit tests can pin
+ * the routing without a live LLM. The orchestrator wraps this with the
+ * adversarial-filter + validate + apply chain.
+ */
+export function planRecipeExpansion(input: {
+	fixtureHealth: FixtureHealthSignal;
+	catalog: DocumentCatalog;
+	maxNew?: number;
+	seed?: number;
+}): {
+	targetedStrata: TargetedStratum[];
+	plannedPairs: Array<{ sample: RecipeSample; template: QueryTemplate }>;
+} {
+	const maxNew = input.maxNew ?? DEFAULT_MAX_NEW_QUERIES_PER_RUN;
+	const headroom = maxNew * ADVERSARIAL_HEADROOM_FACTOR;
+	const rng = seededRng(input.seed ?? 1);
+	const sortedUncovered = [...input.fixtureHealth.coverage.uncoveredStrata].sort(
+		(a, b) => b.artifactsInCorpus - a.artifactsInCorpus,
+	);
+	const artifactsBySource = indexArtifactsBySourceType(input.catalog);
+	const targetedStrata: TargetedStratum[] = [];
+	const plannedPairs: Array<{ sample: RecipeSample; template: QueryTemplate }> = [];
+	for (const u of sortedUncovered) {
+		if (plannedPairs.length >= headroom) break;
+		const template = pickTemplateForQueryType(u.key.queryType);
+		if (!template) continue;
+		const candidates = artifactsBySource.get(u.key.sourceType);
+		if (!candidates || candidates.length === 0) continue;
+		const idx = Math.floor(rng() * candidates.length) % candidates.length;
+		const artifact = candidates[idx];
+		if (!artifact) continue;
+		plannedPairs.push({ sample: buildSample(artifact, template, rng), template });
+		targetedStrata.push({
+			sourceType: u.key.sourceType,
+			queryType: u.key.queryType,
+			artifactsInCorpus: u.artifactsInCorpus,
+		});
+	}
+	return { targetedStrata, plannedPairs };
+}
+
+function seededRng(seed: number): () => number {
+	let s = seed;
+	return () => {
+		s = (s * 9301 + 49297) % 233280;
+		return s / 233280;
+	};
+}
+
+/**
+ * End-to-end programmatic recipe pipeline. See module docstring for the
+ * step-by-step. The function is `async` because each `authorCandidate`,
+ * `probeCandidate` (via `query` + `trace`), and `applyAdversarialFilter`
+ * call hits the live LLM / vector index.
+ */
+export async function runRecipePipeline(
+	input: RunRecipePipelineInput,
+): Promise<RunRecipePipelineResult> {
+	const maxNew = input.maxNew ?? DEFAULT_MAX_NEW_QUERIES_PER_RUN;
+	const validationCounts: Record<ValidationLabel, number> = {
+		"keeper-candidate": 0,
+		"trivial-suspect": 0,
+		"needs-fix": 0,
+		"human-review": 0,
+		"auto-reject": 0,
+	};
+
+	const planInput: { fixtureHealth: FixtureHealthSignal; catalog: DocumentCatalog; maxNew: number; seed?: number } = {
+		fixtureHealth: input.fixtureHealth,
+		catalog: input.catalog,
+		maxNew,
+	};
+	if (input.seed !== undefined) planInput.seed = input.seed;
+	const { targetedStrata, plannedPairs } = planRecipeExpansion(planInput);
+
+	const excerpts = input.excerpts ?? buildExcerptMap(input.segments);
+
+	// 2. Live LLM author per pair.
+	const authored: CandidateQuery[] = [];
+	const authorErrors: RunRecipePipelineResult["authorErrors"] = [];
+	for (const p of plannedPairs) {
+		const excerpt = excerpts.get(p.sample.artifact.artifactId);
+		const r = await authorCandidate(p.sample, p.template, {
+			collectionId: input.collectionId,
+			...(input.authorOptions?.llmUrl ? { llmUrl: input.authorOptions.llmUrl } : {}),
+			...(input.authorOptions?.llmModel ? { llmModel: input.authorOptions.llmModel } : {}),
+			...(input.authorOptions?.llmApiKey ? { llmApiKey: input.authorOptions.llmApiKey } : {}),
+			...(excerpt ? { excerpt } : {}),
+		});
+		if (r.ok && r.candidate) {
+			authored.push(r.candidate);
+		} else {
+			authorErrors.push({
+				template: p.template.id,
+				artifactId: p.sample.artifact.artifactId,
+				error: r.error ?? "unknown",
+			});
+		}
+	}
+
+	// 3. Adversarial filter — drop trivial cases.
+	const retrieve = buildLiveRetriever({
+		embedder: input.embedder,
+		vectorIndex: input.vectorIndex,
+		segments: input.segments,
+	});
+	const adversarial = await applyAdversarialFilter(authored, retrieve, { topK: 3 });
+
+	// 4. Probe + classify each survivor.
+	const storageToDoc = buildStorageToDocMap(input.segments);
+	const records: ValidationRecord[] = [];
+	for (const candidate of adversarial.kept) {
+		try {
+			const probe = await probeCandidate(candidate, {
+				embedder: input.embedder,
+				vectorIndex: input.vectorIndex,
+				segments: input.segments,
+				storageToDoc,
+			});
+			const { label, reasons } = classifyValidation(candidate, probe);
+			records.push({ candidate, label, reasons, probe });
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			records.push({
+				candidate,
+				label: "human-review",
+				reasons: [{ code: "retrieval-failure", detail: `probe-error: ${msg.slice(0, 120)}` }],
+				probe: {
+					goldRank: null,
+					widerK: 100,
+					requiredTypeCoverage: false,
+					traceHopCount: 0,
+					goldReachedByTrace: false,
+					topResults: [],
+				},
+			});
+		}
+	}
+	Object.assign(validationCounts, summarizeLabels(records));
+
+	// 5. selectKeepers (default policy: only keeper-candidate, no overrides).
+	const enriched: ApplyEnrichedRecord[] = records.map((r) => ({ ...r }));
+	const { keep } = selectKeepers(enriched, {
+		includeHumanReview: false,
+		includeNeedsFix: false,
+		force: false,
+	});
+	const keptCapped = keep.slice(0, maxNew);
+
+	// 6. Structural validation + codegen. The caller (autonomous-loop) decides
+	//    whether to splice into gold-authored-queries.ts or just preview.
+	const existingIds = new Set<string>();
+	const structuralErrors = validateStructural(keptCapped, existingIds);
+	const codegen =
+		structuralErrors.length === 0 && keptCapped.length > 0
+			? codegenAuthoredQueries(keptCapped)
+			: null;
+
+	return {
+		collectionId: input.collectionId,
+		targetedStrata,
+		authoredCount: authored.length,
+		authorErrors,
+		adversarialKept: adversarial.kept.length,
+		adversarialDiscarded: adversarial.discarded.length,
+		validationCounts,
+		records,
+		kept: keptCapped,
+		structuralErrors,
+		codegen,
+	};
+}

--- a/scripts/autoresearch/recipe-pipeline.ts
+++ b/scripts/autoresearch/recipe-pipeline.ts
@@ -37,10 +37,12 @@ import {
 	type CatalogArtifact,
 	type FixtureHealthSignal,
 	type QueryTemplate,
+	type QueryType,
 	type RecipeSample,
 	type Stratum,
 } from "@wtfoc/search";
 import { buildLiveRetriever, buildStorageToDocMap } from "./recipe-adversarial-retriever.js";
+import { templatesForStratum } from "./recipe-templates.js";
 import {
 	type ApplyEnrichedRecord,
 	codegenAuthoredQueries,
@@ -50,7 +52,6 @@ import {
 } from "./recipe-apply.js";
 import { authorCandidate } from "./recipe-llm-author.js";
 import { buildExcerptMap } from "./recipe-segment-loader.js";
-import { RECIPE_TEMPLATES } from "./recipe-templates.js";
 import {
 	classifyValidation,
 	probeCandidate,
@@ -126,11 +127,27 @@ function indexArtifactsBySourceType(catalog: DocumentCatalog): Map<string, Artif
 	return out;
 }
 
-function pickTemplateForQueryType(
-	queryType: QueryTemplate["queryType"],
+/**
+ * Pick a template that satisfies BOTH the uncovered stratum's `queryType`
+ * AND the synthesized stratum's `sourceType` constraints. Falls back to a
+ * sourceType-agnostic template (no `appliesToStrata`) when no source-typed
+ * template matches; returns null when even that fails so the caller can
+ * skip the stratum cleanly.
+ *
+ * Earlier (pre-peer-review) `pickTemplateForQueryType` matched on
+ * `queryType` alone, which routed `github-issue/lookup` to the
+ * code-only `lookup-by-symbol` template and fed nonsensical artifacts
+ * to the LLM. This now mirrors `templatesForStratum`'s applicability
+ * filter and adds the queryType constraint on top.
+ */
+function pickTemplateForStratum(
+	stratum: Pick<Stratum, "sourceType" | "edgeType" | "rarity">,
+	queryType: QueryType,
 ): QueryTemplate | null {
-	const exact = RECIPE_TEMPLATES.find((t) => t.queryType === queryType);
-	return exact ?? null;
+	// `templatesForStratum` already returns templates whose
+	// `appliesToStrata` matches this stratum OR is empty (universal
+	// fallback). All we need on top is the queryType filter.
+	return templatesForStratum(stratum).find((t) => t.queryType === queryType) ?? null;
 }
 
 function lengthBucketOf(length: number): Stratum["lengthBucket"] {
@@ -139,11 +156,7 @@ function lengthBucketOf(length: number): Stratum["lengthBucket"] {
 	return "long";
 }
 
-function buildSample(
-	artifact: ArtifactRow,
-	template: QueryTemplate,
-	rng: () => number,
-): RecipeSample {
+function buildSample(artifact: ArtifactRow, rng: () => number): RecipeSample {
 	void rng;
 	const stratum: Stratum = {
 		sourceType: artifact.sourceType,
@@ -152,9 +165,15 @@ function buildSample(
 		// schema carries explicit edgeType per query.
 		edgeType: null,
 		lengthBucket: lengthBucketOf(artifact.contentLength),
+		// TODO(#360 follow-up): rarity is hardcoded "common" here; the
+		// proper computation runs `stratifyArtifacts` over the full
+		// catalog to derive (sourceType, edgeType) frequency. Hardcoding
+		// `common` means rarity-gated templates (e.g. `lookup-rare-edge`)
+		// are unreachable from this path. Acceptable for slice 1e where
+		// no rarity-gated template covers a queryType the planner targets;
+		// fix before broadening template coverage.
 		rarity: "common",
 	};
-	void template;
 	const ca: CatalogArtifact = {
 		artifactId: artifact.artifactId,
 		sourceType: artifact.sourceType,
@@ -189,14 +208,19 @@ export function planRecipeExpansion(input: {
 	const plannedPairs: Array<{ sample: RecipeSample; template: QueryTemplate }> = [];
 	for (const u of sortedUncovered) {
 		if (plannedPairs.length >= headroom) break;
-		const template = pickTemplateForQueryType(u.key.queryType);
-		if (!template) continue;
 		const candidates = artifactsBySource.get(u.key.sourceType);
 		if (!candidates || candidates.length === 0) continue;
 		const idx = Math.floor(rng() * candidates.length) % candidates.length;
 		const artifact = candidates[idx];
 		if (!artifact) continue;
-		plannedPairs.push({ sample: buildSample(artifact, template, rng), template });
+		// Build the stratum FIRST so the template picker can filter on
+		// sourceType applicability. Earlier the picker matched only on
+		// queryType, which produced nonsensical (sample, template) pairs
+		// for sourceTypes that no template targets.
+		const sample = buildSample(artifact, rng);
+		const template = pickTemplateForStratum(sample.stratum, u.key.queryType);
+		if (!template) continue;
+		plannedPairs.push({ sample, template });
 		targetedStrata.push({
 			sourceType: u.key.sourceType,
 			queryType: u.key.queryType,


### PR DESCRIPTION
## Summary

Fifth slice of #360 — milestone 1e. Replaces the autonomous-loop's fixture-expand stub from #369 with an end-to-end recipe pipeline call.

## Changes

### New module `scripts/autoresearch/recipe-pipeline.ts`

- `planRecipeExpansion({ fixtureHealth, catalog, maxNew, seed })` — pure planner. Maps `uncoveredStrata` → `(sample, template)` pairs sorted by `artifactsInCorpus` desc, capped at `maxNew * 2` for adversarial-filter headroom. Skips strata whose sourceType has no catalog artifacts. Seed-stable.
- `runRecipePipeline(...)` — end-to-end orchestrator. Authors candidates (live LLM via `authorCandidate`), runs `applyAdversarialFilter`, probes + classifies via `probeCandidate` + `classifyValidation`, selects keepers (default policy), structurally validates, and emits a splice-ready codegen string when no errors.
- Constants: `DEFAULT_MAX_NEW_QUERIES_PER_RUN = 5` (matches the spec's `WTFOC_RECIPE_MAX_NEW_QUERIES_PER_RUN` env knob).

### `runFixtureExpandPath` wiring

- Lazy imports of store + catalog + embedder + vector index (no cost on cycles that don't route here).
- Reads `WTFOC_EMBEDDER_URL` / `WTFOC_EMBEDDER_MODEL` / `WTFOC_EMBEDDER_KEY` from env; returns `coverage-gap-skipped` when unset.
- Reads `WTFOC_RECIPE_MAX_NEW_QUERIES_PER_RUN`.
- On success: persists codegen preview to `~/.wtfoc/autoresearch/fixture-expand-previews/<id>-<ts>.preview.ts` for the maintainer to review.
- `--dry-run` short-circuits before preview write; planning + author + validate still runs.

### Deferred to slice 1f

- Splicing into `gold-authored-queries.ts`.
- Draft-PR opener (parallel to `promoteViaPr`).

## Tests

5 cases on `planRecipeExpansion`:
- target-strata ordering by `artifactsInCorpus` desc
- headroom cap at `maxNew * 2`
- missing-source-type skip
- seed determinism
- empty-uncovered short-circuit

The live LLM + vector-index path is exercised end-to-end on the maintainer's homelab smoke test (closes the milestone-3 demonstration in slice 1f).

## Test plan
- [x] `pnpm test` passes (1818 tests, 0 failures)
- [x] `pnpm -r build` passes
- [x] `pnpm lint:fix` clean