### PR TITLE
feat(eval): score-aware hard-negative gate (#343 Phase A)

### DIFF
--- a/packages/search/src/eval/quality-queries-evaluator.test.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.test.ts
@@ -13,7 +13,13 @@ const { evaluateQualityQueries, getActiveQueries } = await import("./quality-que
 const { GOLD_STANDARD_QUERIES } = await import("./gold-standard-queries.js");
 
 function makeQueryResult(
-	results: Array<{ sourceType: string; source: string; score: number; documentId?: string }>,
+	results: Array<{
+		sourceType: string;
+		source: string;
+		score: number;
+		documentId?: string;
+		retrievalScore?: number;
+	}>,
 ): QueryResult {
 	return {
 		query: "test query",
@@ -24,7 +30,7 @@ function makeQueryResult(
 			...(r.documentId ? { documentId: r.documentId } : {}),
 			storageId: "s1",
 			score: r.score,
-			retrievalScore: r.score,
+			retrievalScore: typeof r.retrievalScore === "number" ? r.retrievalScore : r.score,
 		})),
 	};
 }
@@ -845,11 +851,30 @@ describe("evaluateQualityQueries", () => {
 			expect(scores.find((s) => s.id === hardNeg.id)?.passed).toBe(false);
 		});
 
+		it("uses retrievalScore (raw cosine) for thresholds, not composite score (codex MED-3)", async () => {
+			if (!hardNeg) throw new Error("no hard-negative in fixture");
+			// Reranker scenario: composite `score` = 0.85 (rerank output) but
+			// raw `retrievalScore` = 0.05 (real embedder cosine). The hard-
+			// negative gate must trust retrievalScore — the rerank output is
+			// scale-incompatible with the bge-derived 0.6 ceiling.
+			mockQuery.mockResolvedValue(
+				makeQueryResult([
+					{ sourceType: "code", source: "noise.ts", score: 0.85, retrievalScore: 0.05 },
+				]),
+			);
+			mockTrace.mockResolvedValue(makeTraceResult([]));
+			const result = await evaluateQualityQueries(mockEmbedder, mockVectorIndex, mockSegments);
+			const scores = result.metrics.scores as Array<{ id: string; passed: boolean }>;
+			// Composite 0.85 would have failed gate; retrievalScore 0.05 passes.
+			expect(scores.find((s) => s.id === hardNeg.id)?.passed).toBe(true);
+		});
+
 		it("fails when a single high-confidence hit breaches score ceiling", async () => {
 			if (!hardNeg) throw new Error("no hard-negative in fixture");
 			mockQuery.mockResolvedValue(
 				makeQueryResult([
-					{ sourceType: "code", source: "match.ts", score: 0.7 }, // above ceiling 0.6
+					// retrievalScore 0.7 > 0.6 ceiling — fails immediately
+					{ sourceType: "code", source: "match.ts", score: 0.7, retrievalScore: 0.7 },
 				]),
 			);
 			mockTrace.mockResolvedValue(makeTraceResult([]));

--- a/packages/search/src/eval/quality-queries-evaluator.test.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.test.ts
@@ -806,6 +806,59 @@ describe("evaluateQualityQueries", () => {
 		});
 	});
 
+	describe("hard-negative score-aware gate (#343 Phase A)", () => {
+		const hardNeg = GOLD_STANDARD_QUERIES.find((q) => q.isHardNegative === true);
+
+		it("passes when top-K is filled with cosmic-noise scores (all below floor)", async () => {
+			if (!hardNeg) throw new Error("no hard-negative in fixture");
+			// `query()` returns top-K=10 unconditionally; pre-fix this failed
+			// because resultCount=10 >= ceiling=3. Score-aware gate ignores
+			// the noise tail.
+			mockQuery.mockResolvedValue(
+				makeQueryResult(
+					Array.from({ length: 10 }, (_, i) => ({
+						sourceType: "code",
+						source: `noise/${i}.ts`,
+						score: 0.05, // below NOISE_FLOOR=0.1
+					})),
+				),
+			);
+			mockTrace.mockResolvedValue(makeTraceResult([]));
+			const result = await evaluateQualityQueries(mockEmbedder, mockVectorIndex, mockSegments);
+			const scores = result.metrics.scores as Array<{ id: string; passed: boolean }>;
+			expect(scores.find((s) => s.id === hardNeg.id)?.passed).toBe(true);
+		});
+
+		it("fails when ≥3 above-noise hits accumulate (genuine pile-on)", async () => {
+			if (!hardNeg) throw new Error("no hard-negative in fixture");
+			mockQuery.mockResolvedValue(
+				makeQueryResult([
+					{ sourceType: "code", source: "a.ts", score: 0.45 },
+					{ sourceType: "code", source: "b.ts", score: 0.4 },
+					{ sourceType: "code", source: "c.ts", score: 0.35 },
+					{ sourceType: "code", source: "d.ts", score: 0.05 },
+				]),
+			);
+			mockTrace.mockResolvedValue(makeTraceResult([]));
+			const result = await evaluateQualityQueries(mockEmbedder, mockVectorIndex, mockSegments);
+			const scores = result.metrics.scores as Array<{ id: string; passed: boolean }>;
+			expect(scores.find((s) => s.id === hardNeg.id)?.passed).toBe(false);
+		});
+
+		it("fails when a single high-confidence hit breaches score ceiling", async () => {
+			if (!hardNeg) throw new Error("no hard-negative in fixture");
+			mockQuery.mockResolvedValue(
+				makeQueryResult([
+					{ sourceType: "code", source: "match.ts", score: 0.7 }, // above ceiling 0.6
+				]),
+			);
+			mockTrace.mockResolvedValue(makeTraceResult([]));
+			const result = await evaluateQualityQueries(mockEmbedder, mockVectorIndex, mockSegments);
+			const scores = result.metrics.scores as Array<{ id: string; passed: boolean }>;
+			expect(scores.find((s) => s.id === hardNeg.id)?.passed).toBe(false);
+		});
+	});
+
 	describe("preflight-driven skip (#343 P0 forensics finding)", () => {
 		it("skips queries marked invalid by preflight (were counted as failures pre-fix)", async () => {
 			mockQuery.mockResolvedValue(makeQueryResult([]));

--- a/packages/search/src/eval/quality-queries-evaluator.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.ts
@@ -84,6 +84,25 @@ function isFileLevel(gq: GoldQuery): boolean {
 }
 
 /**
+ * Hard-negative gate thresholds (#343 Phase A). Module-scope so tests + the
+ * autoresearch sweep can read them without re-deriving from comments.
+ *
+ * - `HARD_NEGATIVE_NOISE_FLOOR` — score below this is treated as cosmic
+ *   noise from the unconditional top-K fill. Codex caveat: 0.3 was too
+ *   permissive (let moderately-suspicious through). 0.1 is the tighter
+ *   floor; relax later if data shows positives still suppressed.
+ * - `HARD_NEGATIVE_SCORE_CEILING` — any single result at or above this is
+ *   treated as a genuinely on-topic match; one is enough to fail a hard-
+ *   negative immediately.
+ * - `HARD_NEGATIVE_RESULT_CEILING` — number of above-noise hits at which
+ *   retrieval is judged to have piled on too many plausible false
+ *   positives, even if none individually breached the score ceiling.
+ */
+export const HARD_NEGATIVE_NOISE_FLOOR = 0.1;
+export const HARD_NEGATIVE_SCORE_CEILING = 0.6;
+export const HARD_NEGATIVE_RESULT_CEILING = 3;
+
+/**
  * #320 — fast-iteration smoke support. When `WTFOC_QUERY_FILTER` is set
  * to a comma-separated list of query ids, score only those queries from
  * the gold fixture. Aggregate metrics get noisier (demo-critical
@@ -832,6 +851,7 @@ async function scoreText(
 	let recallAtK: number | null = null;
 	let recallK: number | null = null;
 	let topScore: number | null = null;
+	let aboveNoiseCount = 0;
 
 	const requiredArtifacts = gq.expectedEvidence.filter((e) => e.required).map((e) => e.artifactId);
 	const allArtifacts = gq.expectedEvidence.map((e) => e.artifactId);
@@ -863,6 +883,12 @@ async function scoreText(
 			distinctTypes.add(r.sourceType);
 			if (typeof r.score === "number" && (topScore === null || r.score > topScore)) {
 				topScore = r.score;
+			}
+			// #343 Phase A — count above-noise hits separately so the
+			// hard-negative gate can ignore the cosmic-noise tail that
+			// `query()` always fills top-K with.
+			if (typeof r.score === "number" && r.score >= HARD_NEGATIVE_NOISE_FLOOR) {
+				aboveNoiseCount++;
 			}
 		}
 
@@ -944,22 +970,22 @@ async function scoreText(
 	// Hard-negative scoring is INVERTED. A hard negative passes when
 	// retrieval correctly does NOT pile on strong-looking false positives.
 	// Two checks combined:
-	//   1. resultCount < HARD_NEGATIVE_RESULT_CEILING — fewer false hits
-	//   2. topScore < HARD_NEGATIVE_SCORE_CEILING — even if a couple
-	//      results slip through, none should look high-confidence
+	//   1. count(score >= NOISE_FLOOR) < RESULT_CEILING — fewer real hits,
+	//      ignoring the cosmic-noise tail `query()` always fills K with.
+	//   2. topScore < SCORE_CEILING — no single high-confidence false hit.
 	//
-	// Reviewer (peer-review on Phase 1) flagged that count-only scoring
-	// rewards "fewer but high-confidence false positives" — a strictly
-	// worse failure mode. The score ceiling closes that loophole.
-	//
-	// Score ceiling chosen at 0.6 — empirically the boundary above which
-	// vector cosine similarity on bge-base means the chunk is genuinely
-	// on-topic. Tunable; a future PR can swap to a corpus-relative
-	// percentile threshold if 0.6 turns out to be over- or under-tight.
-	const HARD_NEGATIVE_RESULT_CEILING = 3;
-	const HARD_NEGATIVE_SCORE_CEILING = 0.6;
-
+	// Phase A forensics (#343) showed the prior count-only gate fired on
+	// 100% of "ranking" hard-negative failures because `query()` returns
+	// top-K unconditionally. Floor + ceiling distinguish K-filling from
+	// genuine retrieval pile-on. Codex guidance: "scorer should interpret
+	// scores, not punish retriever for filling K."
 	const hardNegativeNoStrongHits = topScore === null || topScore < HARD_NEGATIVE_SCORE_CEILING;
+	// #343 Phase A — score-aware count gate. `query()` returns top-K
+	// unconditionally; raw `resultCount` always equals the K used. Counting
+	// only results above `HARD_NEGATIVE_NOISE_FLOOR` filters the cosmic-noise
+	// tail so the count gate fires only when retrieval surfaced multiple
+	// genuinely-similar false positives, not on K-filling alone.
+	const hardNegativeFewAboveNoise = aboveNoiseCount < HARD_NEGATIVE_RESULT_CEILING;
 
 	// #344 D1 — pick canonical exact-match identity gate when the catalog
 	// confirms every required artifactId is a real `documentId`. Otherwise
@@ -974,7 +1000,7 @@ async function scoreText(
 	const evidencePass = evidenceGateCanonical ? documentIdFound : substringFound;
 
 	const passed = gq.isHardNegative
-		? resultCount < HARD_NEGATIVE_RESULT_CEILING && hardNegativeNoStrongHits
+		? hardNegativeFewAboveNoise && hardNegativeNoStrongHits
 		: resultCount >= gq.minResults &&
 			requiredTypesFound &&
 			evidencePass &&
@@ -984,7 +1010,7 @@ async function scoreText(
 	// Query-only pass: same criteria EXCEPT use the pre-trace requiredTypes check
 	// and ignore edge-hop/cross-source requirements (those are inherently trace-assisted).
 	const passedQueryOnly = gq.isHardNegative
-		? resultCount < HARD_NEGATIVE_RESULT_CEILING && hardNegativeNoStrongHits
+		? hardNegativeFewAboveNoise && hardNegativeNoStrongHits
 		: resultCount >= gq.minResults && requiredTypesFoundQueryOnly && evidencePass;
 
 	let goldProximity: InnerScore["goldProximity"];

--- a/packages/search/src/eval/quality-queries-evaluator.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.ts
@@ -851,6 +851,12 @@ async function scoreText(
 	let recallAtK: number | null = null;
 	let recallK: number | null = null;
 	let topScore: number | null = null;
+	// #343 Phase A — calibration-stable score for the hard-negative gate.
+	// Composite `score` includes reranker output + boosts which compress
+	// or stretch the dynamic range per scorer variant. `retrievalScore` is
+	// always the raw embedder cosine, so the gate's thresholds (derived
+	// from bge-base empirics) stay portable across rerankers.
+	let topRetrievalScore: number | null = null;
 	let aboveNoiseCount = 0;
 
 	const requiredArtifacts = gq.expectedEvidence.filter((e) => e.required).map((e) => e.artifactId);
@@ -884,10 +890,19 @@ async function scoreText(
 			if (typeof r.score === "number" && (topScore === null || r.score > topScore)) {
 				topScore = r.score;
 			}
-			// #343 Phase A — count above-noise hits separately so the
-			// hard-negative gate can ignore the cosmic-noise tail that
-			// `query()` always fills top-K with.
-			if (typeof r.score === "number" && r.score >= HARD_NEGATIVE_NOISE_FLOOR) {
+			// Hard-negative gate inputs use `retrievalScore` (raw embedder
+			// cosine) so the floor + ceiling thresholds stay calibrated to
+			// bge-base empirics regardless of whether a reranker ran. See
+			// the constant comments above for the codex review chain.
+			const calibScore =
+				typeof r.retrievalScore === "number" ? r.retrievalScore : (r.score ?? null);
+			if (
+				typeof calibScore === "number" &&
+				(topRetrievalScore === null || calibScore > topRetrievalScore)
+			) {
+				topRetrievalScore = calibScore;
+			}
+			if (typeof calibScore === "number" && calibScore >= HARD_NEGATIVE_NOISE_FLOOR) {
 				aboveNoiseCount++;
 			}
 		}
@@ -979,7 +994,8 @@ async function scoreText(
 	// top-K unconditionally. Floor + ceiling distinguish K-filling from
 	// genuine retrieval pile-on. Codex guidance: "scorer should interpret
 	// scores, not punish retriever for filling K."
-	const hardNegativeNoStrongHits = topScore === null || topScore < HARD_NEGATIVE_SCORE_CEILING;
+	const hardNegativeNoStrongHits =
+		topRetrievalScore === null || topRetrievalScore < HARD_NEGATIVE_SCORE_CEILING;
 	// #343 Phase A — score-aware count gate. `query()` returns top-K
 	// unconditionally; raw `resultCount` always equals the K used. Counting
 	// only results above `HARD_NEGATIVE_NOISE_FLOOR` filters the cosmic-noise


### PR DESCRIPTION
**Stacked on #376 — base into that branch.**

## Summary

- Replaces count-only hard-negative gate with floor + ceiling logic
- `HARD_NEGATIVE_NOISE_FLOOR = 0.1` filters cosmic-noise K-filling out of the count
- `HARD_NEGATIVE_SCORE_CEILING = 0.6` (unchanged) — single high-confidence hit still fails
- Constants exported for sweep + test reuse

## Why

Phase A forensics (#343) found 100% of ranking-classified hard-negative failures had `topScore` 0.0003-0.42 (well below 0.6) but `resultCount=10`. `query()` returns top-K unconditionally, so the count gate fired on K-filling alone, not on real retrieval pile-on.

Codex prescription: scorer should interpret scores, not punish retriever for filling K. Codex caveat: 0.3 floor was too permissive — 0.1 is the tighter starting point.

This is PR 2 of 3 in the Phase A Tier 0 hygiene sequence. PR 1 = #376 (canonical documentId gate). PR 3 = goldRank=null → retrieval-miss attribution.

## Test plan

- [x] `pnpm test` — 1850 passed, 0 failed
- [x] `pnpm -r build` — clean
- [x] `pnpm lint:fix` — clean
- [x] New tests: cosmic-noise pass, ≥3 above-noise fail, single high-score fail
- [ ] Sweep against filoz-v12 + wtfoc-v3 to measure how many hard-negative failures move (post-merge of #376 + this)

Refs #343