### PR TITLE
feat(autoresearch): slow-but-passing FailureClass + per-query duration capture

### DIFF
--- a/packages/search/src/eval/failure-diagnosis.test.ts
+++ b/packages/search/src/eval/failure-diagnosis.test.ts
@@ -266,3 +266,98 @@ describe("aggregateDiagnoses", () => {
 		expect(agg.dominantLayerShare).toBe(0);
 	});
 });
+
+describe("diagnoseFailure — slow-but-passing (#364)", () => {
+	it("emits slow-but-passing when a passing query exceeds the floor", () => {
+		const result = diagnoseFailure({
+			score: makeScore({
+				id: "q1",
+				passed: true,
+				passedQueryOnly: true,
+				resultCount: 5,
+				requiredTypesFound: true,
+				substringFound: true,
+				durationMs: 9500,
+			}),
+			query: makeQuery({ id: "q1" }),
+			slowQueryFloorMs: 8000,
+		});
+		expect(result?.failureClass).toBe("slow-but-passing");
+		expect(result?.layer).toBe("ranking");
+	});
+
+	it("returns null when passing query duration is at-or-below the floor", () => {
+		const result = diagnoseFailure({
+			score: makeScore({
+				id: "q1",
+				passed: true,
+				passedQueryOnly: true,
+				resultCount: 5,
+				requiredTypesFound: true,
+				substringFound: true,
+				durationMs: 8000,
+			}),
+			query: makeQuery({ id: "q1" }),
+			slowQueryFloorMs: 8000,
+		});
+		expect(result).toBeNull();
+	});
+
+	it("returns null when slowQueryFloorMs is undefined (legacy behavior)", () => {
+		const result = diagnoseFailure({
+			score: makeScore({
+				id: "q1",
+				passed: true,
+				passedQueryOnly: true,
+				resultCount: 5,
+				requiredTypesFound: true,
+				substringFound: true,
+				durationMs: 99_000,
+			}),
+			query: makeQuery({ id: "q1" }),
+		});
+		expect(result).toBeNull();
+	});
+
+	it("returns null when durationMs is missing", () => {
+		const result = diagnoseFailure({
+			score: makeScore({
+				id: "q1",
+				passed: true,
+				passedQueryOnly: true,
+				resultCount: 5,
+				requiredTypesFound: true,
+				substringFound: true,
+			}),
+			query: makeQuery({ id: "q1" }),
+			slowQueryFloorMs: 8000,
+		});
+		expect(result).toBeNull();
+	});
+
+	it("does not override a real failure with slow-but-passing", () => {
+		// Failed query with very high duration — must classify as the real
+		// failure (e.g. retrieved-not-ranked / retrieval-miss), not slow-but-passing.
+		const result = diagnoseFailure({
+			score: makeScore({
+				id: "q1",
+				passed: false,
+				passedQueryOnly: false,
+				resultCount: 0,
+				requiredTypesFound: false,
+				substringFound: false,
+				durationMs: 99_000,
+				goldProximity: {
+					widerK: 50,
+					topKCutoff: 10,
+					goldRank: null,
+					goldScore: null,
+					topKLastScore: null,
+				},
+			}),
+			query: makeQuery({ id: "q1" }),
+			slowQueryFloorMs: 8000,
+		});
+		expect(result?.failureClass).not.toBe("slow-but-passing");
+	});
+});

--- a/packages/search/src/eval/failure-diagnosis.ts
+++ b/packages/search/src/eval/failure-diagnosis.ts
@@ -39,7 +39,16 @@ export type FailureClass =
 	| "retrieved-not-ranked"
 	| "missing-edge"
 	| "answer-synthesis"
-	| "hard-negative-violated";
+	| "hard-negative-violated"
+	/**
+	 * #364 — query passed all rubric criteria but exceeded the slow-query p95
+	 * floor. Treated as a regression because the loop must reject patches that
+	 * raise quality at unacceptable latency cost. Layer pinned to `ranking`
+	 * by default; substage-aware routing (#364 follow-up) will refine to
+	 * `embedding` / `chunking` / `trace` when per-substage per-query data is
+	 * captured.
+	 */
+	| "slow-but-passing";
 
 export interface DiagnosisEvidence {
 	/**
@@ -107,6 +116,8 @@ export interface DiagnosisScoreInput {
 	evidenceGateCanonical?: boolean;
 	edgeHopFound: boolean;
 	crossSourceFound: boolean;
+	/** #364 — wall-clock per-query duration (ms). Used for `slow-but-passing`. */
+	durationMs?: number;
 	goldProximity?: {
 		widerK: number;
 		topKCutoff: number;
@@ -126,16 +137,67 @@ export interface DiagnoseFailureInput {
 	 * — no retrieval change can pass this query.
 	 */
 	preflightStatus?: PreflightStatus;
+	/**
+	 * #364 — wall-clock duration (ms) above which a passing query gets the
+	 * `slow-but-passing` failure class. `undefined` disables the check
+	 * (legacy behavior; passing queries return `null`).
+	 */
+	slowQueryFloorMs?: number;
 }
 
 /**
- * Diagnose a single failed query. Returns `null` when the query passed or was
- * skipped (skipped queries are not failures and don't need a diagnosis).
+ * #364 — default p95 floor for the `slow-but-passing` class. Calibrated
+ * against the production `noar_div_rrOff` baseline (per-query-total p95
+ * ~4250ms): 8000ms catches reranker variants (~14000ms) and the
+ * borderline `noar_nodiv_rrBge` (~7000ms) without firing on the noise
+ * band of non-rerank variants.
+ */
+export const DEFAULT_SLOW_QUERY_FLOOR_MS = 8000;
+
+/**
+ * Diagnose a single query. Returns `null` for skipped queries and for
+ * passing queries whose duration is within `slowQueryFloorMs`. A passing
+ * query whose `durationMs` exceeds the floor is diagnosed as
+ * `slow-but-passing` (#364) so the autoresearch loop can reject patches
+ * that improve quality at unacceptable latency cost.
  */
 export function diagnoseFailure(input: DiagnoseFailureInput): FailureDiagnosis | null {
-	const { score, query, corpusId, preflightStatus } = input;
+	const { score, query, corpusId, preflightStatus, slowQueryFloorMs } = input;
 	if (score.skipped) return null;
-	if (score.passed) return null;
+
+	// #364 — slow-but-passing: a query that satisfies all rubric criteria
+	// but exceeded the per-query latency floor. Pinned to `ranking` layer
+	// for now; substage-aware routing follows when per-query substage data
+	// is captured.
+	if (score.passed) {
+		if (
+			slowQueryFloorMs !== undefined &&
+			typeof score.durationMs === "number" &&
+			score.durationMs > slowQueryFloorMs
+		) {
+			return {
+				queryId: query.id,
+				corpusId: corpusId ?? null,
+				failureClass: "slow-but-passing",
+				layer: "ranking",
+				evidence: {
+					goldInCatalog: preflightStatus !== "invalid",
+					retrievedInWiderK: null,
+					finalRank: null,
+					requiredTypesMet: score.requiredTypesFound,
+					edgeHopsMet: score.edgeHopFound,
+					crossSourceMet: score.crossSourceFound,
+					substringFound: score.substringFound,
+					documentIdFound: score.documentIdFound,
+					evidenceGateCanonical: score.evidenceGateCanonical,
+					goldRank: null,
+					topKCutoff: null,
+					widerK: null,
+				},
+			};
+		}
+		return null;
+	}
 
 	const goldRank = score.goldProximity?.goldRank ?? null;
 	const widerK = score.goldProximity?.widerK ?? null;
@@ -295,6 +357,7 @@ const ALL_FAILURE_CLASSES: FailureClass[] = [
 	"missing-edge",
 	"answer-synthesis",
 	"hard-negative-violated",
+	"slow-but-passing",
 ];
 const ALL_LAYERS: FailureLayer[] = [
 	"fixture",

--- a/packages/search/src/eval/quality-queries-evaluator.test.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.test.ts
@@ -504,6 +504,8 @@ describe("evaluateQualityQueries", () => {
 			const run2 = await evaluateQualityQueries(mockEmbedder, mockVectorIndex, mockSegments);
 
 			// Deterministic slice: everything except wall-clock and duration.
+			// Per-query `durationMs` is wall-clock (#364) and varies run-to-run;
+			// strip it from the comparison.
 			const deterministic = (r: typeof run1) => ({
 				stage: r.stage,
 				verdict: r.verdict,
@@ -517,7 +519,7 @@ describe("evaluateQualityQueries", () => {
 					queryOnlyPassCount: r.metrics.queryOnlyPassCount,
 					totalQueries: r.metrics.totalQueries,
 					categoryBreakdown: r.metrics.categoryBreakdown,
-					scores: r.metrics.scores,
+					scores: r.metrics.scores.map(({ durationMs: _omit, ...rest }) => rest),
 					lineage: r.metrics.lineage,
 				},
 			});

--- a/packages/search/src/eval/quality-queries-evaluator.test.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.test.ts
@@ -519,7 +519,9 @@ describe("evaluateQualityQueries", () => {
 					queryOnlyPassCount: r.metrics.queryOnlyPassCount,
 					totalQueries: r.metrics.totalQueries,
 					categoryBreakdown: r.metrics.categoryBreakdown,
-					scores: r.metrics.scores.map(({ durationMs: _omit, ...rest }) => rest),
+					scores: (r.metrics.scores as Array<Record<string, unknown>>).map(
+						({ durationMs: _omit, ...rest }: Record<string, unknown>) => rest,
+					),
 					lineage: r.metrics.lineage,
 				},
 			});

--- a/packages/search/src/eval/quality-queries-evaluator.ts
+++ b/packages/search/src/eval/quality-queries-evaluator.ts
@@ -14,6 +14,7 @@ import { trace } from "../trace/trace.js";
 import type { PreflightStatus } from "./catalog-applicability-preflight.js";
 import {
 	aggregateDiagnoses,
+	DEFAULT_SLOW_QUERY_FLOOR_MS,
 	type DiagnosisAggregate,
 	diagnoseFailure,
 	type FailureDiagnosis,
@@ -155,6 +156,13 @@ interface QueryScore {
 	category: string;
 	queryText: string;
 	/**
+	 * #364 — wall-clock per-query duration in milliseconds (rounded). Captured
+	 * around `scoreQuery` and used by `failure-diagnosis` to detect the
+	 * `slow-but-passing` failure class. Optional because skipped queries
+	 * never run scoreQuery.
+	 */
+	durationMs?: number;
+	/**
 	 * True when the query was skipped as inapplicable to this corpus (because
 	 * its `requiredSourceTypes` are not present, or its `collectionScopePattern`
 	 * does not match the collection id). Skipped queries do not count toward
@@ -295,6 +303,12 @@ export interface QualityQueriesContext {
 	 */
 	checkParaphrases?: boolean;
 	/**
+	 * #364 — per-query duration floor (ms) above which a passing query is
+	 * diagnosed as `slow-but-passing`. When unset, defaults to
+	 * `DEFAULT_SLOW_QUERY_FLOOR_MS` from `failure-diagnosis`.
+	 */
+	slowQueryFloorMs?: number;
+	/**
 	 * Numeric retrieval-config overrides for the autoresearch loop
 	 * (#334). When unset, evaluator uses its built-in defaults
 	 * (topK=10, traceMaxPerSource=3, traceMaxTotal=15, traceMinScore=0.3).
@@ -403,7 +417,9 @@ export async function evaluateQualityQueries(
 			context.recordGoldProximity ?? process.env.WTFOC_GOLD_PROXIMITY === "1",
 			catalogDocumentIds,
 		);
-		context.perQueryHook?.(gq.id, performance.now() - queryStart);
+		const durationMs = performance.now() - queryStart;
+		score.durationMs = Math.round(durationMs);
+		context.perQueryHook?.(gq.id, durationMs);
 		scores.push(score);
 		if (score.passed) passCount++;
 		if (score.passedQueryOnly) queryOnlyPassCount++;
@@ -421,6 +437,7 @@ export async function evaluateQualityQueries(
 			query: gq,
 			corpusId: context.collectionId,
 			preflightStatus: context.preflightStatusByQueryId?.get(gq.id),
+			slowQueryFloorMs: context.slowQueryFloorMs ?? DEFAULT_SLOW_QUERY_FLOOR_MS,
 		});
 		if (d) diagnoses.push(d);
 	}


### PR DESCRIPTION
Phase B latency layer continues. Closes #364 acceptance criterion 3.

A query that satisfies all rubric criteria but exceeds a configured per-query latency floor is now diagnosed as `slow-but-passing` so the autoresearch loop can reject patches that improve quality at unacceptable latency cost.

## Changes

- `QueryScore.durationMs?: number` — wall-clock per-query duration captured around `scoreQuery` (round-trip from existing `queryStart` timestamp; no extra timing calls)
- `QualityQueriesContext.slowQueryFloorMs?: number` — threads to `diagnoseFailure`
- `FailureClass` extended with `slow-but-passing`
- `DEFAULT_SLOW_QUERY_FLOOR_MS = 8000` (calibrated: production baseline ~4250ms; floor catches rerank variants ~14000ms + borderline `noar_nodiv_rrBge` ~7000ms without firing on non-rerank noise band)
- `diagnoseFailure` returns slow-but-passing when `passed && durationMs > floor`; layer pinned to `ranking`
- Substage-aware routing (embedding / chunking / trace) deferred to follow-up — needs per-query per-substage timing capture

## Tests (5 new; full suite 1873 pass)

- emits slow-but-passing when passing query exceeds floor
- returns null at-or-below floor (boundary check)
- returns null when `slowQueryFloorMs` is undefined (legacy behavior preserved)
- returns null when `durationMs` is missing
- does not override a real failure with slow-but-passing

## Out of scope (subsequent PRs)

- Substage-aware layer routing for slow-but-passing
- Patch-capsule (#349) routing of slow-but-passing diagnoses to the correct tier
- `prioritizeStrata` (#360) latency weighting
- Live `--skip-pr` validation harness

## Test plan

- [x] Full suite 1873 pass
- [x] SP-1 (`pnpm tsx scripts/autoresearch/gate3-seeded-positive.ts`) — PASS unchanged
- [x] `pnpm -r build` clean
- [x] `pnpm lint:fix` clean

Refs #364, #311