### PR TITLE
feat(autoresearch): promote-fixture-via-pr — splice + draft PR (refs #360)

### DIFF
--- a/scripts/autoresearch/autonomous-loop.ts
+++ b/scripts/autoresearch/autonomous-loop.ts
@@ -425,33 +425,43 @@ async function runFixtureExpandPath(input: {
 		return { status: "coverage-gap-skipped", notes };
 	}
 
+	const proposalId = `${fixtureHealth.collectionId}-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+
 	if (cli.dryRun) {
 		notes.push(`fixture-expand: --dry-run; would splice ${result.kept.length} new queries`);
 		return { status: "coverage-gap-detected", notes };
 	}
-
-	// Slice 1e stops short of writing gold-authored-queries.ts + opening
-	// a PR — that's slice 1f. For now persist the codegen preview to an
-	// autoresearch artifact path so the maintainer can review. Wrapped
-	// in try/catch so a permission-denied / disk-full does not crash the
-	// loop (cron's "no fatal exit" policy).
-	try {
-		const { writeFile, mkdir } = await import("node:fs/promises");
-		const { join } = await import("node:path");
-		const artifactDir =
-			process.env.WTFOC_AUTORESEARCH_DIR ?? `${process.env.HOME}/.wtfoc/autoresearch`;
-		const previewDir = join(artifactDir, "fixture-expand-previews");
-		await mkdir(previewDir, { recursive: true });
-		const previewPath = join(
-			previewDir,
-			`${fixtureHealth.collectionId}-${new Date().toISOString().replace(/[:.]/g, "-")}.preview.ts`,
+	if (cli.skipPr) {
+		notes.push(
+			`fixture-expand: --skip-pr; ${result.kept.length} keepers ready but PR creation skipped`,
 		);
-		const banner = `// Recipe-pipeline preview — review before splicing into\n// packages/search/src/eval/gold-authored-queries.ts.\n// Generated: ${new Date().toISOString()} collection=${fixtureHealth.collectionId}\n\nexport const RECIPE_PIPELINE_PREVIEW = ${result.codegen};\n`;
-		await writeFile(previewPath, banner, "utf-8");
-		notes.push(`fixture-expand: codegen preview written to ${previewPath} (slice 1f wires PR)`);
+		return { status: "coverage-gap-detected", notes };
+	}
+
+	// #360 milestone 1f — splice into gold-authored-queries.ts and open a
+	// draft PR via `promoteFixtureViaPr`. Mirrors the patch path's
+	// `promoteViaPr` shape (clean working tree guardrail, branch encodes
+	// proposal id, never silent auto-merge). Wrapped in try/catch so a
+	// transient git/gh failure doesn't crash the cron chain.
+	try {
+		const { promoteFixtureViaPr } = await import("./promote-fixture-via-pr.js");
+		const promote = await promoteFixtureViaPr({
+			proposalId,
+			collectionId: fixtureHealth.collectionId,
+			codegen: result.codegen,
+			keptCount: result.kept.length,
+			targetedStrata: result.targetedStrata,
+		});
+		if (promote.skippedReason) {
+			notes.push(`fixture-expand: PR skipped: ${promote.skippedReason}`);
+			return { status: "coverage-gap-skipped", notes };
+		}
+		notes.push(
+			`fixture-expand: draft PR created${promote.prUrl ? ` at ${promote.prUrl}` : ` on branch ${promote.branch}`}`,
+		);
 	} catch (err) {
 		const msg = err instanceof Error ? err.message : String(err);
-		notes.push(`fixture-expand: failed to write codegen preview: ${msg.slice(0, 200)}`);
+		notes.push(`fixture-expand: PR creation failed: ${msg.slice(0, 200)}`);
 		return { status: "coverage-gap-error", notes };
 	}
 	return { status: "coverage-gap-detected", notes };

--- a/scripts/autoresearch/promote-fixture-via-pr.test.ts
+++ b/scripts/autoresearch/promote-fixture-via-pr.test.ts
@@ -1,0 +1,100 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { promoteFixtureViaPr } from "./promote-fixture-via-pr.js";
+
+const FIXTURE_BASELINE = `// gold-authored-queries.ts (test fixture)
+import type { GoldQuery } from "./gold-standard-queries.js";
+
+// === BEGIN AUTHORED-QUERIES MANAGED ARRAY ===
+export const AUTHORED_QUERIES: GoldQuery[] = [];
+// === END AUTHORED-QUERIES MANAGED ARRAY ===
+`;
+
+const CODEGEN_SAMPLE = `[
+\t{
+\t\t"id": "test-q1",
+\t\t"query": "x"
+\t}
+]`;
+
+function setupRepo(fixture: string = FIXTURE_BASELINE): string {
+	const repo = mkdtempSync(join(tmpdir(), "wtfoc-promote-fixture-"));
+	const dir = join(repo, "packages", "search", "src", "eval");
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, "gold-authored-queries.ts"), fixture);
+	return repo;
+}
+
+describe("promoteFixtureViaPr — dry-run", () => {
+	it("returns dry-run result without touching disk", async () => {
+		const repo = setupRepo();
+		const result = await promoteFixtureViaPr({
+			proposalId: "p1",
+			collectionId: "alpha",
+			codegen: CODEGEN_SAMPLE,
+			keptCount: 1,
+			targetedStrata: [
+				{ sourceType: "code", queryType: "lookup", artifactsInCorpus: 10 },
+			],
+			dryRun: true,
+			repoRoot: repo,
+		});
+		expect(result.dryRun).toBe(true);
+		expect(result.prUrl).toBeNull();
+		expect(result.branch).toBe("autoresearch/fixture-p1");
+		// Source file untouched in dry-run.
+		const after = readFileSync(
+			join(repo, "packages", "search", "src", "eval", "gold-authored-queries.ts"),
+			"utf-8",
+		);
+		expect(after).toBe(FIXTURE_BASELINE);
+	});
+
+	it("skips with reason when fixture file missing", async () => {
+		const repo = mkdtempSync(join(tmpdir(), "wtfoc-promote-fixture-"));
+		const result = await promoteFixtureViaPr({
+			proposalId: "p2",
+			collectionId: "alpha",
+			codegen: CODEGEN_SAMPLE,
+			keptCount: 1,
+			targetedStrata: [],
+			repoRoot: repo,
+		});
+		expect(result.skippedReason).toMatch(/not found/);
+		expect(result.prUrl).toBeNull();
+	});
+
+	it("skips with reason when markers missing in fixture file", async () => {
+		const repo = setupRepo("// empty file, no markers\n");
+		const result = await promoteFixtureViaPr({
+			proposalId: "p3",
+			collectionId: "alpha",
+			codegen: CODEGEN_SAMPLE,
+			keptCount: 1,
+			targetedStrata: [],
+			dryRun: true,
+			repoRoot: repo,
+		});
+		expect(result.skippedReason).toMatch(/splice failed/i);
+	});
+
+	it("returns dry-run with non-null branch when splice produces a diff", async () => {
+		const repo = setupRepo();
+		const result = await promoteFixtureViaPr({
+			proposalId: "p4",
+			collectionId: "alpha",
+			codegen: CODEGEN_SAMPLE,
+			keptCount: 2,
+			targetedStrata: [
+				{ sourceType: "code", queryType: "lookup", artifactsInCorpus: 5 },
+				{ sourceType: "github-issue", queryType: "trace", artifactsInCorpus: 3 },
+			],
+			dryRun: true,
+			repoRoot: repo,
+		});
+		expect(result.skippedReason).toBeUndefined();
+		expect(result.branch).toBe("autoresearch/fixture-p4");
+	});
+});

--- a/scripts/autoresearch/promote-fixture-via-pr.ts
+++ b/scripts/autoresearch/promote-fixture-via-pr.ts
@@ -1,0 +1,222 @@
+/**
+ * Fixture-expand PR promotion (#360 milestone 1f). Maintainer-only.
+ *
+ * Given a recipe-pipeline `codegen` blob from `runRecipePipeline`, splice
+ * it into `packages/search/src/eval/gold-authored-queries.ts` between the
+ * managed-array markers, commit on a fresh branch, and `gh pr create
+ * --draft`. Maintainer reviews + merges manually; never silent
+ * auto-merge.
+ *
+ * Hard guardrails (mirrors `promote-via-pr.ts`):
+ *
+ *   - Only `gold-authored-queries.ts` may be touched. Anything else in
+ *     the working tree fails-closed before commit.
+ *   - The branch name encodes the proposal id so concurrent runs cannot
+ *     collide.
+ *   - The splice goes through `spliceAuthoredQueries` (existing
+ *     marker-aware helper from #361). If markers are missing, fail-soft
+ *     with a `skippedReason` rather than corrupting the file.
+ *
+ * @see https://github.com/SgtPooki/wtfoc/issues/360
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { safeExecFileSync as execFileSync } from "../lib/safe-exec.js";
+import { spliceAuthoredQueries } from "./recipe-apply.js";
+
+export interface PromoteFixtureInputs {
+	/** Stable id for the cycle, used in branch + commit subject. */
+	proposalId: string;
+	/** Source collection that drove this fixture-expand cycle. */
+	collectionId: string;
+	/** Codegen blob from `runRecipePipeline`. Splice-ready TS array literal. */
+	codegen: string;
+	/** Number of new gold queries the codegen carries; for the PR body. */
+	keptCount: number;
+	/** Top targeted strata for the PR body. */
+	targetedStrata: ReadonlyArray<{
+		sourceType: string;
+		queryType: string;
+		artifactsInCorpus: number;
+	}>;
+	dryRun?: boolean;
+	/** Path to the wtfoc repo root. Defaults to walking up from this file. */
+	repoRoot?: string;
+	spawnFn?: (cmd: string, args: string[], opts?: { cwd?: string }) => Buffer | string;
+}
+
+export interface PromoteFixtureResult {
+	prUrl: string | null;
+	branch: string;
+	fixtureFilePath: string;
+	dryRun: boolean;
+	skippedReason?: string;
+}
+
+const HERE = (() => {
+	try {
+		return dirname(fileURLToPath(import.meta.url));
+	} catch {
+		return process.cwd();
+	}
+})();
+
+function defaultRepoRoot(): string {
+	// scripts/autoresearch/promote-fixture-via-pr.ts → repo root is two
+	// levels up.
+	return resolve(HERE, "..", "..");
+}
+
+const FIXTURE_REL_PATH = join(
+	"packages",
+	"search",
+	"src",
+	"eval",
+	"gold-authored-queries.ts",
+);
+
+function git(
+	args: string[],
+	opts: { cwd: string },
+	spawnFn: PromoteFixtureInputs["spawnFn"],
+): string {
+	const fn = spawnFn ?? execFileSync;
+	const out = fn("git", args, { cwd: opts.cwd });
+	return typeof out === "string" ? out : out.toString("utf-8");
+}
+
+export async function promoteFixtureViaPr(
+	input: PromoteFixtureInputs,
+): Promise<PromoteFixtureResult> {
+	const repoRoot = input.repoRoot ?? defaultRepoRoot();
+	const filePath = join(repoRoot, FIXTURE_REL_PATH);
+	if (!existsSync(filePath)) {
+		return {
+			prUrl: null,
+			branch: "",
+			fixtureFilePath: filePath,
+			dryRun: input.dryRun ?? false,
+			skippedReason: `gold-authored-queries.ts not found at ${filePath}`,
+		};
+	}
+
+	const original = readFileSync(filePath, "utf-8");
+	let newSource: string;
+	try {
+		newSource = spliceAuthoredQueries(original, input.codegen);
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		return {
+			prUrl: null,
+			branch: "",
+			fixtureFilePath: filePath,
+			dryRun: input.dryRun ?? false,
+			skippedReason: `splice failed: ${msg.slice(0, 200)}`,
+		};
+	}
+	if (newSource === original) {
+		return {
+			prUrl: null,
+			branch: "",
+			fixtureFilePath: filePath,
+			dryRun: input.dryRun ?? false,
+			skippedReason: "splice produced no diff (codegen already in file?)",
+		};
+	}
+
+	const branch = `autoresearch/fixture-${input.proposalId}`;
+
+	if (input.dryRun) {
+		return {
+			prUrl: null,
+			branch,
+			fixtureFilePath: filePath,
+			dryRun: true,
+		};
+	}
+
+	// Hard guardrail: working tree must be clean OR have only the
+	// fixture file modified — never sweep up unrelated work.
+	const status = git(
+		["status", "--porcelain", "--", FIXTURE_REL_PATH, "."],
+		{ cwd: repoRoot },
+		input.spawnFn,
+	);
+	const dirtyLines = status
+		.split("\n")
+		.map((l) => l.trim())
+		.filter((l) => l.length > 0);
+	const allowed = (l: string) => l.endsWith(FIXTURE_REL_PATH);
+	const stray = dirtyLines.filter((l) => !allowed(l));
+	if (stray.length > 0) {
+		return {
+			prUrl: null,
+			branch,
+			fixtureFilePath: filePath,
+			dryRun: false,
+			skippedReason: `working tree has unrelated changes — refusing to commit: ${stray.join("; ")}`,
+		};
+	}
+
+	git(["checkout", "-b", branch], { cwd: repoRoot }, input.spawnFn);
+	writeFileSync(filePath, newSource);
+	git(["add", "--", FIXTURE_REL_PATH], { cwd: repoRoot }, input.spawnFn);
+
+	const subject = `feat(autoresearch): expand gold fixture +${input.keptCount} (proposal ${input.proposalId})`;
+	const stratumList = input.targetedStrata
+		.slice(0, 5)
+		.map((s) => `- \`${s.sourceType}/${s.queryType}\` (artifacts=${s.artifactsInCorpus})`)
+		.join("\n");
+	const body = [
+		"Autoresearch loop expanded the gold-query fixture against under-represented strata in the corpus catalog. Maintainer review required before merge.",
+		"",
+		`Source collection: \`${input.collectionId}\``,
+		`Kept candidates: ${input.keptCount}`,
+		"",
+		"## Targeted strata",
+		"",
+		stratumList || "(none)",
+		"",
+		"## Review checklist",
+		"",
+		"- [ ] Each new query is well-formed (no fabricated concepts).",
+		"- [ ] Each `expectedEvidence.artifactId` exists in the corpus catalog.",
+		"- [ ] Required source types match what the query intent implies.",
+		"- [ ] No accidental duplicates of existing `GOLD_STANDARD_QUERIES` ids.",
+		"",
+		"_Generated by `scripts/autoresearch/recipe-pipeline.ts` → `promote-fixture-via-pr.ts`. See #360._",
+	].join("\n");
+	git(["commit", "-m", subject, "-m", body], { cwd: repoRoot }, input.spawnFn);
+
+	const fn = input.spawnFn ?? execFileSync;
+	fn("git", ["push", "-u", "origin", branch], { cwd: repoRoot });
+
+	const prOut = fn(
+		"gh",
+		[
+			"pr",
+			"create",
+			"--draft",
+			"--title",
+			subject,
+			"--body",
+			body,
+			"--label",
+			"enhancement",
+			"--head",
+			branch,
+		],
+		{ cwd: repoRoot },
+	);
+	const prText = typeof prOut === "string" ? prOut : prOut.toString("utf-8");
+	const prUrl = prText.split("\n").find((l) => l.startsWith("https://")) ?? null;
+
+	return {
+		prUrl,
+		branch,
+		fixtureFilePath: filePath,
+		dryRun: false,
+	};
+}

--- a/scripts/autoresearch/promote-fixture-via-pr.ts
+++ b/scripts/autoresearch/promote-fixture-via-pr.ts
@@ -21,7 +21,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { safeExecFileSync as execFileSync } from "../lib/safe-exec.js";
 import { spliceAuthoredQueries } from "./recipe-apply.js";


### PR DESCRIPTION
## Summary

Sixth and final slice of milestone 1 on #360. Closes the fixture-expand loop end-to-end.

Replaces the codegen-preview-to-disk path from #370 with:
1. Real splice into `packages/search/src/eval/gold-authored-queries.ts` via `spliceAuthoredQueries` (#361 helper).
2. Fresh branch + commit + draft GitHub PR via a new `promote-fixture-via-pr.ts` module that mirrors the patch path's `promote-via-pr.ts` shape exactly.

## Changes

### New module `scripts/autoresearch/promote-fixture-via-pr.ts`

- Mirrors `promote-via-pr.ts` shape: fresh branch (`autoresearch/fixture-<proposalId>`), write file, commit, push, `gh pr create --draft`. Never silent auto-merge.
- **Hard guardrails**: working tree must have only the fixture file modified — any unrelated diff fails-closed before commit. Splice goes through `spliceAuthoredQueries` so missing markers fail-soft with `skippedReason` rather than corrupting the file.
- PR body lists targeted strata + a review checklist (well-formed query, artifactId in catalog, no duplicate ids, source-type match).

### `runFixtureExpandPath` wiring

- `--dry-run` short-circuits before any git/gh interaction.
- `--skip-pr` honored (parallel to existing patch path).
- Real call wrapped in try/catch; transient git/gh failures map to `coverage-gap-error` (no fatal exit).
- Disk-preview fallback removed; that was scaffolding, not a long-term path.

## Tests

4 cases on `promoteFixtureViaPr`:
- dry-run leaves source untouched + reports correct branch name
- missing fixture file → `skippedReason`
- missing markers → splice failure surfaces as `skippedReason`
- normal dry-run with diff produces non-null branch + no skip

Live git/gh interactions out-of-scope for unit tests; exercised on the maintainer's homelab smoke test.

## Milestone-1 status (after this merges)

- 1a: types + builder ✓
- 1b: evaluator emits ✓
- 1c: dogfood threads catalog ✓
- 1d: loop reads + routes ✓
- 1e: programmatic recipe pipeline ✓
- 1f: splice + draft PR opener (this PR) ✓

## Cron-readiness checklist (per peer-review)

After this lands:
- [x] Routing orthogonal (patch + fixture-expand under independent caps)
- [x] Source-type-aware template selection
- [x] `WTFOC_RECIPE_MAX_NEW_QUERIES_PER_RUN` validation
- [x] Exception safety (no fatal exit on transient I/O)
- [x] Distinct status for LLM-down (`coverage-gap-author-unavailable`)
- [x] Real PR creation (was disk preview)
- [ ] **Live homelab smoke**: end-to-end demonstration on real corpus (milestone 3 work)
- [ ] Hardcoded `rarity: "common"` in synthesized strata (deferred)
- [ ] Adversarial-headroom factor configurable (deferred)

## Test plan
- [x] `pnpm test` passes (1824 tests, 0 failures)
- [x] `pnpm -r build` passes
- [x] `pnpm lint:fix` clean