### PR TITLE
feat(eval): canonical documentId evidence gate (#344 D1)

### DIFF
--- a/packages/search/src/eval/failure-diagnosis.test.ts
+++ b/packages/search/src/eval/failure-diagnosis.test.ts
@@ -181,6 +181,36 @@ describe("diagnoseFailure", () => {
 		expect(result?.layer).toBe("trace");
 	});
 
+	it("canonical gate active: substringFound=true but documentIdFound=false → ranking failure (#344 D1)", () => {
+		// Query in widerK, required types met, substring superficially hit BUT
+		// the canonical exact-id gate failed. Rule 6 must consult `evidencePass`
+		// (= documentIdFound when canonical) and route to ranking, not let the
+		// stale substring=true mask the failure into answer-synthesis.
+		const result = diagnoseFailure({
+			score: makeScore({
+				id: "q1",
+				resultCount: 5,
+				requiredTypesFound: true,
+				substringFound: true,
+				documentIdFound: false,
+				evidenceGateCanonical: true,
+				goldProximity: {
+					widerK: 50,
+					topKCutoff: 10,
+					goldRank: 8,
+					goldScore: 0.5,
+					topKLastScore: 0.4,
+				},
+			}),
+			query: makeQuery({ id: "q1" }),
+			preflightStatus: "applicable",
+		});
+		expect(result?.failureClass).toBe("retrieved-not-ranked");
+		expect(result?.layer).toBe("ranking");
+		expect(result?.evidence.documentIdFound).toBe(false);
+		expect(result?.evidence.evidenceGateCanonical).toBe(true);
+	});
+
 	it("populates evidence.retrievedInWiderK as null when goldProximity is unrecorded", () => {
 		const result = diagnoseFailure({
 			score: makeScore({

--- a/packages/search/src/eval/failure-diagnosis.ts
+++ b/packages/search/src/eval/failure-diagnosis.ts
@@ -72,6 +72,10 @@ export interface DiagnosisEvidence {
 	crossSourceMet: boolean;
 	/** True when ≥1 `required:true` artifactId surfaced in retrieved sources. */
 	substringFound: boolean;
+	/** #344 D1 — true when ≥1 required artifactId exact-matched a retrieved `Chunk.documentId`. */
+	documentIdFound?: boolean;
+	/** True when canonical exact-match gate drove pass/fail (vs legacy substring). */
+	evidenceGateCanonical?: boolean;
 	/** Gold-source proximity context, when available. */
 	goldRank: number | null;
 	topKCutoff: number | null;
@@ -99,6 +103,8 @@ export interface DiagnosisScoreInput {
 	resultCount: number;
 	requiredTypesFound: boolean;
 	substringFound: boolean;
+	documentIdFound?: boolean;
+	evidenceGateCanonical?: boolean;
 	edgeHopFound: boolean;
 	crossSourceFound: boolean;
 	goldProximity?: {
@@ -138,6 +144,14 @@ export function diagnoseFailure(input: DiagnoseFailureInput): FailureDiagnosis |
 		score.goldProximity === undefined ? null : score.goldProximity.goldRank !== null;
 	const goldInCatalog = preflightStatus !== "invalid";
 
+	// #344 D1 — when the canonical exact-match gate is in force, evidence
+	// pass/fail is `documentIdFound`. Otherwise the legacy substring gate
+	// drives. Routing rules below consult the active signal so a substring-
+	// only hit in a canonical query no longer masquerades as a pass.
+	const evidencePass = score.evidenceGateCanonical
+		? score.documentIdFound === true
+		: score.substringFound;
+
 	const evidence: DiagnosisEvidence = {
 		goldInCatalog,
 		retrievedInWiderK,
@@ -146,6 +160,8 @@ export function diagnoseFailure(input: DiagnoseFailureInput): FailureDiagnosis |
 		edgeHopsMet: score.edgeHopFound,
 		crossSourceMet: score.crossSourceFound,
 		substringFound: score.substringFound,
+		documentIdFound: score.documentIdFound,
+		evidenceGateCanonical: score.evidenceGateCanonical,
 		goldRank,
 		topKCutoff,
 		widerK,
@@ -230,11 +246,11 @@ export function diagnoseFailure(input: DiagnoseFailureInput): FailureDiagnosis |
 		};
 	}
 
-	// Rule 6 — required types absent or substring absent: ranking layer.
-	// (Substring matching is the legacy proxy for evidence presence and
-	// will switch to exact documentId match in step 3 fixture regen; until
-	// then a substring miss is still a ranking failure on the gold set.)
-	if (!score.requiredTypesFound || !score.substringFound) {
+	// Rule 6 — required types absent or evidence gate failed: ranking layer.
+	// `evidencePass` is `documentIdFound` when canonical, `substringFound`
+	// otherwise. Either way, gold IS in widerK (Rule 3 already exited) so
+	// the failure is "retrieved but the right artifact didn't surface".
+	if (!score.requiredTypesFound || !evidencePass) {
 		return {
 			queryId: query.id,
 			corpusId: corpusId ?? null,

--- a/packages/search/src/eval/quality-queries-evaluator.test.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.test.ts
@@ -13,7 +13,7 @@ const { evaluateQualityQueries, getActiveQueries } = await import("./quality-que
 const { GOLD_STANDARD_QUERIES } = await import("./gold-standard-queries.js");
 
 function makeQueryResult(
-	results: Array<{ sourceType: string; source: string; score: number }>,
+	results: Array<{ sourceType: string; source: string; score: number; documentId?: string }>,
 ): QueryResult {
 	return {
 		query: "test query",
@@ -21,6 +21,7 @@ function makeQueryResult(
 			content: "test",
 			sourceType: r.sourceType,
 			source: r.source,
+			...(r.documentId ? { documentId: r.documentId } : {}),
 			storageId: "s1",
 			score: r.score,
 			retrievalScore: r.score,
@@ -652,6 +653,156 @@ describe("evaluateQualityQueries", () => {
 			};
 			expect(sig.collectionId).toBe("alpha");
 			expect(sig.thresholds.giniFloor).toBe(0.6);
+		});
+	});
+
+	describe("canonical exact-match evidence gate (#344 D1)", () => {
+		// Pick a query with at least one required artifactId. Tests confirm the
+		// canonical exact-match gate (`documentIdFound`) supersedes the legacy
+		// substring gate when the catalog confirms the artifactId is a real
+		// `Chunk.documentId`.
+		const candidate = GOLD_STANDARD_QUERIES.find(
+			(q) => q.expectedEvidence.some((e) => e.required) && !q.isHardNegative,
+		);
+		const allRequiredAids =
+			candidate?.expectedEvidence.filter((e) => e.required).map((e) => e.artifactId) ?? [];
+		const requiredAid = allRequiredAids[0];
+
+		function makeCatalog(documentIds: string[]) {
+			return {
+				schemaVersion: 1 as const,
+				collectionId: "alpha",
+				documents: Object.fromEntries(
+					documentIds.map((id) => [
+						id,
+						{
+							documentId: id,
+							currentVersionId: "v1",
+							previousVersionIds: [],
+							chunkIds: [],
+							supersededChunkIds: [],
+							contentFingerprints: [],
+							state: "active" as const,
+							mutability: "mutable-state" as const,
+							sourceType: "code",
+							updatedAt: new Date().toISOString(),
+						},
+					]),
+				),
+			};
+		}
+
+		it("substring-only hit FAILS when canonical gate is active (no documentId match)", async () => {
+			if (!candidate || !requiredAid) throw new Error("no canonical candidate query in fixture");
+			// Result whose `source` substring-matches but `documentId` does NOT.
+			mockQuery.mockResolvedValue(
+				makeQueryResult([
+					{
+						sourceType: candidate.requiredSourceTypes[0] ?? "code",
+						source: `wrapper-around-${requiredAid}-but-not-the-doc`,
+						documentId: "different-doc-id",
+						score: 0.9,
+					},
+				]),
+			);
+			mockTrace.mockResolvedValue(makeTraceResult([]));
+			const result = await evaluateQualityQueries(
+				mockEmbedder,
+				mockVectorIndex,
+				mockSegments,
+				undefined,
+				[],
+				undefined,
+				false,
+				{
+					documentCatalog: makeCatalog(allRequiredAids),
+				},
+			);
+			const scores = result.metrics.scores as Array<{
+				id: string;
+				passed: boolean;
+				substringFound: boolean;
+				documentIdFound: boolean;
+				evidenceGateCanonical: boolean;
+			}>;
+			const score = scores.find((s) => s.id === candidate.id);
+			expect(score).toBeDefined();
+			expect(score?.evidenceGateCanonical).toBe(true);
+			expect(score?.substringFound).toBe(true);
+			expect(score?.documentIdFound).toBe(false);
+			expect(score?.passed).toBe(false);
+		});
+
+		it("exact documentId hit PASSES under canonical gate even with no substring match", async () => {
+			if (!candidate || !requiredAid) throw new Error("no canonical candidate query in fixture");
+			mockQuery.mockResolvedValue(
+				makeQueryResult(
+					Array.from({ length: candidate.minResults }, (_, i) => ({
+						sourceType: candidate.requiredSourceTypes[0] ?? "code",
+						source: `unrelated/path/${i}.ts`,
+						documentId: i === 0 ? requiredAid : `other-doc-${i}`,
+						score: 0.9 - i * 0.05,
+					})),
+				),
+			);
+			mockTrace.mockResolvedValue(makeTraceResult([]));
+			const result = await evaluateQualityQueries(
+				mockEmbedder,
+				mockVectorIndex,
+				mockSegments,
+				undefined,
+				[],
+				undefined,
+				false,
+				{
+					documentCatalog: makeCatalog(allRequiredAids),
+				},
+			);
+			const scores = result.metrics.scores as Array<{
+				id: string;
+				substringFound: boolean;
+				documentIdFound: boolean;
+				evidenceGateCanonical: boolean;
+			}>;
+			const score = scores.find((s) => s.id === candidate.id);
+			expect(score?.evidenceGateCanonical).toBe(true);
+			expect(score?.substringFound).toBe(false);
+			expect(score?.documentIdFound).toBe(true);
+		});
+
+		it("falls back to substring gate when artifactId not in catalog (legacy fixture)", async () => {
+			if (!candidate || !requiredAid) throw new Error("no canonical candidate query in fixture");
+			mockQuery.mockResolvedValue(
+				makeQueryResult([
+					{
+						sourceType: candidate.requiredSourceTypes[0] ?? "code",
+						source: `path/with/${requiredAid}/inside.ts`,
+						documentId: "different-doc-id",
+						score: 0.9,
+					},
+				]),
+			);
+			mockTrace.mockResolvedValue(makeTraceResult([]));
+			// Catalog deliberately empty — artifactId not present => legacy gate.
+			const result = await evaluateQualityQueries(
+				mockEmbedder,
+				mockVectorIndex,
+				mockSegments,
+				undefined,
+				[],
+				undefined,
+				false,
+				{ documentCatalog: makeCatalog([]) },
+			);
+			const scores = result.metrics.scores as Array<{
+				id: string;
+				substringFound: boolean;
+				documentIdFound: boolean;
+				evidenceGateCanonical: boolean;
+			}>;
+			const score = scores.find((s) => s.id === candidate.id);
+			expect(score?.evidenceGateCanonical).toBe(false);
+			expect(score?.substringFound).toBe(true);
 		});
 	});
 

--- a/packages/search/src/eval/quality-queries-evaluator.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.ts
@@ -155,6 +155,20 @@ interface QueryScore {
 	/** #261 — requiredTypesFound computed against query results only (no trace). */
 	requiredTypesFoundQueryOnly: boolean;
 	substringFound: boolean;
+	/**
+	 * #344 D1 — exact-match identity gate: true when at least one required
+	 * `expectedEvidence.artifactId` matches a retrieved chunk's `documentId`
+	 * exactly. Used as the canonical pass criterion when the corpus catalog
+	 * confirms the fixture is on v2.0.0-shape (artifactIds are real
+	 * documentIds). Falls back to `substringFound` for unmigrated queries.
+	 */
+	documentIdFound: boolean;
+	/**
+	 * True when the canonical exact-match gate (`documentIdFound`) is the
+	 * one that drove pass/fail. False when the legacy substring gate was
+	 * used instead (artifactIds didn't all resolve in the catalog).
+	 */
+	evidenceGateCanonical: boolean;
 	edgeHopFound: boolean;
 	crossSourceFound: boolean;
 	sourceTypesReached: string[];
@@ -336,6 +350,15 @@ export async function evaluateQualityQueries(
 
 	const { queries: activeQueries, filter: queryFilter } = getActiveQueries();
 
+	// #344 D1 — when the corpus catalog is available, build the documentId
+	// set once so the canonical exact-match evidence gate can confirm each
+	// query's `expectedEvidence.artifactId` is a real `Chunk.documentId`.
+	// Queries whose artifactIds aren't all in the catalog fall back to the
+	// legacy substring gate inside `scoreText`.
+	const catalogDocumentIds: ReadonlySet<string> | undefined = context.documentCatalog
+		? new Set(Object.keys(context.documentCatalog.documents))
+		: undefined;
+
 	for (const gq of activeQueries) {
 		signal?.throwIfAborted();
 		const skip = resolveSkip(gq, context);
@@ -359,6 +382,7 @@ export async function evaluateQualityQueries(
 			context.checkParaphrases ?? false,
 			context.retrievalOverrides ?? {},
 			context.recordGoldProximity ?? process.env.WTFOC_GOLD_PROXIMITY === "1",
+			catalogDocumentIds,
 		);
 		context.perQueryHook?.(gq.id, performance.now() - queryStart);
 		scores.push(score);
@@ -722,6 +746,8 @@ function skippedScore(gq: GoldQuery, reason: string): QueryScore {
 		requiredTypesFound: false,
 		requiredTypesFoundQueryOnly: false,
 		substringFound: true,
+		documentIdFound: true,
+		evidenceGateCanonical: false,
 		edgeHopFound: true,
 		crossSourceFound: true,
 		sourceTypesReached: [],
@@ -741,6 +767,8 @@ interface InnerScore {
 	requiredTypesFound: boolean;
 	requiredTypesFoundQueryOnly: boolean;
 	substringFound: boolean;
+	documentIdFound: boolean;
+	evidenceGateCanonical: boolean;
 	edgeHopFound: boolean;
 	crossSourceFound: boolean;
 	sourceTypesReached: string[];
@@ -782,6 +810,7 @@ async function scoreText(
 	diversityEnforce = false,
 	overrides: RetrievalOverrides = {},
 	recordGoldProximity = false,
+	catalogDocumentIds?: ReadonlySet<string>,
 ): Promise<InnerScore> {
 	const TOPK = overrides.topK ?? 10;
 	const TRACE_MAX_PER_SOURCE = overrides.traceMaxPerSource ?? 3;
@@ -793,6 +822,7 @@ async function scoreText(
 	// independently of the graph-assisted pass rate.
 	let requiredTypesFoundQueryOnly = false;
 	let substringFound = true; // default true if no substrings specified
+	let documentIdFound = true; // default true when no required artifacts
 	let edgeHopFound = true; // default true if not required
 	let crossSourceFound = true; // default true if not required
 	const sourceTypesReached: string[] = [];
@@ -842,14 +872,21 @@ async function scoreText(
 
 		if (requiredArtifacts.length > 0) {
 			const resultSources = qResult.results.map((r) => r.source);
-			// Substring (legacy) match retained during step-2 transition because
-			// the mechanically-migrated fixture still contains unresolved
-			// substrings as `artifactId`. Step-3 query regeneration emits exact
-			// catalog `documentId`s and the grader will switch to exact match
-			// against `Chunk.documentId` at that point.
+			// Legacy substring gate — kept for unmigrated queries whose
+			// `expectedEvidence.artifactId` is still a path substring rather
+			// than a canonical `Chunk.documentId`. The canonical gate below
+			// supersedes this when the corpus catalog confirms identity.
 			substringFound = requiredArtifacts.some((sub) =>
 				resultSources.some((src) => src.toLowerCase().includes(sub.toLowerCase())),
 			);
+			// Canonical exact-match gate (#344 D1). Compares each required
+			// `artifactId` against retrieved chunks' `documentId`. Pass requires
+			// at least one required artifact to be hit by exact identity.
+			const resultDocIds = qResult.results
+				.map((r) => r.documentId)
+				.filter((d): d is string => typeof d === "string" && d.length > 0);
+			documentIdFound =
+				resultDocIds.length > 0 && requiredArtifacts.some((aid) => resultDocIds.includes(aid));
 		}
 
 		// #311 Phase 0d — recall@K computed over the full evidence set
@@ -924,11 +961,23 @@ async function scoreText(
 
 	const hardNegativeNoStrongHits = topScore === null || topScore < HARD_NEGATIVE_SCORE_CEILING;
 
+	// #344 D1 — pick canonical exact-match identity gate when the catalog
+	// confirms every required artifactId is a real `documentId`. Otherwise
+	// fall back to the legacy substring gate. Codex caveat: replacement must
+	// assert identity, not silently drop the gate; that is why both
+	// `documentIdFound` and `substringFound` are output even though only one
+	// drives pass/fail.
+	const evidenceGateCanonical =
+		requiredArtifacts.length > 0 &&
+		catalogDocumentIds !== undefined &&
+		requiredArtifacts.every((aid) => catalogDocumentIds.has(aid));
+	const evidencePass = evidenceGateCanonical ? documentIdFound : substringFound;
+
 	const passed = gq.isHardNegative
 		? resultCount < HARD_NEGATIVE_RESULT_CEILING && hardNegativeNoStrongHits
 		: resultCount >= gq.minResults &&
 			requiredTypesFound &&
-			substringFound &&
+			evidencePass &&
 			edgeHopFound &&
 			crossSourceFound;
 
@@ -936,7 +985,7 @@ async function scoreText(
 	// and ignore edge-hop/cross-source requirements (those are inherently trace-assisted).
 	const passedQueryOnly = gq.isHardNegative
 		? resultCount < HARD_NEGATIVE_RESULT_CEILING && hardNegativeNoStrongHits
-		: resultCount >= gq.minResults && requiredTypesFoundQueryOnly && substringFound;
+		: resultCount >= gq.minResults && requiredTypesFoundQueryOnly && evidencePass;
 
 	let goldProximity: InnerScore["goldProximity"];
 	if (recordGoldProximity && !passed && allArtifacts.length > 0) {
@@ -985,6 +1034,8 @@ async function scoreText(
 		requiredTypesFound,
 		requiredTypesFoundQueryOnly,
 		substringFound,
+		documentIdFound,
+		evidenceGateCanonical,
 		edgeHopFound,
 		crossSourceFound,
 		sourceTypesReached,
@@ -1011,6 +1062,7 @@ async function scoreQuery(
 	checkParaphrases = false,
 	overrides: RetrievalOverrides = {},
 	recordGoldProximity = false,
+	catalogDocumentIds?: ReadonlySet<string>,
 ): Promise<QueryScore> {
 	const inner = await scoreText(
 		gq.query,
@@ -1025,6 +1077,7 @@ async function scoreQuery(
 		diversityEnforce,
 		overrides,
 		recordGoldProximity,
+		catalogDocumentIds,
 	);
 
 	let paraphraseScores: ParaphraseScore[] | undefined;
@@ -1044,6 +1097,8 @@ async function scoreQuery(
 				autoRoute,
 				diversityEnforce,
 				overrides,
+				false,
+				catalogDocumentIds,
 			);
 			paraphraseScores.push({ text: p, passed: ps.passed, passedQueryOnly: ps.passedQueryOnly });
 		}

--- a/packages/search/src/mount.ts
+++ b/packages/search/src/mount.ts
@@ -127,6 +127,9 @@ export async function mountCollection(
 				content: chunk.content,
 				...chunk.metadata,
 			};
+			if (chunk.documentId) {
+				metadata.documentId = chunk.documentId;
+			}
 			if (chunk.signalScores && Object.keys(chunk.signalScores).length > 0) {
 				metadata.signalScores = JSON.stringify(chunk.signalScores);
 			}

--- a/packages/search/src/query.ts
+++ b/packages/search/src/query.ts
@@ -69,6 +69,7 @@ export interface QueryResult {
 		sourceType: string;
 		source: string;
 		sourceUrl?: string;
+		documentId?: string;
 		storageId: string;
 		/**
 		 * Composite ranking score. Composed of `retrievalScore` plus any
@@ -259,6 +260,7 @@ export async function query(
 				sourceType: m.entry.metadata.sourceType ?? "unknown",
 				source: m.entry.metadata.source ?? "unknown",
 				sourceUrl: m.entry.metadata.sourceUrl,
+				documentId: m.entry.metadata.documentId || undefined,
 				storageId: m.entry.storageId,
 				score: boostedScore,
 				retrievalScore,


### PR DESCRIPTION
## Summary

- Replaces legacy substring-based evidence gate with exact-match `Chunk.documentId` identity gate when corpus catalog confirms `expectedEvidence.artifactId` is a real documentId
- Falls back to substring for unmigrated queries (no breaking change)
- Routes failure-diagnosis Rule 6 on the active gate so stale-substring failures no longer masquerade as answer-synthesis

## Why

Phase A forensics (#343 P0) found ~57% of \"ranking\" failures were scorer/diagnosis misattribution. A core driver: queries whose required `artifactId` substring-matched `result.source` but whose canonical documentId never surfaced were passing the evidence gate. Loop's reward signal was structurally corrupted.

This is PR 1 of 3 in the Phase A Tier 0 hygiene sequence (gemini-recommended order). PR 2 = score-aware hard-negative gate. PR 3 = goldRank=null → retrieval-miss attribution.

## Mechanics

- `mount.ts` propagates `chunk.documentId` into vector metadata
- `query.ts` surfaces `documentId` on each `QueryResult.results[]`
- `quality-queries-evaluator.ts` builds `catalogDocumentIds` once per call and threads it through `scoreText`. `evidencePass = canonical ? documentIdFound : substringFound`
- `failure-diagnosis.ts` Rule 6 consults the active gate

Both `documentIdFound` and `substringFound` are emitted on every score for triage transparency.

## Test plan

- [x] `pnpm test` — 1847 passed, 0 failed
- [x] `pnpm -r build` — clean
- [x] `pnpm lint:fix` — clean
- [x] New tests cover canonical-substring-fail, canonical-documentId-pass, and legacy-fallback paths
- [x] Diagnosis test for Rule 6 routing under canonical gate
- [ ] Sweep against filoz-v12 + wtfoc-v3 to measure how many prior \"ranking\" failures move under the canonical gate (post-merge)

Refs #343, #344