### PR TITLE
fix(autoresearch): address Copilot review on gate 3 seeded positive

### DIFF
--- a/docs/autoresearch/seeded-positives.md
+++ b/docs/autoresearch/seeded-positives.md
@@ -24,7 +24,9 @@ Each entry pins:
 +const TOPK = overrides.topK ?? 30;
 ```
 
-Monotonic retrieval lift: more candidates per query → more chances rubric thresholds met. Cannot reduce pass rate. Reverted on main; lives in candidate runs only.
+Retrieval lift: more candidates per query → more chances rubric thresholds met. Reverted on main; lives in candidate runs only.
+
+**Monotonicity caveat** (Copilot review on PR #386): TOPK is *not* strictly monotonic — `aboveNoiseCount` in the hard-negative gate increments for every retrieved result above `HARD_NEGATIVE_NOISE_FLOOR` (0.1), so a wider top-K can push previously-passing hard-negative queries past `HARD_NEGATIVE_RESULT_CEILING` (3) and flip them pass→fail. Empirically inert here because hard-negatives sit at 0/12 in both baseline and candidate runs (already floored, cannot get worse). A future Phase B retrieval improvement that lifts hard-negative pass rate above 0/12 would need this seam re-validated; document the assumption explicitly so the regression check doesn't silently break.
 
 ### Configuration (held constant across A/B)
 
@@ -85,10 +87,11 @@ All four held: gate 3 PASS.
 - Hard-gate inversions (a Phase B recalibration that pushes a floor above achievable rates)
 - Patch-routing changes that fail to apply a synthetic patch end-to-end
 
-### Why TOPK 10→30 is a valid synthetic positive
+### Why TOPK 10→30 is a valid synthetic positive (current corpus state)
 
 - Real, single-line code change (not a sweep-axis flip)
-- Monotonic — additional candidates can only increase pass rate, never decrease
+- Empirically positive in current state — additional candidates increased pass rate on filoz, dogfood, with zero hard-negative regression because hard-negatives floored at 0/12
+- *Not* unconditionally monotonic — see hard-negative caveat above
 - Independent of the 04-30 audit's known retrieval bugs (no overlap with #314/#327 territory)
 - Cheap to verify (~3-5 min per corpus run)
 - Easy to revert (1 LoC numeric)

--- a/scripts/autoresearch/gate3-seeded-positive.test.ts
+++ b/scripts/autoresearch/gate3-seeded-positive.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+import type { ExtendedDogfoodReport, RunConfig } from "../lib/run-config.js";
+import { type HardGates } from "./decision.js";
+import { BRIDGE_GATES, PRIMARY_CORPUS, verifySp1 } from "./gate3-seeded-positive.js";
+
+const runConfig: RunConfig = {
+	collectionId: "test",
+	corpusDigest: "abc",
+	goldFixtureVersion: "2.0.0",
+	goldFixtureHash: "h",
+	embedder: { url: "u", model: "m" },
+	extractor: null,
+	reranker: null,
+	grader: null,
+	retrieval: {
+		topK: 10,
+		traceMaxPerSource: 3,
+		traceMaxTotal: 15,
+		traceMaxHops: 3,
+		traceMinScore: 0.3,
+		traceMode: "analytical",
+		autoRoute: false,
+		diversityEnforce: true,
+	},
+	evaluation: { checkParaphrases: false, groundCheck: false },
+	promptHashes: {},
+	seed: 0,
+	gitSha: null,
+	packageVersions: {},
+	nodeVersion: "24.11",
+	cacheNamespaceSchemeVersion: 1,
+};
+
+function alignedScore(id: string, passed: boolean) {
+	return {
+		id,
+		category: "synthesis",
+		queryText: id,
+		passed,
+		passedQueryOnly: passed,
+		requiredTypesFound: true,
+		requiredTypesFoundQueryOnly: true,
+		resultCount: 10,
+		substringFound: true,
+		edgeHopFound: true,
+		crossSourceFound: true,
+		sourceTypesReached: [] as string[],
+		lineage: null,
+		distinctDocs: 5,
+		distinctSourceTypes: 3,
+		recallAtK: null,
+		recallK: null,
+		topScore: null,
+	};
+}
+
+function makeReport(opts: {
+	passRate: number;
+	scores: ReturnType<typeof alignedScore>[];
+	applicableRate?: number;
+	workLineage?: number;
+	fileLevel?: number;
+	demoCritical?: number;
+}): ExtendedDogfoodReport {
+	return {
+		reportSchemaVersion: "1.0.0",
+		timestamp: new Date().toISOString(),
+		collectionId: "t",
+		collectionName: "t",
+		stages: [
+			{
+				stage: "quality-queries",
+				startedAt: "",
+				durationMs: 0,
+				verdict: "pass",
+				summary: "",
+				metrics: {
+					passRate: opts.passRate,
+					applicableRate: opts.applicableRate ?? 0.6,
+					tierBreakdown: { "demo-critical": { passRate: opts.demoCritical ?? 0 } },
+					categoryBreakdown: {
+						"work-lineage": { passRate: opts.workLineage ?? 0.5 },
+						"file-level": { passRate: opts.fileLevel ?? 0.7 },
+						"hard-negative": { passRate: 0 },
+					},
+					paraphraseInvariance: { checked: false, invariantFraction: 0 },
+					scores: opts.scores,
+				},
+				checks: [],
+			},
+		],
+		verdict: "pass",
+		durationMs: 0,
+		runConfig,
+		runConfigFingerprint: "fp",
+		fingerprintVersion: 1,
+	};
+}
+
+/** Build paired baseline/candidate scores. `flips` controls how many
+ * queries flip fail→pass between baseline and candidate. */
+function pairedScores(total: number, baselinePassed: number, flips: number) {
+	const ids = Array.from({ length: total }, (_, i) => `q${i}`);
+	const baseline = ids.map((id, i) => alignedScore(id, i < baselinePassed));
+	const candidate = ids.map((id, i) =>
+		alignedScore(id, i < baselinePassed || (i >= baselinePassed && i < baselinePassed + flips)),
+	);
+	return { baseline, candidate };
+}
+
+describe("gate3 seeded-positive verifier", () => {
+	it("accepts when primary corpus shows confident lift + auxiliary directional positive", () => {
+		// Primary: 100 queries, 40 → 50 (+10pp lift, all flips real)
+		const primary = pairedScores(100, 40, 10);
+		// Auxiliary: 50 queries, 30 → 31 (+2pp directional but underpowered)
+		const aux = pairedScores(50, 30, 1);
+
+		const baseline = new Map<string, ExtendedDogfoodReport>([
+			[
+				PRIMARY_CORPUS,
+				makeReport({ passRate: 0.4, scores: primary.baseline }),
+			],
+			[
+				"wtfoc-dogfood-2026-04-v3",
+				makeReport({ passRate: 0.6, scores: aux.baseline }),
+			],
+		]);
+		const candidate = new Map<string, ExtendedDogfoodReport>([
+			[
+				PRIMARY_CORPUS,
+				makeReport({ passRate: 0.5, scores: primary.candidate }),
+			],
+			[
+				"wtfoc-dogfood-2026-04-v3",
+				makeReport({ passRate: 0.62, scores: aux.candidate }),
+			],
+		]);
+
+		const result = verifySp1({
+			baseline,
+			candidate,
+			gates: BRIDGE_GATES,
+			primaryCorpus: PRIMARY_CORPUS,
+		});
+
+		expect(result.multi.accept).toBe(true);
+		expect(result.primaryBootstrapPass).toBe(true);
+		expect(result.auxiliaryDirectional).toBe(true);
+		expect(result.accept).toBe(true);
+	});
+
+	it("rejects when primary corpus bootstrap underpowered (small lift)", () => {
+		// Primary lift is only +2pp (underpowered), should fail primary bootstrap
+		const primary = pairedScores(100, 40, 2);
+		const aux = pairedScores(50, 30, 5);
+
+		const baseline = new Map<string, ExtendedDogfoodReport>([
+			[PRIMARY_CORPUS, makeReport({ passRate: 0.4, scores: primary.baseline })],
+			["wtfoc-dogfood-2026-04-v3", makeReport({ passRate: 0.6, scores: aux.baseline })],
+		]);
+		const candidate = new Map<string, ExtendedDogfoodReport>([
+			[PRIMARY_CORPUS, makeReport({ passRate: 0.42, scores: primary.candidate })],
+			["wtfoc-dogfood-2026-04-v3", makeReport({ passRate: 0.7, scores: aux.candidate })],
+		]);
+
+		const result = verifySp1({
+			baseline,
+			candidate,
+			gates: BRIDGE_GATES,
+			primaryCorpus: PRIMARY_CORPUS,
+		});
+
+		expect(result.primaryBootstrapPass).toBe(false);
+		expect(result.accept).toBe(false);
+	});
+
+	it("rejects when auxiliary regresses (negative directional)", () => {
+		const primary = pairedScores(100, 40, 10);
+		// Auxiliary regression: candidate has fewer passes than baseline
+		const auxBaseline = pairedScores(50, 35, 0).baseline;
+		const auxCandidate = pairedScores(50, 30, 0).baseline;
+
+		const baseline = new Map<string, ExtendedDogfoodReport>([
+			[PRIMARY_CORPUS, makeReport({ passRate: 0.4, scores: primary.baseline })],
+			["wtfoc-dogfood-2026-04-v3", makeReport({ passRate: 0.7, scores: auxBaseline })],
+		]);
+		const candidate = new Map<string, ExtendedDogfoodReport>([
+			[PRIMARY_CORPUS, makeReport({ passRate: 0.5, scores: primary.candidate })],
+			["wtfoc-dogfood-2026-04-v3", makeReport({ passRate: 0.6, scores: auxCandidate })],
+		]);
+
+		const result = verifySp1({
+			baseline,
+			candidate,
+			gates: BRIDGE_GATES,
+			primaryCorpus: PRIMARY_CORPUS,
+		});
+
+		expect(result.auxiliaryDirectional).toBe(false);
+		expect(result.accept).toBe(false);
+	});
+
+	it("rejects when bridge gate fails (e.g., applicableRate floor)", () => {
+		const primary = pairedScores(100, 40, 10);
+		const aux = pairedScores(50, 30, 5);
+
+		const baseline = new Map<string, ExtendedDogfoodReport>([
+			[
+				PRIMARY_CORPUS,
+				makeReport({ passRate: 0.4, applicableRate: 0.6, scores: primary.baseline }),
+			],
+			[
+				"wtfoc-dogfood-2026-04-v3",
+				makeReport({ passRate: 0.6, applicableRate: 0.6, scores: aux.baseline }),
+			],
+		]);
+		// candidate has applicableRate 0.4 — below BRIDGE_GATES.applicableRateMin=0.5
+		const candidate = new Map<string, ExtendedDogfoodReport>([
+			[
+				PRIMARY_CORPUS,
+				makeReport({ passRate: 0.5, applicableRate: 0.4, scores: primary.candidate }),
+			],
+			[
+				"wtfoc-dogfood-2026-04-v3",
+				makeReport({ passRate: 0.7, applicableRate: 0.4, scores: aux.candidate }),
+			],
+		]);
+
+		const result = verifySp1({
+			baseline,
+			candidate,
+			gates: BRIDGE_GATES,
+			primaryCorpus: PRIMARY_CORPUS,
+		});
+
+		expect(result.multi.accept).toBe(false);
+		expect(result.accept).toBe(false);
+	});
+
+	it("BRIDGE_GATES.demoCriticalMin=0 — auxiliary corpus with no demo-critical tier passes", () => {
+		// Regression check: previous version of bridge gates had
+		// demoCriticalMin=0.33 which falsely tripped on dogfood corpus
+		// (no demo-critical queries; passRate defaults to 0).
+		const gates: HardGates = { ...BRIDGE_GATES };
+		expect(gates.demoCriticalMin).toBe(0);
+	});
+});

--- a/scripts/autoresearch/gate3-seeded-positive.ts
+++ b/scripts/autoresearch/gate3-seeded-positive.ts
@@ -3,9 +3,12 @@
  *
  * Verifies the autoresearch decideMulti + decide path accepts a known-good
  * synthetic patch end-to-end. Patch: bump default `TOPK` constant in
- * `quality-queries-evaluator.ts` from 10 → 30 (1 LoC). This is a
- * monotonic retrieval-quality lift — more candidates per query, more
- * chances to satisfy rubric thresholds, cannot reduce pass rate.
+ * `quality-queries-evaluator.ts` from 10 → 30 (1 LoC).
+ *
+ * Not strictly monotonic — see hard-negative caveat in
+ * docs/autoresearch/seeded-positives.md (SP-1). Empirically positive on
+ * the 2026-05-04 corpus state because hard-negatives sit at 0/12 and
+ * cannot regress further.
  *
  * Baseline: cached main reports from 2026-05-04 16-variant sweep
  * (`~/.wtfoc/autoresearch/reports/sweep-retrieval-baseline-1777900815204/`,
@@ -14,7 +17,8 @@
  *
  * Candidate: fresh dogfood runs on `feat/381-gate3-v2` branch with the
  * patch applied, on the same `noar_div_rrOff` axis settings (autoRoute
- * off, diversity on, no rerank).
+ * off, diversity on, no rerank). Committed under
+ * docs/autoresearch/seeded-positives/ for reproducibility.
  *
  * Hard gates: BRIDGE_GATES — relaxed against post-hygiene empirical pass
  * rates pending Phase B (#364) recalibration of DEFAULT_GATES. Gate 3
@@ -30,37 +34,25 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import type { ExtendedDogfoodReport } from "../lib/run-config.js";
-import { decide, decideMulti, type HardGates } from "./decision.js";
+import {
+	decide,
+	decideMulti,
+	type DecideMultiVerdict,
+	type DecisionVerdict,
+	type HardGates,
+} from "./decision.js";
 
 const BASELINE_DIR = join(
 	homedir(),
 	".wtfoc/autoresearch/reports/sweep-retrieval-baseline-1777900815204",
 );
 
-const CANDIDATE_PATHS: Record<string, string> = {
+export const SP1_CANDIDATE_PATHS: Record<string, string> = {
 	"filoz-ecosystem-2026-04-v12": "docs/autoresearch/seeded-positives/sp1-candidate-filoz.json",
 	"wtfoc-dogfood-2026-04-v3": "docs/autoresearch/seeded-positives/sp1-candidate-dogfood.json",
 };
 
 const BASELINE_VARIANT = "noar_div_rrOff";
-
-function loadBaseline(corpus: string): ExtendedDogfoodReport {
-	const path = join(BASELINE_DIR, `${BASELINE_VARIANT}__${corpus}.json`);
-	return JSON.parse(readFileSync(path, "utf-8")) as ExtendedDogfoodReport;
-}
-
-function loadCandidate(corpus: string): ExtendedDogfoodReport {
-	const path = CANDIDATE_PATHS[corpus];
-	if (!path) throw new Error(`No candidate path for corpus ${corpus}`);
-	return JSON.parse(readFileSync(path, "utf-8")) as ExtendedDogfoodReport;
-}
-
-const baseline = new Map<string, ExtendedDogfoodReport>();
-const candidate = new Map<string, ExtendedDogfoodReport>();
-for (const corpus of Object.keys(CANDIDATE_PATHS)) {
-	baseline.set(corpus, loadBaseline(corpus));
-	candidate.set(corpus, loadCandidate(corpus));
-}
 
 // Bridge gates — calibrated against post-scorer-hygiene empirical pass
 // rates from the 2026-05-04 sweep. Floors set just below current
@@ -68,7 +60,7 @@ for (const corpus of Object.keys(CANDIDATE_PATHS)) {
 // DEFAULT_GATES (pre-hygiene calibration) are stale; demoCriticalMin=1.0
 // is mathematically unreachable on current scorer state. Phase B (#364)
 // recalibrates DEFAULT_GATES from empirical reality.
-const BRIDGE_GATES: HardGates = {
+export const BRIDGE_GATES: HardGates = {
 	overallMin: 0.4,
 	// dogfood corpus has no demo-critical queries; evaluateGates emits
 	// passRate=0 in that case which would falsely trip a positive floor.
@@ -85,57 +77,127 @@ const BRIDGE_GATES: HardGates = {
 // Auxiliary corpora may show directional lift only (small samples produce
 // underpowered single-corpus bootstrap; cross-corpus aggregate via
 // decideMulti is the spec-binding acceptance signal).
-const PRIMARY_CORPUS = "filoz-ecosystem-2026-04-v12";
+export const PRIMARY_CORPUS = "filoz-ecosystem-2026-04-v12";
 
-console.log(`# Gate 3 — seeded positive control (TOPK 10→30)`);
-console.log(`Baseline:  ${BASELINE_DIR} (variant ${BASELINE_VARIANT})`);
-console.log(`Candidate: ${Object.values(CANDIDATE_PATHS).join(", ")}`);
-console.log();
-
-const multi = decideMulti({
-	baseline,
-	candidate,
-	cumulativeLocChange: 1,
-	gates: BRIDGE_GATES,
-});
-
-console.log(`## decideMulti`);
-console.log(`accept:             ${multi.accept}`);
-console.log(`trimmedMeanDelta:   ${multi.trimmedMeanDelta.toFixed(4)}`);
-console.log(`per-corpus deltas:`);
-for (const p of multi.perCorpus) {
-	console.log(
-		`  ${p.corpusId}: ${p.baselinePassRate.toFixed(3)} → ${p.candidatePassRate.toFixed(3)} (Δ ${p.delta >= 0 ? "+" : ""}${p.delta.toFixed(3)})`,
-	);
+export interface Sp1Verification {
+	multi: DecideMultiVerdict;
+	perCorpus: Array<{ corpusId: string; isPrimary: boolean; verdict: DecisionVerdict }>;
+	primaryBootstrapPass: boolean;
+	auxiliaryDirectional: boolean;
+	accept: boolean;
 }
-console.log(`reasons (if reject): ${multi.reasons.join("; ") || "(none)"}`);
-console.log();
 
-console.log(`## decide (per-corpus bootstrap)`);
-let primaryBootstrapPass = false;
-let auxiliaryDirectional = true;
-for (const corpus of Object.keys(CANDIDATE_PATHS)) {
-	const v = decide({
-		baseline: baseline.get(corpus)!,
-		candidate: candidate.get(corpus)!,
-		gates: BRIDGE_GATES,
+/**
+ * Pure verification logic. Takes already-loaded reports + gates so
+ * tests can swap in synthetic data instead of reading from disk.
+ */
+export function verifySp1(input: {
+	baseline: ReadonlyMap<string, ExtendedDogfoodReport>;
+	candidate: ReadonlyMap<string, ExtendedDogfoodReport>;
+	gates: HardGates;
+	primaryCorpus: string;
+}): Sp1Verification {
+	const multi = decideMulti({
+		baseline: input.baseline,
+		candidate: input.candidate,
+		cumulativeLocChange: 1,
+		gates: input.gates,
 	});
-	const isPrimary = corpus === PRIMARY_CORPUS;
-	console.log(`${corpus}${isPrimary ? " [PRIMARY]" : " [auxiliary]"}:`);
-	console.log(`  accept:           ${v.accept}`);
-	console.log(`  meanDelta:        ${v.bootstrap.meanDelta.toFixed(4)}`);
-	console.log(`  probBgreaterA:    ${v.bootstrap.probBgreaterA.toFixed(4)}`);
-	console.log(`  ci95:             [${v.bootstrap.ciLow.toFixed(4)}, ${v.bootstrap.ciHigh.toFixed(4)}]`);
-	console.log(`  reasons:          ${v.reasons.join("; ") || "(none)"}`);
-	if (isPrimary) {
-		primaryBootstrapPass = v.accept && v.bootstrap.probBgreaterA >= 0.95;
-	} else if (v.bootstrap.meanDelta <= 0) {
-		auxiliaryDirectional = false;
-	}
-}
-console.log();
 
-const ok = multi.accept && primaryBootstrapPass && auxiliaryDirectional;
-console.log(`## Verdict`);
-console.log(ok ? "PASS — harness accepts seeded positive end-to-end" : "FAIL — see reasons");
-process.exit(ok ? 0 : 1);
+	const perCorpus: Sp1Verification["perCorpus"] = [];
+	let primaryBootstrapPass = false;
+	let auxiliaryDirectional = true;
+	for (const corpusId of input.candidate.keys()) {
+		const verdict = decide({
+			baseline: input.baseline.get(corpusId)!,
+			candidate: input.candidate.get(corpusId)!,
+			gates: input.gates,
+		});
+		const isPrimary = corpusId === input.primaryCorpus;
+		perCorpus.push({ corpusId, isPrimary, verdict });
+		if (isPrimary) {
+			primaryBootstrapPass = verdict.accept && verdict.bootstrap.probBgreaterA >= 0.95;
+		} else if (verdict.bootstrap.meanDelta <= 0) {
+			auxiliaryDirectional = false;
+		}
+	}
+
+	return {
+		multi,
+		perCorpus,
+		primaryBootstrapPass,
+		auxiliaryDirectional,
+		accept: multi.accept && primaryBootstrapPass && auxiliaryDirectional,
+	};
+}
+
+function loadBaseline(corpus: string): ExtendedDogfoodReport {
+	const path = join(BASELINE_DIR, `${BASELINE_VARIANT}__${corpus}.json`);
+	return JSON.parse(readFileSync(path, "utf-8")) as ExtendedDogfoodReport;
+}
+
+function loadCandidate(corpus: string): ExtendedDogfoodReport {
+	const path = SP1_CANDIDATE_PATHS[corpus];
+	if (!path) throw new Error(`No candidate path for corpus ${corpus}`);
+	return JSON.parse(readFileSync(path, "utf-8")) as ExtendedDogfoodReport;
+}
+
+function main(): void {
+	const baseline = new Map<string, ExtendedDogfoodReport>();
+	const candidate = new Map<string, ExtendedDogfoodReport>();
+	for (const corpus of Object.keys(SP1_CANDIDATE_PATHS)) {
+		baseline.set(corpus, loadBaseline(corpus));
+		candidate.set(corpus, loadCandidate(corpus));
+	}
+
+	console.log(`# Gate 3 — seeded positive control (TOPK 10→30)`);
+	console.log(`Baseline:  ${BASELINE_DIR} (variant ${BASELINE_VARIANT})`);
+	console.log(`Candidate: ${Object.values(SP1_CANDIDATE_PATHS).join(", ")}`);
+	console.log();
+
+	const result = verifySp1({
+		baseline,
+		candidate,
+		gates: BRIDGE_GATES,
+		primaryCorpus: PRIMARY_CORPUS,
+	});
+
+	console.log(`## decideMulti`);
+	console.log(`accept:             ${result.multi.accept}`);
+	console.log(`trimmedMeanDelta:   ${result.multi.trimmedMeanDelta.toFixed(4)}`);
+	console.log(`per-corpus deltas:`);
+	for (const p of result.multi.perCorpus) {
+		console.log(
+			`  ${p.corpusId}: ${p.baselinePassRate.toFixed(3)} → ${p.candidatePassRate.toFixed(3)} (Δ ${p.delta >= 0 ? "+" : ""}${p.delta.toFixed(3)})`,
+		);
+	}
+	console.log(`reasons (if reject): ${result.multi.reasons.join("; ") || "(none)"}`);
+	console.log();
+
+	console.log(`## decide (per-corpus bootstrap)`);
+	for (const { corpusId, isPrimary, verdict } of result.perCorpus) {
+		console.log(`${corpusId}${isPrimary ? " [PRIMARY]" : " [auxiliary]"}:`);
+		console.log(`  accept:           ${verdict.accept}`);
+		console.log(`  meanDelta:        ${verdict.bootstrap.meanDelta.toFixed(4)}`);
+		console.log(`  probBgreaterA:    ${verdict.bootstrap.probBgreaterA.toFixed(4)}`);
+		console.log(
+			`  ci95:             [${verdict.bootstrap.ciLow.toFixed(4)}, ${verdict.bootstrap.ciHigh.toFixed(4)}]`,
+		);
+		console.log(`  reasons:          ${verdict.reasons.join("; ") || "(none)"}`);
+	}
+	console.log();
+
+	console.log(`## Verdict`);
+	console.log(
+		result.accept
+			? "PASS — harness accepts seeded positive end-to-end"
+			: "FAIL — see reasons",
+	);
+	process.exit(result.accept ? 0 : 1);
+}
+
+// Only run main when invoked directly. Lets the module be imported by
+// tests without triggering disk reads + process.exit.
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main();
+}


### PR DESCRIPTION
Follow-up to merged PR #386 addressing Copilot review comments on #381.

## Copilot's points (all verified accurate)

1. **Monotonicity claim was wrong**: TOPK 10→30 is not unconditionally a positive control. Hard-negative gate's `aboveNoiseCount` increments for every retrieved result above `HARD_NEGATIVE_NOISE_FLOOR=0.1` in returned top-K. A wider top-K can push previously-passing hard-negatives past `HARD_NEGATIVE_RESULT_CEILING=3` and flip them pass→fail.
2. **Empirically harmless** in current corpus state because hard-negatives sit at 0/12 in both baseline and candidate runs — already floored, cannot regress further.
3. **No test coverage** on gate3 script: previous version executed at import time + called `process.exit`, so could not be imported into a unit test.

## Changes

- `docs/autoresearch/seeded-positives.md`: replaced "Cannot reduce pass rate" / "Monotonic" with explicit caveat + empirical justification
- `scripts/autoresearch/gate3-seeded-positive.ts`: extracted `verifySp1` pure function (takes maps + gates, returns verdict struct); main() guarded behind direct-invoke check so module is import-safe
- `scripts/autoresearch/gate3-seeded-positive.test.ts`: 5 tests
  - accept path (primary lift confident, auxiliary directional)
  - reject when primary underpowered (small lift)
  - reject when auxiliary regresses
  - reject when bridge gate fails (applicableRate floor)
  - regression: BRIDGE_GATES.demoCriticalMin must stay 0 (auxiliary corpora without demo-critical tier)

## Test plan

- [x] `pnpm vitest run scripts/autoresearch/gate3-seeded-positive.test.ts` — 5/5 pass
- [x] `pnpm tsx scripts/autoresearch/gate3-seeded-positive.ts` — still PASS verdict
- [x] `pnpm -r build` clean
- [x] `pnpm lint:fix` clean