### PR TITLE
fix(eval): preflight invalid status now actually skips (refs #343 P0, #345)

### DIFF
--- a/packages/search/src/eval/quality-queries-evaluator.test.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.test.ts
@@ -654,4 +654,39 @@ describe("evaluateQualityQueries", () => {
 			expect(sig.thresholds.giniFloor).toBe(0.6);
 		});
 	});
+
+	describe("preflight-driven skip (#343 P0 forensics finding)", () => {
+		it("skips queries marked invalid by preflight (were counted as failures pre-fix)", async () => {
+			mockQuery.mockResolvedValue(makeQueryResult([]));
+			mockTrace.mockResolvedValue(makeTraceResult([]));
+			const firstId = GOLD_STANDARD_QUERIES[0]?.id;
+			const secondId = GOLD_STANDARD_QUERIES[1]?.id;
+			if (!firstId || !secondId) throw new Error("fixture too small");
+			const preflightStatusByQueryId = new Map([
+				[firstId, "invalid" as const],
+				[secondId, "skipped" as const],
+			]);
+			const result = await evaluateQualityQueries(
+				mockEmbedder,
+				mockVectorIndex,
+				mockSegments,
+				undefined,
+				[],
+				undefined,
+				false,
+				{ preflightStatusByQueryId },
+			);
+			const scores = result.metrics.scores as Array<{
+				id: string;
+				skipped?: boolean;
+				skipReason?: string;
+			}>;
+			const first = scores.find((s) => s.id === firstId);
+			const second = scores.find((s) => s.id === secondId);
+			expect(first?.skipped).toBe(true);
+			expect(first?.skipReason).toContain("fixture-invalid");
+			expect(second?.skipped).toBe(true);
+			expect(second?.skipReason).toContain("preflight-skipped");
+		});
+	});
 });

--- a/packages/search/src/eval/quality-queries-evaluator.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.ts
@@ -598,11 +598,19 @@ export async function evaluateQualityQueries(
  * Decide whether a query is inapplicable to the current corpus.
  * Returns a human-readable reason string when skipped, or null when applicable.
  *
- * Two gates:
+ * Three gates:
  * 1. `collectionScopePattern` — query declares which corpora it targets.
  * 2. corpus source-type coverage — if the query requires a source type not
  *    ingested into the corpus, skip instead of failing (a coverage gap in
  *    the corpus is not a retrieval regression).
+ * 3. catalog-applicability preflight — if `preflightStatusByQueryId` marks
+ *    the (query, corpus) pair as `fixture-invalid` (required artifact not
+ *    in the corpus catalog), skip instead of failing. Per #344 D2 / #345
+ *    spec: "If absent → mark query skipped, NOT failed. Skipped queries
+ *    excluded from aggregate." Prior implementation only annotated the
+ *    failure-diagnosis layer, leaving these queries counted as failures
+ *    and depressing pass rates by ~30% on cross-corpus runs (P0
+ *    forensics finding on #343).
  */
 function resolveSkip(gq: GoldQuery, ctx: QualityQueriesContext): string | null {
 	if (ctx.collectionId && !gq.applicableCorpora.includes(ctx.collectionId)) {
@@ -612,6 +620,15 @@ function resolveSkip(gq: GoldQuery, ctx: QualityQueriesContext): string | null {
 		const missing = gq.requiredSourceTypes.filter((st) => !ctx.corpusSourceTypes?.has(st));
 		if (missing.length > 0) {
 			return `corpus lacks required source type(s): ${missing.join(", ")}`;
+		}
+	}
+	if (ctx.preflightStatusByQueryId) {
+		const status = ctx.preflightStatusByQueryId.get(gq.id);
+		if (status === "invalid") {
+			return "fixture-invalid: required artifact not present in corpus catalog";
+		}
+		if (status === "skipped") {
+			return "preflight-skipped: query not applicable to this corpus";
 		}
 	}
 	return null;


### PR DESCRIPTION
## Summary

#343 P0 forensics on the latest sweep surfaced this. **59 queries across two corpora** (25 filoz + 34 wtfoc-v3) had `failureClass: fixture-invalid` AND were counted as **failures**, depressing pass rates by ~30%.

Per #344 D2 / #345 spec: "If absent → mark query skipped, NOT failed. Skipped queries excluded from aggregate."

## Root cause

#345 wired the preflight result into the **diagnosis layer** (via `preflightStatusByQueryId.get(gq.id)` in `diagnoseFailure`) but did NOT extend `resolveSkip()` to consult preflight. So queries ran the full evaluation pipeline → got correctly annotated as `fixture-invalid` in the diagnosis output → but were still counted in `failed` not `skipped`.

## Fix

Extend `resolveSkip()` with a third gate. When `preflightStatusByQueryId.get(gq.id)` returns `"invalid"` (or `"skipped"`), the query is skipped with a clear reason rather than running through the failure path.

## Expected impact on real reports

For the two sweep reports analyzed in #343 P0 forensics:

| | filoz-v12 (before → after) | wtfoc-v3 (before → after) |
|---|---|---|
| pass rate | 31.5% → ~45% | 24.8% → ~40% |
| fixture failures | 25 → 0 | 34 → 0 |
| dominantLayer | ranking (unchanged) | fixture → ranking |
| skipped count | 14 → 39 | 40 → 74 |

## Test plan
- [x] New regression test pinning that `"invalid"` and `"skipped"` preflight statuses both produce `score.skipped: true` with reason
- [x] `pnpm test` passes (1843 tests)
- [x] `pnpm -r build` passes
- [x] `pnpm lint:fix` clean

## Refs
- #343 — comment posted with P0 forensics findings
- #345 — original preflight implementation that this fixes