### PR TITLE
feat(autoresearch): latency floors in decideMulti — minimal + catastrophic-veto

### DIFF
--- a/scripts/autoresearch/decision.test.ts
+++ b/scripts/autoresearch/decision.test.ts
@@ -91,7 +91,20 @@ function makeReport(opts: {
 	applicableRate?: number;
 	paraphraseInvariant?: number | null;
 	costComparable?: { value: boolean; reasons: string[] };
+	/** per-query-total p95 in ms; pass `null` to omit timing entirely. */
+	perQueryP95Ms?: number | null;
 }): ExtendedDogfoodReport {
+	const timing =
+		opts.perQueryP95Ms === null
+			? undefined
+			: {
+					"per-query-total": {
+						p50Ms: Math.round((opts.perQueryP95Ms ?? 3000) * 0.7),
+						p95Ms: opts.perQueryP95Ms ?? 3000,
+						callCount: 100,
+						totalMs: 0,
+					},
+				};
 	const m = {
 		passRate: opts.passRate ?? 0.7,
 		applicableRate: opts.applicableRate ?? 1,
@@ -106,6 +119,7 @@ function makeReport(opts: {
 				? { checked: false, invariantFraction: 0 }
 				: { checked: true, invariantFraction: opts.paraphraseInvariant ?? 0.81 },
 		scores: opts.scores,
+		...(timing ? { timing } : {}),
 	};
 	return {
 		reportSchemaVersion: "1.0.0",
@@ -284,13 +298,17 @@ describe("trimmedMean", () => {
 	});
 });
 
-function makeMultiReport(passRate: number, scoreCount = 30): ExtendedDogfoodReport {
+function makeMultiReport(
+	passRate: number,
+	scoreCount = 30,
+	perQueryP95Ms: number | null | undefined = 3000,
+): ExtendedDogfoodReport {
 	const scores = Array.from({ length: scoreCount }, (_, i) =>
 		score({ id: `q${i}`, passed: i / scoreCount < passRate }),
 	);
 	const actualPassRate =
 		scores.length === 0 ? 0 : scores.filter((entry) => entry.passed).length / scores.length;
-	return makeReport({ scores, passRate: actualPassRate });
+	return makeReport({ scores, passRate: actualPassRate, perQueryP95Ms });
 }
 
 describe("decideMulti", () => {
@@ -429,5 +447,109 @@ describe("decideMulti", () => {
 		const v = decideMulti({ baseline, candidate, cumulativeLocChange: 5 });
 		expect(v.perCorpus.find((p) => p.corpusId === "alpha")?.delta).toBeCloseTo(0.2, 1);
 		expect(v.perCorpus.find((p) => p.corpusId === "beta")?.delta).toBeCloseTo(0.1, 1);
+	});
+});
+
+describe("decideMulti — latency floors (#364)", () => {
+	it("emits a warning (warn-only default) when baseline timing is missing", () => {
+		const baseline = new Map([["alpha", makeMultiReport(0.5, 30, null)]]);
+		const candidate = new Map([["alpha", makeMultiReport(0.6, 30, 3000)]]);
+		const v = decideMulti({ baseline, candidate, cumulativeLocChange: 5 });
+		expect(v.accept).toBe(true);
+		expect(
+			v.latencyWarnings.some((w) => w.includes("alpha") && w.includes("missing")),
+		).toBe(true);
+		expect(v.reasons.some((r) => r.includes("p95"))).toBe(false);
+	});
+
+	it("emits a warning (warn-only default) when candidate timing is missing", () => {
+		const baseline = new Map([["alpha", makeMultiReport(0.5, 30, 3000)]]);
+		const candidate = new Map([["alpha", makeMultiReport(0.6, 30, null)]]);
+		const v = decideMulti({ baseline, candidate, cumulativeLocChange: 5 });
+		expect(v.accept).toBe(true);
+		expect(
+			v.latencyWarnings.some((w) => w.includes("alpha") && w.includes("missing")),
+		).toBe(true);
+	});
+
+	it("acceptable p95 delta within p95FloorMs leaves verdict clean", () => {
+		const baseline = new Map([["alpha", makeMultiReport(0.5, 30, 3000)]]);
+		// candidate +800ms, well under DEFAULT_P95_FLOOR_MS=1500
+		const candidate = new Map([["alpha", makeMultiReport(0.6, 30, 3800)]]);
+		const v = decideMulti({ baseline, candidate, cumulativeLocChange: 5 });
+		expect(v.accept).toBe(true);
+		expect(v.latencyWarnings).toHaveLength(0);
+		expect(v.reasons.some((r) => r.includes("p95"))).toBe(false);
+	});
+
+	it("warns (warn-only default) on p95 floor breach without rejecting", () => {
+		const baseline = new Map([["alpha", makeMultiReport(0.5, 30, 3000)]]);
+		// candidate +2000ms exceeds DEFAULT_P95_FLOOR_MS=1500
+		const candidate = new Map([["alpha", makeMultiReport(0.6, 30, 5000)]]);
+		const v = decideMulti({ baseline, candidate, cumulativeLocChange: 5 });
+		expect(v.accept).toBe(true);
+		expect(
+			v.latencyWarnings.some((w) => w.includes("p95 regression") && w.includes("alpha")),
+		).toBe(true);
+		expect(v.reasons.some((r) => r.includes("p95 regression"))).toBe(false);
+	});
+
+	it("REJECTS p95 floor breach when latencyGateHard=true", () => {
+		const baseline = new Map([["alpha", makeMultiReport(0.5, 30, 3000)]]);
+		const candidate = new Map([["alpha", makeMultiReport(0.6, 30, 5000)]]);
+		const v = decideMulti({
+			baseline,
+			candidate,
+			cumulativeLocChange: 5,
+			floors: { latencyGateHard: true },
+		});
+		expect(v.accept).toBe(false);
+		expect(v.reasons.some((r) => r.includes("p95 regression") && r.includes("alpha"))).toBe(
+			true,
+		);
+	});
+
+	it("REJECTS catastrophic 2× breach when latencyGateHard=true", () => {
+		const baseline = new Map([["alpha", makeMultiReport(0.5, 30, 3000)]]);
+		// candidate 6500ms > 2× 3000ms = 6000ms
+		const candidate = new Map([["alpha", makeMultiReport(0.6, 30, 6500)]]);
+		const v = decideMulti({
+			baseline,
+			candidate,
+			cumulativeLocChange: 5,
+			floors: { latencyGateHard: true },
+		});
+		expect(v.accept).toBe(false);
+		expect(
+			v.reasons.some((r) => r.includes("catastrophic latency") && r.includes("alpha")),
+		).toBe(true);
+		// Catastrophic check fires instead of the lower-priority p95FloorMs check.
+		expect(v.reasons.some((r) => r.includes("p95 regression"))).toBe(false);
+	});
+
+	it("REJECTS absolute totalP95FloorMs breach when latencyGateHard=true", () => {
+		const baseline = new Map([["alpha", makeMultiReport(0.5, 30, 9000)]]);
+		// candidate 9500ms — only +500ms (within p95FloorMs) but absolute
+		// >totalP95FloorMs after override.
+		const candidate = new Map([["alpha", makeMultiReport(0.6, 30, 9500)]]);
+		const v = decideMulti({
+			baseline,
+			candidate,
+			cumulativeLocChange: 5,
+			floors: { latencyGateHard: true, totalP95FloorMs: 9200 },
+		});
+		expect(v.accept).toBe(false);
+		expect(
+			v.reasons.some((r) => r.includes("absolute p95 ceiling") && r.includes("alpha")),
+		).toBe(true);
+	});
+
+	it("populates baselineP95Ms + candidateP95Ms on PerCorpusDelta", () => {
+		const baseline = new Map([["alpha", makeMultiReport(0.5, 30, 2500)]]);
+		const candidate = new Map([["alpha", makeMultiReport(0.6, 30, 2700)]]);
+		const v = decideMulti({ baseline, candidate, cumulativeLocChange: 5 });
+		const entry = v.perCorpus.find((p) => p.corpusId === "alpha");
+		expect(entry?.baselineP95Ms).toBe(2500);
+		expect(entry?.candidateP95Ms).toBe(2700);
 	});
 });

--- a/scripts/autoresearch/decision.ts
+++ b/scripts/autoresearch/decision.ts
@@ -45,6 +45,25 @@ export const DEFAULT_MUST_PASS_FLOOR = 0.03;
 export const DEFAULT_TYPE_FLOOR = 0.05;
 export const DEFAULT_CATASTROPHIC_FLOOR = 0.3;
 export const DEFAULT_MIN_MEANINGFUL_LOC = 1;
+/**
+ * Latency floors (#364). Calibrated against 2026-05-04 production-variant
+ * baseline (`noar_div_rrOff` filoz): per-query-total p95 ~3000-4300ms across
+ * cached runs (32% run-to-run variance). Defaults reject patches with p95
+ * regressions large enough to matter on top of that variance.
+ */
+export const DEFAULT_P95_FLOOR_MS = 1500; // candidate p95 may exceed baseline by at most 1500ms
+export const DEFAULT_TOTAL_P95_FLOOR_MS = 10_000; // absolute ceiling regardless of baseline
+export const DEFAULT_CATASTROPHIC_LATENCY_FACTOR = 2.0; // candidate.p95 > 2× baseline.p95 → auto-reject
+
+/**
+ * Phase-B activation flag (#364). When `true`, latency floor breaches add
+ * to `reasons` and reject the candidate. When `false`, breaches surface in
+ * the warn-only `latencyWarnings` field on the verdict so a calibration
+ * cycle can observe behavior without rejecting candidates. Per peer-review
+ * consensus (codex+cursor+gemini, 2026-05-04): flip after one calibration
+ * cycle to avoid sliding into permanent observe-only mode.
+ */
+export const DEFAULT_LATENCY_GATE_HARD = false;
 
 export interface PerCorpusFloors {
 	/** Maximum tolerated delta drop on a must-pass corpus (default 3pp). */
@@ -59,6 +78,23 @@ export interface PerCorpusFloors {
 	minMeaningfulLoC?: number;
 	/** Minimum trimmed-mean delta to accept (default `MIN_LIFT`). */
 	minLift?: number;
+	/**
+	 * Latency floors (#364). Read from `metrics.timing["per-query-total"]`.
+	 * When timing data is missing on either side, latency gating is skipped
+	 * for that corpus (reported as `latencyWarnings` entry). Defaults from
+	 * `DEFAULT_P95_FLOOR_MS`, `DEFAULT_TOTAL_P95_FLOOR_MS`,
+	 * `DEFAULT_CATASTROPHIC_LATENCY_FACTOR`.
+	 */
+	p95FloorMs?: number;
+	totalP95FloorMs?: number;
+	catastrophicLatencyFactor?: number;
+	/**
+	 * When false (default), latency breaches go to `latencyWarnings` only and
+	 * do not reject the candidate. When true, breaches add to `reasons` and
+	 * cause `accept: false`. Phase B / #364 ships warn-only and flips to
+	 * hard-fail after one calibration cycle.
+	 */
+	latencyGateHard?: boolean;
 }
 
 export interface DecideMultiInputs {
@@ -91,11 +127,23 @@ export interface PerCorpusDelta {
 	candidatePassRate: number;
 	delta: number;
 	gateResults: DecisionVerdict["gateResults"];
+	/**
+	 * Latency telemetry (#364). `null` for either field when timing data is
+	 * missing on the corresponding report.
+	 */
+	baselineP95Ms: number | null;
+	candidateP95Ms: number | null;
 }
 
 export interface DecideMultiVerdict {
 	accept: boolean;
 	reasons: string[];
+	/**
+	 * Latency-floor warnings emitted when `latencyGateHard` is false (#364).
+	 * Same content shape as a `reasons` entry; surfaced separately so the
+	 * calibration-cycle harness can observe regressions without rejecting.
+	 */
+	latencyWarnings: string[];
 	perCorpus: PerCorpusDelta[];
 	trimmedMeanDelta: number;
 	mustPassCorpora: string[];
@@ -166,6 +214,11 @@ export function decideMulti(input: DecideMultiInputs): DecideMultiVerdict {
 	const typeFloor = floors.typeFloor ?? DEFAULT_TYPE_FLOOR;
 	const catastrophicFloor = floors.catastrophicFloor ?? DEFAULT_CATASTROPHIC_FLOOR;
 	const minLoc = floors.minMeaningfulLoC ?? DEFAULT_MIN_MEANINGFUL_LOC;
+	const p95FloorMs = floors.p95FloorMs ?? DEFAULT_P95_FLOOR_MS;
+	const totalP95FloorMs = floors.totalP95FloorMs ?? DEFAULT_TOTAL_P95_FLOOR_MS;
+	const catastrophicLatencyFactor =
+		floors.catastrophicLatencyFactor ?? DEFAULT_CATASTROPHIC_LATENCY_FACTOR;
+	const latencyGateHard = floors.latencyGateHard ?? DEFAULT_LATENCY_GATE_HARD;
 	const gates = input.gates ?? DEFAULT_GATES;
 
 	const sharedCorpora = Array.from(input.baseline.keys()).filter((k) =>
@@ -188,10 +241,17 @@ export function decideMulti(input: DecideMultiInputs): DecideMultiVerdict {
 			candidatePassRate,
 			delta: candidatePassRate - baselinePassRate,
 			gateResults: evaluateGates(c, gates),
+			baselineP95Ms: extractPerQueryP95Ms(b),
+			candidateP95Ms: extractPerQueryP95Ms(c),
 		});
 	}
 
 	const reasons: string[] = [];
+	const latencyWarnings: string[] = [];
+	const sink = (msg: string) => {
+		if (latencyGateHard) reasons.push(msg);
+		else latencyWarnings.push(msg);
+	};
 
 	if (perCorpus.length === 0) {
 		reasons.push("no shared corpora between baseline and candidate");
@@ -250,9 +310,36 @@ export function decideMulti(input: DecideMultiInputs): DecideMultiVerdict {
 		);
 	}
 
+	// Latency gates (#364). Per-corpus checks against per-query-total p95.
+	for (const entry of perCorpus) {
+		const { corpusId, baselineP95Ms, candidateP95Ms } = entry;
+		if (baselineP95Ms === null || candidateP95Ms === null) {
+			latencyWarnings.push(
+				`corpus "${corpusId}" missing per-query-total timing — latency gates skipped`,
+			);
+			continue;
+		}
+		// Catastrophic-latency veto: candidate p95 > factor × baseline p95.
+		if (candidateP95Ms > baselineP95Ms * catastrophicLatencyFactor) {
+			sink(
+				`catastrophic latency on "${corpusId}": candidate p95 ${candidateP95Ms}ms > ${catastrophicLatencyFactor}× baseline ${baselineP95Ms}ms`,
+			);
+		} else if (candidateP95Ms - baselineP95Ms > p95FloorMs) {
+			sink(
+				`p95 regression on "${corpusId}": candidate ${candidateP95Ms}ms − baseline ${baselineP95Ms}ms = ${candidateP95Ms - baselineP95Ms}ms > p95FloorMs ${p95FloorMs}`,
+			);
+		}
+		if (candidateP95Ms > totalP95FloorMs) {
+			sink(
+				`absolute p95 ceiling on "${corpusId}": candidate ${candidateP95Ms}ms > totalP95FloorMs ${totalP95FloorMs}`,
+			);
+		}
+	}
+
 	return {
 		accept: reasons.length === 0,
 		reasons,
+		latencyWarnings,
 		perCorpus,
 		trimmedMeanDelta: aggregate,
 		mustPassCorpora: [...mustPass],
@@ -326,10 +413,23 @@ interface QQMetrics {
 	categoryBreakdown?: Record<string, { passRate?: number }>;
 	paraphraseInvariance?: { invariantFraction?: number; checked?: boolean };
 	scores?: Array<{ id: string; passed: boolean; skipped?: boolean }>;
+	timing?: Record<string, { p50Ms?: number; p95Ms?: number }>;
 }
 
 function qq(report: ExtendedDogfoodReport): QQMetrics | undefined {
 	return report.stages.find((s) => s.stage === "quality-queries")?.metrics as QQMetrics | undefined;
+}
+
+/**
+ * Read per-query-total p95 from `metrics.timing` (#364 — SubstageTimer
+ * already records this in every quality-queries stage). Returns null when
+ * timing is absent so latency gates can skip rather than treat missing
+ * data as 0.
+ */
+function extractPerQueryP95Ms(report: ExtendedDogfoodReport): number | null {
+	const m = qq(report);
+	const v = m?.timing?.["per-query-total"]?.p95Ms;
+	return typeof v === "number" ? v : null;
 }
 
 export function evaluateGates(


### PR DESCRIPTION
First slice of #364 per 3-way peer-review consensus (codex+cursor+gemini, 2026-05-04). Refs #311.

## Mechanism

`PerCorpusFloors` extended:
- `p95FloorMs` (default 1500ms) — candidate may exceed baseline by at most this
- `totalP95FloorMs` (default 10000ms) — absolute ceiling
- `catastrophicLatencyFactor` (default 2.0) — auto-reject when candidate.p95 > 2× baseline
- `latencyGateHard` (default **false** — warn-only)

`PerCorpusDelta` carries `baselineP95Ms` + `candidateP95Ms`. Null when timing data is absent on either side; gate skipped + emitted as a `latencyWarnings` entry.

`DecideMultiVerdict` adds `latencyWarnings: string[]`. Same content shape as `reasons`. Surfaces breaches when `latencyGateHard=false` so calibration can observe before rejecting.

## Why warn-only first

Filoz baseline `noar_div_rrOff` per-query-total p95 varies **2914–4303ms** across cached sweep runs (~32% run-to-run variance). The 1500ms delta floor + 2× catastrophic factor admit that variance band while rejecting clear regressions, but the variance also means we want one calibration cycle to confirm the gate is calibrated correctly before flipping to hard-fail.

Per peer-review: pre-commit the warn-only→hard-fail transition. After **one calibration cycle observes warn-only behavior on real sweeps**, flip `DEFAULT_LATENCY_GATE_HARD` to `true`. This avoids "observe forever" calibration nihilism.

## Tests (8 new, full suite 1867 pass)

Per codex's exact test plan:
- baseline timing missing → warning, accept clean
- candidate timing missing → warning, accept clean
- p95 delta within floor → no warning, no reason
- p95 floor breach (warn-only) → warning, accept stays true
- p95 floor breach (latencyGateHard=true) → reject
- catastrophic 2× breach (latencyGateHard=true) → reject; p95FloorMs check skipped to avoid double-counting
- absolute totalP95FloorMs breach (override 9200ms) → reject
- PerCorpusDelta carries baselineP95Ms + candidateP95Ms

## Out of scope (deferred to subsequent PRs)

- `slow-but-passing` `FailureClass` + capsule routing
- `prioritizeStrata` (#360) latency weighting
- `computeLatencyAggregates` typed export from @wtfoc/search
- Live `--skip-pr` validation harness
- Hard-flip of `DEFAULT_LATENCY_GATE_HARD` (after observation cycle)

## Roadmap position

Phase B kickoff. After this lands → observe one calibration cycle → flip hard → straight to **#382 autonomy proof on #327**. Hard-negative blindness deferred forensics in #389.

## Test plan

- [x] `pnpm test` — 1867 pass
- [x] SP-1 (`pnpm tsx scripts/autoresearch/gate3-seeded-positive.ts`) — PASS unchanged
- [x] `pnpm -r build` clean
- [x] `pnpm lint:fix` clean