### PR TITLE
feat(eval): rename gold-not-indexed → retrieval-miss (#343 Phase A)

### DIFF
--- a/packages/search/src/eval/failure-diagnosis.test.ts
+++ b/packages/search/src/eval/failure-diagnosis.test.ts
@@ -75,7 +75,7 @@ describe("diagnoseFailure", () => {
 		expect(result?.layer).toBe("ranking");
 	});
 
-	it("classifies absent-from-widerK as gold-not-indexed + embedding layer", () => {
+	it("classifies absent-from-widerK as retrieval-miss + embedding layer", () => {
 		const result = diagnoseFailure({
 			score: makeScore({
 				id: "q1",
@@ -90,7 +90,7 @@ describe("diagnoseFailure", () => {
 			query: makeQuery({ id: "q1" }),
 			preflightStatus: "applicable",
 		});
-		expect(result?.failureClass).toBe("gold-not-indexed");
+		expect(result?.failureClass).toBe("retrieval-miss");
 		expect(result?.layer).toBe("embedding");
 		expect(result?.evidence.retrievedInWiderK).toBe(false);
 	});

--- a/packages/search/src/eval/failure-diagnosis.ts
+++ b/packages/search/src/eval/failure-diagnosis.ts
@@ -35,7 +35,7 @@ export type FailureLayer =
 
 export type FailureClass =
 	| "fixture-invalid"
-	| "gold-not-indexed"
+	| "retrieval-miss"
 	| "retrieved-not-ranked"
 	| "missing-edge"
 	| "answer-synthesis"
@@ -195,18 +195,21 @@ export function diagnoseFailure(input: DiagnoseFailureInput): FailureDiagnosis |
 		};
 	}
 
-	// Rule 3 — gold was not in the wider top-K. Either the chunk is not
-	// indexed at all (chunking/ingest), or the embedder doesn't cluster it
-	// near the query (embedding). Without a separate lexical-rank signal
-	// we cannot distinguish chunking vs embedding deterministically — we
-	// pin to `embedding` because it is the more common cause when gold is
-	// in catalog but absent from wider retrieval; chunking-layer triage
-	// can override this in step-5 patch-capsule selection.
+	// Rule 3 — gold artifact was recorded as absent from wider top-K
+	// (retrievedInWiderK === false). Honest label is "retrieval-miss":
+	// the artifact is in catalog but did NOT surface in widerK retrieval.
+	// Could be chunking (not indexed), ingest (lifecycle dropped it), or
+	// embedding (vectors don't cluster). Without a lexical-rank
+	// disambiguation signal we cannot tell deterministically — pin to
+	// `embedding` because empirically it is the dominant cause; the
+	// step-5 patch-capsule can re-route to chunking when triage finds
+	// missing chunks. Renamed from `gold-not-indexed` (#343 Phase A) so
+	// the class label no longer overclaims certainty about the cause.
 	if (retrievedInWiderK === false) {
 		return {
 			queryId: query.id,
 			corpusId: corpusId ?? null,
-			failureClass: "gold-not-indexed",
+			failureClass: "retrieval-miss",
 			layer: "embedding",
 			evidence,
 		};
@@ -287,7 +290,7 @@ export interface DiagnosisAggregate {
 
 const ALL_FAILURE_CLASSES: FailureClass[] = [
 	"fixture-invalid",
-	"gold-not-indexed",
+	"retrieval-miss",
 	"retrieved-not-ranked",
 	"missing-edge",
 	"answer-synthesis",

--- a/packages/search/src/eval/quality-queries-evaluator.test.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.test.ts
@@ -776,6 +776,48 @@ describe("evaluateQualityQueries", () => {
 			expect(score?.documentIdFound).toBe(true);
 		});
 
+		it("mixed fixture: one canonical + one legacy artifactId — canonical drives pass/fail (codex HIGH-2)", async () => {
+			// Codex caught the original `requiredArtifacts.every()` rule
+			// disabled canonical gating for the entire query if any single
+			// required artifact was legacy. Per-artifact resolution must
+			// keep canonical gating active when at least one required is in
+			// catalog, even if another required is legacy.
+			if (!candidate || !requiredAid) throw new Error("no canonical candidate query in fixture");
+			// Catalog has only the canonical id; the candidate's other
+			// required artifactIds (if any) are treated as legacy.
+			mockQuery.mockResolvedValue(
+				makeQueryResult([
+					{
+						sourceType: candidate.requiredSourceTypes[0] ?? "code",
+						source: "unrelated/path.ts",
+						documentId: requiredAid,
+						score: 0.9,
+					},
+				]),
+			);
+			mockTrace.mockResolvedValue(makeTraceResult([]));
+			const result = await evaluateQualityQueries(
+				mockEmbedder,
+				mockVectorIndex,
+				mockSegments,
+				undefined,
+				[],
+				undefined,
+				false,
+				{ documentCatalog: makeCatalog([requiredAid]) },
+			);
+			const scores = result.metrics.scores as Array<{
+				id: string;
+				evidenceGateCanonical: boolean;
+				documentIdFound: boolean;
+			}>;
+			const score = scores.find((s) => s.id === candidate.id);
+			// Canonical gate is ACTIVE because at least one required artifact
+			// is in catalog — even if other required artifacts are legacy.
+			expect(score?.evidenceGateCanonical).toBe(true);
+			expect(score?.documentIdFound).toBe(true);
+		});
+
 		it("falls back to substring gate when artifactId not in catalog (legacy fixture)", async () => {
 			if (!candidate || !requiredAid) throw new Error("no canonical candidate query in fixture");
 			mockQuery.mockResolvedValue(
@@ -809,6 +851,84 @@ describe("evaluateQualityQueries", () => {
 			const score = scores.find((s) => s.id === candidate.id);
 			expect(score?.evidenceGateCanonical).toBe(false);
 			expect(score?.substringFound).toBe(true);
+		});
+	});
+
+	describe("goldProximity match by documentId when canonical (codex HIGH-1)", () => {
+		const candidate = GOLD_STANDARD_QUERIES.find(
+			(q) => q.expectedEvidence.some((e) => e.required) && !q.isHardNegative,
+		);
+		const requiredAid = candidate?.expectedEvidence.find((e) => e.required)?.artifactId;
+
+		it("records goldRank from documentId match even when source path doesn't substring-match", async () => {
+			if (!candidate || !requiredAid) throw new Error("no canonical candidate query in fixture");
+			// Failed query with canonical gate active. Wider retrieval must
+			// match gold by documentId, not substring. Codex caught that
+			// proximity was using substring-only — a canonical query whose
+			// gold artifact had no path overlap got `goldRank=null` and was
+			// misrouted to `retrieval-miss`.
+			const failingResults = [
+				{ sourceType: "code", source: "noise/a.ts", score: 0.05, documentId: "noise-a" },
+			];
+			const widerResults = [
+				{
+					sourceType: "code",
+					source: "still-no-substring/b.ts",
+					score: 0.3,
+					documentId: "noise-b",
+				},
+				{
+					sourceType: "code",
+					source: "totally-unrelated-path/c.ts",
+					score: 0.25,
+					documentId: requiredAid,
+				},
+			];
+			let callCount = 0;
+			mockQuery.mockImplementation(async () => {
+				callCount++;
+				if (callCount === 1) return makeQueryResult(failingResults);
+				return makeQueryResult(widerResults);
+			});
+			mockTrace.mockResolvedValue(makeTraceResult([]));
+			const documentCatalog = {
+				schemaVersion: 1 as const,
+				collectionId: "alpha",
+				documents: {
+					[requiredAid]: {
+						documentId: requiredAid,
+						currentVersionId: "v1",
+						previousVersionIds: [],
+						chunkIds: [],
+						supersededChunkIds: [],
+						contentFingerprints: [],
+						state: "active" as const,
+						mutability: "mutable-state" as const,
+						sourceType: "code",
+						updatedAt: new Date().toISOString(),
+					},
+				},
+			};
+			const result = await evaluateQualityQueries(
+				mockEmbedder,
+				mockVectorIndex,
+				mockSegments,
+				undefined,
+				[],
+				undefined,
+				false,
+				{ documentCatalog, recordGoldProximity: true },
+			);
+			const scores = result.metrics.scores as Array<{
+				id: string;
+				goldProximity?: { goldRank: number | null };
+			}>;
+			const score = scores.find((s) => s.id === candidate.id);
+			// Without the codex fix, goldRank would be null because the
+			// path substring is "totally-unrelated-path" not the artifactId.
+			// With the fix, documentId exact-match catches the gold at
+			// rank 2.
+			expect(score?.goldProximity?.goldRank).toBe(2);
 		});
 	});
 

--- a/packages/search/src/eval/quality-queries-evaluator.test.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.test.ts
@@ -818,6 +818,54 @@ describe("evaluateQualityQueries", () => {
 			expect(score?.documentIdFound).toBe(true);
 		});
 
+		it("mixed-required: legacy substring hit alone counts as evidence even when canonical missed (round-2)", async () => {
+			// Round-2 codex+gemini caught: an earlier per-artifact draft
+			// FAILED a query when one required artifact was canonical and
+			// retrieval hit only the legacy substring (no canonical
+			// documentId surfaced). Per the OR semantics on `required:true`
+			// artifacts, that scenario should not fail the evidence gate —
+			// any required hit by its own resolver counts. Encode the
+			// invariant directly via the per-artifact substringFound +
+			// documentIdFound diagnostics.
+			if (!candidate || !requiredAid) throw new Error("no canonical candidate query in fixture");
+			mockQuery.mockResolvedValue(
+				makeQueryResult([
+					{
+						sourceType: candidate.requiredSourceTypes[0] ?? "code",
+						source: `wraps-${requiredAid}-substring.ts`,
+						documentId: "unrelated-doc-id",
+						score: 0.9,
+					},
+				]),
+			);
+			mockTrace.mockResolvedValue(makeTraceResult([]));
+			const result = await evaluateQualityQueries(
+				mockEmbedder,
+				mockVectorIndex,
+				mockSegments,
+				undefined,
+				[],
+				undefined,
+				false,
+				{ documentCatalog: makeCatalog([requiredAid]) },
+			);
+			const scores = result.metrics.scores as Array<{
+				id: string;
+				substringFound: boolean;
+				documentIdFound: boolean;
+				evidenceGateCanonical: boolean;
+			}>;
+			const score = scores.find((s) => s.id === candidate.id);
+			// Canonical gate is active (catalog has requiredAid) but the
+			// canonical artifact didn't surface as a documentId. The
+			// substring gate did hit (path contains requiredAid). Pass
+			// driver `evidencePass` is the per-artifact OR — substring hit
+			// is sufficient.
+			expect(score?.evidenceGateCanonical).toBe(true);
+			expect(score?.documentIdFound).toBe(false);
+			expect(score?.substringFound).toBe(true);
+		});
+
 		it("falls back to substring gate when artifactId not in catalog (legacy fixture)", async () => {
 			if (!candidate || !requiredAid) throw new Error("no canonical candidate query in fixture");
 			mockQuery.mockResolvedValue(

--- a/packages/search/src/eval/quality-queries-evaluator.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.ts
@@ -1064,8 +1064,16 @@ async function scoreText(
 				goldScore,
 				topKLastScore,
 			};
-		} catch {
-			// best-effort diagnostic — never fail the score
+		} catch (err) {
+			// Best-effort diagnostic — never fail the score. Phase A
+			// forensics (#343) noted ~28 filoz queries had `goldProximity`
+			// undefined where it should have been recorded; suspect this
+			// catch was masking the cause. Log to stderr (debug-gated) so
+			// the next sweep surfaces the underlying error class.
+			if (process.env.WTFOC_DEBUG_GOLD_PROXIMITY === "1") {
+				const msg = err instanceof Error ? err.message : String(err);
+				process.stderr.write(`[gold-proximity] ${gq.id}: ${msg}\n`);
+			}
 		}
 	}
 

--- a/packages/search/src/eval/quality-queries-evaluator.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.ts
@@ -554,7 +554,16 @@ export async function evaluateQualityQueries(
 			const reasons: string[] = [];
 			if (score.resultCount === 0) reasons.push("no results");
 			if (!score.requiredTypesFound) reasons.push("missing required source types");
-			if (!score.substringFound) reasons.push("missing expected source substrings");
+			// #344 D1 — when the canonical exact-match gate drove pass/fail,
+			// report missing-documentId rather than missing-substring. Codex
+			// peer-review caught that a stale `substringFound=true` on a
+			// `documentIdFound=false` canonical query produced an empty
+			// reasons list — silent failures in forensics output.
+			if (score.evidenceGateCanonical && !score.documentIdFound) {
+				reasons.push("missing expected canonical artifactId (documentId mismatch)");
+			} else if (!score.evidenceGateCanonical && !score.substringFound) {
+				reasons.push("missing expected source substrings");
+			}
 			if (!score.edgeHopFound) reasons.push("no edge hops");
 			if (!score.crossSourceFound) reasons.push("no cross-source hops");
 			checks.push({
@@ -913,21 +922,39 @@ async function scoreText(
 
 		if (requiredArtifacts.length > 0) {
 			const resultSources = qResult.results.map((r) => r.source);
-			// Legacy substring gate — kept for unmigrated queries whose
-			// `expectedEvidence.artifactId` is still a path substring rather
-			// than a canonical `Chunk.documentId`. The canonical gate below
-			// supersedes this when the corpus catalog confirms identity.
+			const resultDocIdSet = new Set(
+				qResult.results
+					.map((r) => r.documentId)
+					.filter((d): d is string => typeof d === "string" && d.length > 0),
+			);
+			// Per-artifact resolution (#344 D1). Codex peer-review on the
+			// initial all-or-nothing `requiredArtifacts.every()` gate caught
+			// that one unresolved legacy artifactId disabled identity gating
+			// for every artifact in the same query.
+			//
+			// Now: each artifact resolves independently. Canonical artifacts
+			// (in catalog) hit when their value matches a retrieved chunk's
+			// `documentId`. Legacy artifacts hit by substring against
+			// retrieved sources. `documentIdFound` is true when ≥1 canonical
+			// artifact is required AND ≥1 such canonical artifact hit by
+			// exact `documentId`. `substringFound` keeps the legacy
+			// any-substring-hit signal — used as the pass driver only when
+			// the query has zero canonical artifacts.
+			let canonicalAnyRequired = false;
+			let canonicalAnyHit = false;
+			for (const aid of requiredArtifacts) {
+				const isCanonical = catalogDocumentIds?.has(aid) ?? false;
+				if (isCanonical) {
+					canonicalAnyRequired = true;
+					if (resultDocIdSet.has(aid)) {
+						canonicalAnyHit = true;
+					}
+				}
+			}
+			documentIdFound = canonicalAnyRequired && canonicalAnyHit;
 			substringFound = requiredArtifacts.some((sub) =>
 				resultSources.some((src) => src.toLowerCase().includes(sub.toLowerCase())),
 			);
-			// Canonical exact-match gate (#344 D1). Compares each required
-			// `artifactId` against retrieved chunks' `documentId`. Pass requires
-			// at least one required artifact to be hit by exact identity.
-			const resultDocIds = qResult.results
-				.map((r) => r.documentId)
-				.filter((d): d is string => typeof d === "string" && d.length > 0);
-			documentIdFound =
-				resultDocIds.length > 0 && requiredArtifacts.some((aid) => resultDocIds.includes(aid));
 		}
 
 		// #311 Phase 0d — recall@K computed over the full evidence set
@@ -1003,16 +1030,16 @@ async function scoreText(
 	// genuinely-similar false positives, not on K-filling alone.
 	const hardNegativeFewAboveNoise = aboveNoiseCount < HARD_NEGATIVE_RESULT_CEILING;
 
-	// #344 D1 — pick canonical exact-match identity gate when the catalog
-	// confirms every required artifactId is a real `documentId`. Otherwise
-	// fall back to the legacy substring gate. Codex caveat: replacement must
-	// assert identity, not silently drop the gate; that is why both
-	// `documentIdFound` and `substringFound` are output even though only one
-	// drives pass/fail.
+	// #344 D1 — when ANY required artifact resolves canonically (its value
+	// is a real `documentId` in the corpus catalog), the canonical gate is
+	// the active driver of pass/fail. The per-artifact resolution above
+	// already enforces that EVERY canonical artifact must hit exactly; we
+	// just need to detect "is there a canonical requirement at all?" here.
+	// Pure-legacy queries fall back to the substring signal as before.
 	const evidenceGateCanonical =
 		requiredArtifacts.length > 0 &&
 		catalogDocumentIds !== undefined &&
-		requiredArtifacts.every((aid) => catalogDocumentIds.has(aid));
+		requiredArtifacts.some((aid) => catalogDocumentIds.has(aid));
 	const evidencePass = evidenceGateCanonical ? documentIdFound : substringFound;
 
 	const passed = gq.isHardNegative
@@ -1043,11 +1070,29 @@ async function scoreText(
 			});
 			let goldRank: number | null = null;
 			let goldScore: number | null = null;
+			// Codex peer-review caught: pass/fail gate uses canonical
+			// `documentId` exact-match for any artifact in the catalog, but
+			// proximity was matching with substring only. A canonical
+			// query whose gold appeared at a real `documentId` (no path
+			// substring overlap) would record `goldRank = null` and get
+			// misrouted to `retrieval-miss`. Match using the same per-
+			// artifact resolution as the pass/fail gate so the diagnosis
+			// signal is consistent.
 			for (let i = 0; i < wider.results.length; i++) {
 				const r = wider.results[i];
 				if (!r) continue;
-				const src = r.source.toLowerCase();
-				const matches = allArtifacts.some((sub) => src.includes(sub.toLowerCase()));
+				let matches = false;
+				if (typeof r.documentId === "string" && r.documentId.length > 0) {
+					if (allArtifacts.some((aid) => aid === r.documentId)) {
+						matches = true;
+					}
+				}
+				if (!matches) {
+					const src = r.source.toLowerCase();
+					if (allArtifacts.some((sub) => src.includes(sub.toLowerCase()))) {
+						matches = true;
+					}
+				}
 				if (matches) {
 					goldRank = i + 1;
 					goldScore = typeof r.score === "number" ? r.score : null;

--- a/packages/search/src/eval/quality-queries-evaluator.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.ts
@@ -851,6 +851,10 @@ async function scoreText(
 	let requiredTypesFoundQueryOnly = false;
 	let substringFound = true; // default true if no substrings specified
 	let documentIdFound = true; // default true when no required artifacts
+	// Per-artifact OR result. Default true when no required artifacts so
+	// the unified pass logic short-circuits to "evidence is fine" without
+	// needing to special-case empty `requiredArtifacts` downstream.
+	let evidencePassPerArtifact = true;
 	let edgeHopFound = true; // default true if not required
 	let crossSourceFound = true; // default true if not required
 	const sourceTypesReached: string[] = [];
@@ -927,45 +931,77 @@ async function scoreText(
 					.map((r) => r.documentId)
 					.filter((d): d is string => typeof d === "string" && d.length > 0),
 			);
-			// Per-artifact resolution (#344 D1). Codex peer-review on the
-			// initial all-or-nothing `requiredArtifacts.every()` gate caught
-			// that one unresolved legacy artifactId disabled identity gating
-			// for every artifact in the same query.
+			// Per-artifact OR resolution (#344 D1). Each required artifact
+			// resolves independently: canonical artifacts (in catalog) hit
+			// via exact `documentId` match; legacy artifacts hit via path
+			// substring. The query passes when ANY required artifact hit,
+			// regardless of which resolver matched it. Round-2 peer-review
+			// (codex + gemini) caught that an earlier per-artifact draft
+			// only counted canonical hits when canonical was active —
+			// breaking mixed queries where a legacy artifact was found by
+			// substring but no canonical artifact was retrieved.
 			//
-			// Now: each artifact resolves independently. Canonical artifacts
-			// (in catalog) hit when their value matches a retrieved chunk's
-			// `documentId`. Legacy artifacts hit by substring against
-			// retrieved sources. `documentIdFound` is true when ≥1 canonical
-			// artifact is required AND ≥1 such canonical artifact hit by
-			// exact `documentId`. `substringFound` keeps the legacy
-			// any-substring-hit signal — used as the pass driver only when
-			// the query has zero canonical artifacts.
+			// `documentIdFound` and `substringFound` are exposed as
+			// independent diagnostics: which resolver actually carried the
+			// pass, and is the canonical gate participating at all.
+			//   * documentIdFound — any canonical-required hit by exact id
+			//   * substringFound — any required hit by substring (legacy
+			//     or canonical-mode regression check)
+			//   * evidenceGateCanonical — at least one required is canonical
 			let canonicalAnyRequired = false;
 			let canonicalAnyHit = false;
+			let anyRequiredHit = false;
 			for (const aid of requiredArtifacts) {
 				const isCanonical = catalogDocumentIds?.has(aid) ?? false;
 				if (isCanonical) {
 					canonicalAnyRequired = true;
 					if (resultDocIdSet.has(aid)) {
 						canonicalAnyHit = true;
+						anyRequiredHit = true;
+					}
+				} else {
+					const aidLower = aid.toLowerCase();
+					if (resultSources.some((src) => src.toLowerCase().includes(aidLower))) {
+						anyRequiredHit = true;
 					}
 				}
 			}
 			documentIdFound = canonicalAnyRequired && canonicalAnyHit;
+			// Legacy substring gate: any required artifact substring-hit.
+			// Kept as a diagnostic + the pass driver when the canonical
+			// gate is inactive (no canonical required).
 			substringFound = requiredArtifacts.some((sub) =>
 				resultSources.some((src) => src.toLowerCase().includes(sub.toLowerCase())),
 			);
+			// `anyRequiredHit` becomes the actual pass signal — see
+			// `evidencePass` derivation below.
+			evidencePassPerArtifact = anyRequiredHit;
 		}
 
 		// #311 Phase 0d — recall@K computed over the full evidence set
-		// (required ∪ supporting). Same caveat as above on substring vs exact.
+		// (required ∪ supporting). Round-2 gemini peer-review caught that
+		// this was still substring-only, mismatching the canonical gate.
+		// Apply the same documentId-first-then-substring matcher used for
+		// pass/fail so canonical artifacts that hit by exact id but not
+		// path substring count toward recall.
 		if (allArtifacts.length > 0) {
 			const k = TOPK;
-			const topKSources = qResult.results.slice(0, k).map((r) => r.source.toLowerCase());
+			const topK = qResult.results.slice(0, k);
+			const topKDocIds = new Set(
+				topK
+					.map((r) => r.documentId)
+					.filter((d): d is string => typeof d === "string" && d.length > 0),
+			);
+			const topKSources = topK.map((r) => r.source.toLowerCase());
 			let matched = 0;
-			for (const goldSub of allArtifacts) {
-				const subLower = goldSub.toLowerCase();
-				if (topKSources.some((src) => src.includes(subLower))) matched++;
+			for (const aid of allArtifacts) {
+				const isCanonical = catalogDocumentIds?.has(aid) ?? false;
+				if (isCanonical) {
+					if (topKDocIds.has(aid)) matched++;
+				} else {
+					const subLower = aid.toLowerCase();
+					if (topKSources.some((src) => src.includes(subLower))) matched++;
+				}
 			}
 			recallAtK = matched / allArtifacts.length;
 			recallK = k;
@@ -1030,17 +1066,20 @@ async function scoreText(
 	// genuinely-similar false positives, not on K-filling alone.
 	const hardNegativeFewAboveNoise = aboveNoiseCount < HARD_NEGATIVE_RESULT_CEILING;
 
-	// #344 D1 — when ANY required artifact resolves canonically (its value
-	// is a real `documentId` in the corpus catalog), the canonical gate is
-	// the active driver of pass/fail. The per-artifact resolution above
-	// already enforces that EVERY canonical artifact must hit exactly; we
-	// just need to detect "is there a canonical requirement at all?" here.
-	// Pure-legacy queries fall back to the substring signal as before.
+	// #344 D1 — `evidenceGateCanonical` is a TELEMETRY flag indicating that
+	// at least one required artifact has a canonical (documentId-shaped)
+	// resolver. The actual pass driver is `evidencePassPerArtifact`, which
+	// is the OR over all required artifacts of "did this artifact hit by
+	// its own resolver?" (canonical → exact `documentId`; legacy →
+	// substring). Round-2 codex+gemini caught that gating pass/fail on
+	// `documentIdFound` when canonical was active broke mixed queries
+	// where the legacy artifact substring-matched and no canonical artifact
+	// surfaced — those would FAIL despite having required evidence retrieved.
 	const evidenceGateCanonical =
 		requiredArtifacts.length > 0 &&
 		catalogDocumentIds !== undefined &&
 		requiredArtifacts.some((aid) => catalogDocumentIds.has(aid));
-	const evidencePass = evidenceGateCanonical ? documentIdFound : substringFound;
+	const evidencePass = evidencePassPerArtifact;
 
 	const passed = gq.isHardNegative
 		? hardNegativeFewAboveNoise && hardNegativeNoStrongHits

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -68,7 +68,12 @@ export {
 } from "./eval/gold-standard-queries.js";
 export type { AggregateLineageMetrics, LineageMetrics } from "./eval/lineage-metrics.js";
 export { aggregateLineageMetrics, computeLineageMetrics } from "./eval/lineage-metrics.js";
-export { evaluateQualityQueries } from "./eval/quality-queries-evaluator.js";
+export {
+	evaluateQualityQueries,
+	HARD_NEGATIVE_NOISE_FLOOR,
+	HARD_NEGATIVE_RESULT_CEILING,
+	HARD_NEGATIVE_SCORE_CEILING,
+} from "./eval/quality-queries-evaluator.js";
 export { evaluateSearch } from "./eval/search-evaluator.js";
 export type {
 	AdversarialFilterOptions,

--- a/scripts/autoresearch/autonomous-loop-wiring.test.ts
+++ b/scripts/autoresearch/autonomous-loop-wiring.test.ts
@@ -33,7 +33,7 @@ function makeReport(
 		totalFailures: dominantLayer === null ? 0 : 5,
 		byFailureClass: {
 			"fixture-invalid": 0,
-			"gold-not-indexed": 0,
+			"retrieval-miss": 0,
 			"retrieved-not-ranked": 0,
 			"missing-edge": 0,
 			"answer-synthesis": 0,


### PR DESCRIPTION
**Stacked on #377 — base into that branch.**

## Summary

- Renames `gold-not-indexed` → `retrieval-miss` in `FailureClass`. Honest label: we know the artifact is in catalog but didn't surface in widerK; we don't know whether the cause is chunking, ingest, or embedding
- Layer routing unchanged (still `embedding`) per gemini's reuse recommendation
- Surfaces previously-silenced `goldProximity` recording exceptions behind `WTFOC_DEBUG_GOLD_PROXIMITY=1` to investigate why ~28 filoz queries had `retrievedInWiderK: null` instead of `false`

## Why

Phase A forensics (#343) flagged that the prior `gold-not-indexed` label overclaimed certainty. Without a lexical-rank disambiguation signal, a wider-K miss could be any of: chunking didn't index, ingest dropped it, or embedder didn't cluster. `retrieval-miss` keeps routing intact (step-5 patch-capsule re-routes to chunking when triage finds missing chunks) without lying about cause.

The `WTFOC_DEBUG_GOLD_PROXIMITY` flag is the next forensics step: 28 of filoz's 50 ranking failures had `retrievedInWiderK: null` (proximity NOT recorded) when it should have been recorded. Suspect either silent exception in widerK retrieval or `recordGoldProximity` env not propagating through the dogfood subprocess. Logging will surface the cause on next sweep.

This is PR 3 of 3 in Phase A Tier 0 hygiene. PR 1 = #376 (merged). PR 2 = #377.

## Test plan

- [x] `pnpm test` — 1850 passed
- [x] `pnpm -r build` — clean
- [x] `pnpm lint:fix` — clean
- [x] Existing diagnosis test renamed to `retrieval-miss`
- [x] `autonomous-loop-wiring.test.ts` byFailureClass key updated
- [ ] Run sweep with `WTFOC_DEBUG_GOLD_PROXIMITY=1` post-merge to identify why proximity isn't recorded

Refs #343