### PR TITLE
fix(autoresearch): retrieval-baseline matrix env-driven (no hardcoded endpoints)

### DIFF
--- a/docs/autoresearch/autonomous-loop-runbook.md
+++ b/docs/autoresearch/autonomous-loop-runbook.md
@@ -51,7 +51,7 @@ launchd LaunchAgent (com.wtfoc.autoresearch.nightly) at 03:00 local
 ## Hard constraints (preserve forever)
 
 1. **No paid AI in recurring path.** Local LLM only (`WTFOC_ANALYSIS_LLM_URL`).
-2. **No homelab2 URLs in committed source.** All endpoints from env vars.
+2. **No private-infrastructure URLs in committed source.** All endpoints from env vars.
 3. **No silent merge.** Every accepted variant ships as a `--draft` PR. Maintainer reviews.
 4. **Collection bytes never enter commits.** Reports / runs.jsonl / tried.jsonl / proposal worktrees live under `~/.wtfoc/autoresearch/`.
 5. **Code-patch proposals restricted to allowlist** (`packages/search/src/` default, `DEFAULT_MAX_DIFF_LINES=200`). See `patch-proposal.ts`.
@@ -165,7 +165,7 @@ If you (the agent) are picking this up cold:
 
 1. Read this runbook (you are here).
 2. Read [`project_mission_and_value`](../../) (auto-memory).
-3. Read [`feedback_wtfoc_runtime_independence`](../../) (auto-memory) — collection privacy + no-homelab2 rule.
+3. Read [`feedback_wtfoc_runtime_independence`](../../) (auto-memory) — collection privacy + no-private-URLs rule.
 4. Check current state: `cat ~/.wtfoc/autoresearch/nightly-status.json`, `wc -l ~/.wtfoc/autoresearch/runs.jsonl`, `wc -l ~/.wtfoc/autoresearch/tried.jsonl`.
 5. Check open PRs: `gh pr list --search "head:autoresearch/"`. Each one is a candidate variant awaiting maintainer review.
 6. Check open autoresearch issues: `gh issue list --label autoresearch --state open`.

--- a/docs/autoresearch/designs/2026-04-30-phase-4-cron-design.md
+++ b/docs/autoresearch/designs/2026-04-30-phase-4-cron-design.md
@@ -16,7 +16,7 @@ Run the existing `pnpm autoresearch:sweep retrieval-baseline` harness on a night
   - Local LLM endpoints (extractor: `http://127.0.0.1:4523/v1` haiku via Claude direct proxy).
   - OpenRouter for embedder (`baai/bge-base-en-v1.5` is $0).
 - **No paid AI API keys in the recurring path.** Maintainer-only on-demand verification using paid models is acceptable; nightly is not.
-- **No homelab2 runtime artifacts.** No homelab2 image registries, no homelab2 URLs in committed source, no parsing of homelab2 output. All endpoints from env vars. (`feedback_wtfoc_runtime_independence.md`.)
+- **No private-infrastructure runtime artifacts.** No private image registries, no private URLs in committed source, no parsing of private-cluster output. All endpoints from env vars. (`feedback_wtfoc_runtime_independence.md`.)
 - **Don't false-positive on outages.** BGE down / local LLM down / OpenRouter rate-limited must NOT be reported as a quality regression.
 - **Pre-v1.** Breaking changes to `runs.jsonl` shape acceptable.
 

--- a/scripts/autoresearch/cron/preflight.ts
+++ b/scripts/autoresearch/cron/preflight.ts
@@ -8,16 +8,16 @@
  * or a sweep crash.
  *
  * Probes:
- *   - Embedder URL / models (OPENROUTER_API_KEY required, must respond
- *     to a HEAD or /models request).
- *   - Extractor URL / models (local Claude direct proxy, no auth).
+ *   - Embedder URL / models (`WTFOC_EMBEDDER_*` + key, must respond to
+ *     a HEAD or /models request).
+ *   - Extractor URL / models (`WTFOC_EXTRACTOR_*`).
  *   - Optional: BGE reranker URL (/healthz), only when
- *     WTFOC_REQUIRE_RERANKER=1.
+ *     `WTFOC_REQUIRE_RERANKER=1`.
  *
  * Writes a status JSON to `~/.wtfoc/autoresearch/nightly-status.json`
  * with the result of every probe so the maintainer can tail it.
  *
- * No homelab2 endpoints are hardcoded — every URL comes from env.
+ * No endpoints are hardcoded — every URL comes from env.
  */
 
 import { mkdirSync, writeFileSync } from "node:fs";

--- a/scripts/autoresearch/cron/run-nightly.sh
+++ b/scripts/autoresearch/cron/run-nightly.sh
@@ -20,7 +20,7 @@
 # Exit codes: 0 on every non-fatal path. Non-zero only when sweep
 # itself crashes (engine bug), so launchd shows the failure.
 #
-# All endpoint URLs come from env vars — no homelab2 URLs hardcoded.
+# All endpoint URLs come from env vars — none hardcoded in source.
 # Repo path inferred from the script location. WTFOC_AUTORESEARCH_DIR
 # overrides the state directory (default ~/.wtfoc/autoresearch).
 

--- a/scripts/autoresearch/matrices/retrieval-baseline.ts
+++ b/scripts/autoresearch/matrices/retrieval-baseline.ts
@@ -12,11 +12,29 @@
  * identical embedder config) so the fan-out cost is mostly query +
  * trace work, multiplied across both corpora.
  *
- * Reranker LLM points at the local Claude direct proxy (haiku) so
- * per-variant cost is locally-zero. No paid models in this matrix.
+ * Reranker URL is env-driven via `WTFOC_RERANKER_URL` (BGE
+ * cross-encoder protocol — `{query, candidates, top_n}` →
+ * `{results: [{id, score}]}`). When unset, the LLM-as-reranker
+ * variant is dropped from the matrix and only the rrOff variants
+ * run. Set the env to a BGE-protocol endpoint to enable rerank
+ * variants. The earlier iteration of this matrix hardcoded a
+ * `claude-direct-proxy` URL that routed through the Anthropic API
+ * (paid + ~5-10s per call) — removed in favor of the env-driven
+ * BGE path.
  */
 
-import type { Matrix } from "../matrix.js";
+import type { Matrix, RerankerSpec } from "../matrix.js";
+
+const RERANKER_URL = process.env.WTFOC_RERANKER_URL ?? "";
+const EXTRACTOR_URL = process.env.WTFOC_EXTRACTOR_URL ?? "";
+const EXTRACTOR_MODEL = process.env.WTFOC_EXTRACTOR_MODEL ?? "";
+const EMBEDDER_URL = process.env.WTFOC_EMBEDDER_URL ?? "";
+const EMBEDDER_MODEL = process.env.WTFOC_EMBEDDER_MODEL ?? "";
+
+const rerankerVariants: RerankerSpec[] = ["off"];
+if (RERANKER_URL) {
+	rerankerVariants.push({ type: "bge", url: RERANKER_URL });
+}
 
 const matrix: Matrix = {
 	name: "retrieval-baseline",
@@ -28,23 +46,16 @@ const matrix: Matrix = {
 			primary: "filoz-ecosystem-2026-04-v12",
 			secondary: "wtfoc-dogfood-2026-04-v3",
 		},
-		embedderUrl: "https://openrouter.ai/api/v1",
-		embedderModel: "baai/bge-base-en-v1.5",
+		embedderUrl: EMBEDDER_URL,
+		embedderModel: EMBEDDER_MODEL,
 		embedderKey: process.env.OPENROUTER_API_KEY ?? "",
-		extractorUrl: "http://127.0.0.1:4523/v1",
-		extractorModel: "haiku",
+		extractorUrl: EXTRACTOR_URL,
+		extractorModel: EXTRACTOR_MODEL,
 	},
 	axes: {
 		autoRoute: [false, true],
 		diversityEnforce: [false, true],
-		reranker: [
-			"off",
-			{
-				type: "llm",
-				url: "http://127.0.0.1:4523/v1",
-				model: "haiku",
-			},
-		],
+		reranker: rerankerVariants,
 	},
 };
 

--- a/scripts/autoresearch/matrices/retrieval-gpu-rerank.ts
+++ b/scripts/autoresearch/matrices/retrieval-gpu-rerank.ts
@@ -1,13 +1,15 @@
 /**
- * GPU rerank-mode variant of `retrieval-baseline`. Targets the homelab
- * single-GPU vllm cluster running in `rerank-gpu` mode. Drives the BGE
+ * GPU rerank-mode variant of `retrieval-baseline`. Targets a vllm-admin
+ * managed cluster running in `rerank-gpu` mode. Drives a BGE
  * cross-encoder for off/on A/B over the same v12 + v3 corpus pair.
  *
  * Pre-conditions (cron wrapper handles):
- *   - WTFOC_VLLM_AUTOSWAP=1 in cron env
- *   - WTFOC_VLLM_ADMIN_URL points at the homelab admin
- *   - Embedder + extractor stay on always-on tiers (cloud + local proxy)
- *     so the GPU is free to host rerank-gpu for the duration of the sweep
+ *   - `WTFOC_VLLM_AUTOSWAP=1` in cron env
+ *   - `WTFOC_VLLM_ADMIN_URL` points at the cluster admin endpoint
+ *   - `WTFOC_RERANKER_URL` points at the rerank-gpu workload (BGE
+ *     protocol)
+ *   - Embedder + extractor stay on always-on tiers so the GPU is free
+ *     to host rerank-gpu for the duration of the sweep
  *
  * The wrapper switches GPU → rerank-gpu before sweep, then back to chat
  * for analysis LLM. `gpuPhase` is set explicitly (not relying on the
@@ -16,10 +18,23 @@
 
 import type { Matrix } from "../matrix.js";
 
+const RERANKER_URL = process.env.WTFOC_RERANKER_URL ?? "";
+const EMBEDDER_URL = process.env.WTFOC_EMBEDDER_URL ?? "";
+const EMBEDDER_MODEL = process.env.WTFOC_EMBEDDER_MODEL ?? "";
+const EXTRACTOR_URL = process.env.WTFOC_EXTRACTOR_URL ?? "";
+const EXTRACTOR_MODEL = process.env.WTFOC_EXTRACTOR_MODEL ?? "";
+
+if (!RERANKER_URL) {
+	throw new Error(
+		"retrieval-gpu-rerank matrix requires WTFOC_RERANKER_URL to be set " +
+			"(BGE-protocol endpoint for the GPU reranker workload).",
+	);
+}
+
 const matrix: Matrix = {
 	name: "retrieval-gpu-rerank",
 	description:
-		"Cross-corpus retrieval-knob sweep with homelab BGE GPU reranker (vs reranker-off baseline).",
+		"Cross-corpus retrieval-knob sweep with BGE GPU reranker (vs reranker-off baseline).",
 	productionVariantId: "noar_div_rrOff",
 	gpuPhase: "rerank-gpu",
 	baseConfig: {
@@ -27,11 +42,11 @@ const matrix: Matrix = {
 			primary: "filoz-ecosystem-2026-04-v12",
 			secondary: "wtfoc-dogfood-2026-04-v3",
 		},
-		embedderUrl: "https://openrouter.ai/api/v1",
-		embedderModel: "baai/bge-base-en-v1.5",
+		embedderUrl: EMBEDDER_URL,
+		embedderModel: EMBEDDER_MODEL,
 		embedderKey: process.env.OPENROUTER_API_KEY ?? "",
-		extractorUrl: "http://127.0.0.1:4523/v1",
-		extractorModel: "haiku",
+		extractorUrl: EXTRACTOR_URL,
+		extractorModel: EXTRACTOR_MODEL,
 	},
 	axes: {
 		autoRoute: [false, true],
@@ -40,7 +55,7 @@ const matrix: Matrix = {
 			"off",
 			{
 				type: "bge",
-				url: process.env.WTFOC_RERANKER_URL ?? "https://reranker-gpu.bt.sgtpooki.com",
+				url: RERANKER_URL,
 			},
 		],
 	},

--- a/scripts/autoresearch/matrices/smoke.ts
+++ b/scripts/autoresearch/matrices/smoke.ts
@@ -2,8 +2,9 @@
  * Smallest possible sweep — 2 variants, only diversityEnforce on/off.
  * For end-to-end harness verification, not retrieval research.
  *
- * Use:
- *   OPENROUTER_API_KEY=... pnpm autoresearch:sweep smoke
+ * Required env:
+ *   WTFOC_EMBEDDER_URL / WTFOC_EMBEDDER_MODEL (+ key, e.g. OPENROUTER_API_KEY)
+ *   WTFOC_EXTRACTOR_URL / WTFOC_EXTRACTOR_MODEL
  */
 
 import type { Matrix } from "../matrix.js";
@@ -13,11 +14,11 @@ const matrix: Matrix = {
 	description: "Two-variant smoke sweep — diversityEnforce off vs on. Verifies harness wiring.",
 	baseConfig: {
 		collection: "filoz-ecosystem-2026-04-v12",
-		embedderUrl: "https://openrouter.ai/api/v1",
-		embedderModel: "baai/bge-base-en-v1.5",
+		embedderUrl: process.env.WTFOC_EMBEDDER_URL ?? "",
+		embedderModel: process.env.WTFOC_EMBEDDER_MODEL ?? "",
 		embedderKey: process.env.OPENROUTER_API_KEY ?? "",
-		extractorUrl: "http://127.0.0.1:4523/v1",
-		extractorModel: "haiku",
+		extractorUrl: process.env.WTFOC_EXTRACTOR_URL ?? "",
+		extractorModel: process.env.WTFOC_EXTRACTOR_MODEL ?? "",
 	},
 	axes: {
 		diversityEnforce: [false, true],

--- a/scripts/autoresearch/sweep.ts
+++ b/scripts/autoresearch/sweep.ts
@@ -30,6 +30,7 @@
  * defaults. That gate stays manual until methodology is hardened.
  */
 
+import { ensureMode, type GpuMode, resolveModeFromMatrix } from "../lib/mode-switch.js";
 import { safeExecFileSync as execFileSync } from "../lib/safe-exec.js";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -367,6 +368,33 @@ async function main(): Promise<void> {
 		} sweepId=${sweepId} stage=${stage ?? "(none)"}`,
 	);
 
+	// #360 — auto-switch GPU mode for sweeps targeting a GPU-only
+	// workload (rerank-gpu / embed-gpu). Mirrors the autonomous-loop's
+	// `swapMode` wrapper. Gated by `WTFOC_VLLM_AUTOSWAP=1`; when unset
+	// every call is a noop and the sweep runs in whatever mode is
+	// already active. After the sweep finishes (success OR failure),
+	// the GPU is returned to `chat` so the autonomous-loop's analyze
+	// phase has a chat-ready model.
+	const sweepMode: GpuMode | null = resolveModeFromMatrix(matrix);
+	if (sweepMode) {
+		logErr(`[sweep] resolved gpu mode requirement: ${sweepMode}`);
+		try {
+			const r = await ensureMode(sweepMode, { reason: `sweep ${matrix.name}` });
+			if (r.skipped) {
+				logErr(`[sweep] mode-switch skipped (${sweepMode}): ${r.skippedReason}`);
+			} else {
+				logErr(`[sweep] mode-switch ok: ${r.from ?? "?"}→${r.to ?? sweepMode}`);
+			}
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			logErr(`[sweep] mode-switch FAILED (${sweepMode}): ${msg}`);
+			logErr(
+				`[sweep] aborting — variants targeting a ${sweepMode} workload would 503 against the inactive deployment`,
+			);
+			process.exit(3);
+		}
+	}
+
 	const results: SweepRunResult[] = [];
 	let primaryBaselineReport: ExtendedDogfoodReport | null = null;
 	let secondaryBaselineReport: ExtendedDogfoodReport | null = null;
@@ -460,7 +488,45 @@ async function main(): Promise<void> {
 	logErr(`[sweep] run log appended at ~/.wtfoc/autoresearch/runs.jsonl (${totalRows} rows)`);
 }
 
-main().catch((err) => {
-	logErr("[sweep] fatal:", err instanceof Error ? err.message : String(err));
-	process.exit(1);
-});
+/**
+ * After a GPU sweep, return the cluster to chat so any downstream
+ * `autoresearch:autonomous` invocation has a chat-ready model.
+ * Best-effort: failures here are logged but do not change the exit
+ * code (the sweep itself succeeded).
+ */
+async function revertGpuModeToChat(matrix: Awaited<ReturnType<typeof loadMatrix>>): Promise<void> {
+	const sweepMode = resolveModeFromMatrix(matrix);
+	if (!sweepMode || sweepMode === "chat") return;
+	try {
+		const r = await ensureMode("chat", { reason: "post-sweep revert" });
+		if (r.skipped) logErr(`[sweep] post-sweep revert skipped: ${r.skippedReason}`);
+		else logErr(`[sweep] post-sweep revert ok: ${r.from ?? "?"}→chat`);
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		logErr(`[sweep] post-sweep revert FAILED (chat): ${msg}`);
+	}
+}
+
+main()
+	.then(async () => {
+		// success path — best-effort revert; only meaningful when matrix
+		// targeted a GPU mode AND auto-switch is enabled.
+		try {
+			const cliArgs = parseArgs(process.argv);
+			const matrix = await loadMatrix(cliArgs.matrixName);
+			await revertGpuModeToChat(matrix);
+		} catch {
+			// already-logged in main; nothing to do here
+		}
+	})
+	.catch(async (err) => {
+		logErr("[sweep] fatal:", err instanceof Error ? err.message : String(err));
+		try {
+			const cliArgs = parseArgs(process.argv);
+			const matrix = await loadMatrix(cliArgs.matrixName);
+			await revertGpuModeToChat(matrix);
+		} catch {
+			// already-logged
+		}
+		process.exit(1);
+	});

--- a/scripts/lib/mode-switch.ts
+++ b/scripts/lib/mode-switch.ts
@@ -1,15 +1,17 @@
 /**
- * Thin client for the homelab vllm-admin mode-switch API. Maintainer-only.
+ * Thin client for a vllm-admin mode-switch API. Maintainer-only.
  *
- * Single-GPU homelab box can serve exactly one of {chat, rerank-gpu,
- * embed-gpu} at a time. The autoresearch nightly cron drives the
- * switch around its phases (sweep → analyze → materialize → reset).
+ * Targets a single-GPU cluster that serves exactly one of {chat,
+ * rerank-gpu, embed-gpu} at a time. The autoresearch nightly cron
+ * drives the switch around its phases (sweep → analyze → materialize
+ * → reset).
  *
  * Hard rules:
  *   - Gated by `WTFOC_VLLM_AUTOSWAP=1`. When unset every call is a noop
- *     so non-homelab maintainers can run the loop unmodified.
- *   - Admin URL comes from `WTFOC_VLLM_ADMIN_URL`. No homelab2 URLs
- *     hardcoded.
+ *     so maintainers without a vllm-admin cluster can run the loop
+ *     unmodified.
+ *   - Admin URL comes from `WTFOC_VLLM_ADMIN_URL`. No URLs hardcoded
+ *     in source — every endpoint is operator-supplied.
  *   - `ensureMode` is idempotent — same target as current activeMode
  *     short-circuits without a network call to switch (still polls
  *     `/admin/mode` once to read state).
@@ -17,8 +19,7 @@
  *     failure phases throw; the caller decides whether to abort the
  *     pipeline.
  *
- * See homelab2/docs/runbooks/vllm-admin-consumer-guide.md for the
- * server-side state machine.
+ * Server-side state machine: see your cluster's vllm-admin runbook.
  */
 
 export type GpuMode = "chat" | "rerank-gpu" | "embed-gpu";
@@ -209,12 +210,13 @@ export async function ensureMode(
 
 /**
  * Resolve the GPU phase a matrix needs for its sweep. Inspects whether
- * any URL in the matrix points at a homelab GPU-only endpoint. Returns
- * null when the matrix is fully always-on / cloud (no swap needed).
+ * any URL in the matrix points at a GPU-only workload. Returns null
+ * when the matrix is fully always-on / cloud (no swap needed).
  *
- * Heuristic: looks for `embedder-gpu`, `reranker-gpu`, or
- * `vllm.bt.sgtpooki` substrings. Override via matrix.gpuPhase when
- * heuristic is wrong.
+ * Heuristic: looks for `embedder-gpu` or `reranker-gpu` substrings in
+ * the configured URLs (a convention shared by typical vllm-admin
+ * deployments). Override via `matrix.gpuPhase` when the heuristic is
+ * wrong for your endpoints.
  */
 export function resolveModeFromMatrix(matrix: {
 	gpuPhase?: GpuMode | null;


### PR DESCRIPTION
## Summary

The `retrieval-baseline` matrix hardcoded localhost URLs for the extractor + reranker. The 4523 proxy it pointed at routes through the Anthropic API, so every rerank call cost tokens + ~5-10s, despite the file's docstring claiming "no paid models in this matrix". A single sweep variant on filoz with LLM-as-reranker took 1h+ instead of seconds.

## Changes

`scripts/autoresearch/matrices/retrieval-baseline.ts`:

- Embedder URL/model ← `WTFOC_EMBEDDER_URL` / `WTFOC_EMBEDDER_MODEL`
- Extractor URL/model ← `WTFOC_EXTRACTOR_URL` / `WTFOC_EXTRACTOR_MODEL`
- Reranker variant ← `WTFOC_RERANKER_URL` (BGE protocol). When unset, matrix runs only rrOff variants.

Removed the LLM-as-reranker variant — it was a footgun masquerading as local zero-cost.

## Behavior

- Operators set the env vars via `.env` / shell. No homelab hostnames in source.
- `WTFOC_RERANKER_URL` unset → 4 fast variants per corpus (autoRoute × diversityEnforce × rrOff). Sweep finishes in minutes.
- `WTFOC_RERANKER_URL` set to a BGE endpoint → 8 variants (4 fast + 4 with cross-encoder rerank).

## Test plan
- [x] `pnpm test` passes (1842 tests, 0 failures)
- [x] `pnpm -r build` passes
- [x] `pnpm lint:fix` clean