### PR TITLE
feat(autoresearch): materialize against finding's target variant (#394)

### DIFF
--- a/scripts/autoresearch/autonomous-loop.ts
+++ b/scripts/autoresearch/autonomous-loop.ts
@@ -854,6 +854,12 @@ async function runLoop(cli: CliArgs): Promise<LoopOutcome> {
 		return { status: "materialize-failed", notes };
 	}
 
+	// Surface materialize audit notes (target-variant mapping, baseline
+	// window scoping) so the evidence chain is visible outside --dry-run.
+	for (const note of materialize.notes) {
+		notes.push(`materialize: ${note}`);
+	}
+
 	// Always log the attempt (accept or reject) so memory persists.
 	const candidateRow = materialize.candidateRows[0];
 	appendTriedRow({
@@ -865,7 +871,10 @@ async function runLoop(cli: CliArgs): Promise<LoopOutcome> {
 		sweepId: candidateRow?.sweepId,
 		runConfigFingerprint: candidateRow?.runConfigFingerprint,
 		verdict: materialize.aggregateAccept ? "accepted" : "rejected",
-		reasons: materialize.decisions.flatMap((d) => d.verdict?.reasons ?? [d.reason ?? ""]),
+		reasons: [
+			...materialize.notes,
+			...materialize.decisions.flatMap((d) => d.verdict?.reasons ?? [d.reason ?? ""]),
+		],
 		metrics: candidateRow?.summary
 			? {
 					passRate: candidateRow.summary.passRate,

--- a/scripts/autoresearch/autonomous-loop.ts
+++ b/scripts/autoresearch/autonomous-loop.ts
@@ -812,6 +812,15 @@ async function runLoop(cli: CliArgs): Promise<LoopOutcome> {
 	}
 
 	if (cli.dryRun) {
+		const productionVariantId = matrix.productionVariantId ?? "(unset)";
+		if (finding.variantId && finding.variantId !== productionVariantId) {
+			notes.push(
+				`DRY-RUN materialize-target: ${finding.variantId} (from finding) — ` +
+					`production=${productionVariantId}; base axes would be derived from target (#394)`,
+			);
+		} else {
+			notes.push(`DRY-RUN materialize-target: ${finding.variantId ?? productionVariantId}`);
+		}
 		notes.push(
 			`DRY-RUN proposal: ${proposal.axis}=${JSON.stringify(proposal.value)} — ${proposal.rationale}`,
 		);
@@ -828,6 +837,7 @@ async function runLoop(cli: CliArgs): Promise<LoopOutcome> {
 			productionMatrix: matrix,
 			productionMatrixName: cli.matrixName,
 			proposal: proposal,
+			targetVariantId: finding.variantId,
 		});
 	} catch (err) {
 		const msg = err instanceof Error ? err.message : String(err);

--- a/scripts/autoresearch/materialize-variant.test.ts
+++ b/scripts/autoresearch/materialize-variant.test.ts
@@ -114,6 +114,44 @@ describe("materializeVariant — matrix synthesis", () => {
 		expect(parsed.axes.traceMinScore).toEqual([0.4]);
 	});
 
+	it("derives base axes from targetVariantId when provided (#394)", async () => {
+		// productionVariantId is noar_div_rrOff but the finding implicates
+		// noar_div_rrBge. Materializer must derive base axes from the
+		// target (BGE reranker), not from production (rerank off).
+		const stateDir = mkdtempSync(join(tmpdir(), "wtfoc-materialize-"));
+		const result = await materializeVariant({
+			productionMatrix: baseMatrix(),
+			productionMatrixName: "retrieval-baseline",
+			proposal: { axis: "topK", value: 30, rationale: "wider K" },
+			targetVariantId: "noar_div_rrBge",
+			spawnFn: () => Buffer.from(""),
+			stateDir,
+		});
+		const body = readFileSync(result.matrixPath, "utf-8");
+		const parsed = JSON.parse(body.split("export default ")[1]?.replace(/;\s*$/, "").trim() ?? "{}");
+		expect(parsed.axes.topK).toEqual([30]);
+		expect(parsed.axes.reranker).toEqual([{ type: "bge", url: "http://127.0.0.1:8386" }]);
+		expect(parsed.axes.diversityEnforce).toEqual([true]);
+		expect(parsed.axes.autoRoute).toEqual([false]);
+		// Audit note surfaced when target diverges from production.
+		expect(result.notes.some((n) => n.includes("noar_div_rrBge") && n.includes("#394"))).toBe(true);
+	});
+
+	it("falls back to productionVariantId when targetVariantId omitted (legacy)", async () => {
+		const stateDir = mkdtempSync(join(tmpdir(), "wtfoc-materialize-"));
+		const result = await materializeVariant({
+			productionMatrix: baseMatrix(),
+			productionMatrixName: "retrieval-baseline",
+			proposal: { axis: "topK", value: 30, rationale: "wider K" },
+			spawnFn: () => Buffer.from(""),
+			stateDir,
+		});
+		const body = readFileSync(result.matrixPath, "utf-8");
+		const parsed = JSON.parse(body.split("export default ")[1]?.replace(/;\s*$/, "").trim() ?? "{}");
+		expect(parsed.axes.reranker).toEqual(["off"]);
+		expect(result.notes.some((n) => n.includes("#394"))).toBe(false);
+	});
+
 	it("encodes reranker enum values into the derived matrix", async () => {
 		const stateDir = mkdtempSync(join(tmpdir(), "wtfoc-materialize-"));
 		const result = await materializeVariant({

--- a/scripts/autoresearch/materialize-variant.test.ts
+++ b/scripts/autoresearch/materialize-variant.test.ts
@@ -137,6 +137,26 @@ describe("materializeVariant — matrix synthesis", () => {
 		expect(result.notes.some((n) => n.includes("noar_div_rrBge") && n.includes("#394"))).toBe(true);
 	});
 
+	it("preserves legacy `?? true` defaults when both productionVariantId and targetVariantId are unset", async () => {
+		// Exploratory matrices may have no productionVariantId. Pre-#394 the
+		// internal `matrix.productionVariantId?.includes(...) ?? true` fallback
+		// defaulted diversityEnforce to true. Coercing to "" would break that.
+		const stateDir = mkdtempSync(join(tmpdir(), "wtfoc-materialize-"));
+		const m = baseMatrix();
+		const noProdMatrix = { ...m, productionVariantId: undefined as unknown as string };
+		const result = await materializeVariant({
+			productionMatrix: noProdMatrix,
+			productionMatrixName: "retrieval-baseline",
+			proposal: { axis: "topK", value: 30, rationale: "wider K" },
+			spawnFn: () => Buffer.from(""),
+			stateDir,
+		});
+		const body = readFileSync(result.matrixPath, "utf-8");
+		const parsed = JSON.parse(body.split("export default ")[1]?.replace(/;\s*$/, "").trim() ?? "{}");
+		expect(parsed.axes.diversityEnforce).toEqual([true]);
+		expect(parsed.axes.reranker).toEqual(["off"]);
+	});
+
 	it("falls back to productionVariantId when targetVariantId omitted (legacy)", async () => {
 		const stateDir = mkdtempSync(join(tmpdir(), "wtfoc-materialize-"));
 		const result = await materializeVariant({

--- a/scripts/autoresearch/materialize-variant.ts
+++ b/scripts/autoresearch/materialize-variant.ts
@@ -37,6 +37,16 @@ export interface MaterializeInputs {
 	productionMatrix: Matrix;
 	productionMatrixName: string;
 	proposal: Proposal;
+	/**
+	 * Variant the patch should target (typically `finding.variantId` from
+	 * the regression detector). When set and different from
+	 * `productionMatrix.productionVariantId`, base axes are derived from
+	 * this variant id and the baseline window for decide() runs against
+	 * the same variant. Mapping is surfaced in `notes` for audit (#394).
+	 *
+	 * When unset, falls back to `productionVariantId` (legacy behavior).
+	 */
+	targetVariantId?: string;
 	/** Stage tag for the run. Default "autoresearch-proposal". */
 	stage?: string;
 	/**
@@ -66,19 +76,24 @@ export interface MaterializeResult {
 	notes: string[];
 }
 
-function applyAxisToMatrix(matrix: Matrix, knob: Knob, value: boolean | number | string): Matrix {
-	// Build single-value axes. For axes that are NOT the proposed one,
-	// pick the production-default so the derived matrix has exactly one
-	// variant.
+function applyAxisToMatrix(
+	matrix: Matrix,
+	knob: Knob,
+	value: boolean | number | string,
+	baseVariantId?: string,
+): Matrix {
+	// Build single-value axes from the base variant id (defaults to the
+	// matrix's productionVariantId; #394 lets callers override with a
+	// finding's targetVariantId so the derived matrix mutates against the
+	// regressed variant rather than unconditionally against production).
+	const baseId = baseVariantId ?? matrix.productionVariantId;
 	const axes: VariantAxes = {
-		autoRoute: [matrix.productionVariantId?.includes("ar_") && !matrix.productionVariantId.startsWith("noar")
-			? true
-			: false],
-		diversityEnforce: [matrix.productionVariantId?.includes("_div_") ?? true],
+		autoRoute: [baseId?.includes("ar_") && !baseId.startsWith("noar") ? true : false],
+		diversityEnforce: [baseId?.includes("_div_") ?? true],
 		reranker: [
-			matrix.productionVariantId?.includes("rrLlm")
+			baseId?.includes("rrLlm")
 				? ({ type: "llm", url: "http://127.0.0.1:4523/v1", model: "haiku" } as RerankerSpec)
-				: matrix.productionVariantId?.includes("rrBge")
+				: baseId?.includes("rrBge")
 					? ({ type: "bge", url: "http://127.0.0.1:8386" } as RerankerSpec)
 					: ("off" as const),
 		],
@@ -161,7 +176,9 @@ export async function materializeVariant(
 	mkdirSync(proposalDir, { recursive: true });
 	const matrixPath = join(proposalDir, "matrix.ts");
 
-	const derived = applyAxisToMatrix(input.productionMatrix, knob, input.proposal.value);
+	const productionVariantId = input.productionMatrix.productionVariantId ?? "";
+	const baseVariantId = input.targetVariantId ?? productionVariantId;
+	const derived = applyAxisToMatrix(input.productionMatrix, knob, input.proposal.value, baseVariantId);
 	writeFileSync(matrixPath, renderMatrixFile(derived, proposalId));
 
 	// Run the sweep.
@@ -203,11 +220,17 @@ export async function materializeVariant(
 	// of those baseline runs — mirroring the regression detector's
 	// majority rule. Single-baseline accept is too noisy given the
 	// documented paraphrase brittleness (~48%).
-	const productionVariantId = input.productionMatrix.productionVariantId ?? "";
 	const minBaseline = input.minBaseline ?? 3;
 	const decisions: MaterializeResult["decisions"] = [];
 	const corpora = Array.from(new Set(reports.map((r) => r.runConfig.collectionId)));
 	const notes: string[] = [];
+	if (input.targetVariantId && input.targetVariantId !== productionVariantId) {
+		notes.push(
+			`materialize: target=${input.targetVariantId} (from finding) ` +
+				`differs from productionVariantId=${productionVariantId || "(unset)"} — ` +
+				`base axes derived from target; baseline window scoped to target variant (#394)`,
+		);
+	}
 	let allAccept = corpora.length > 0;
 	for (const corpus of corpora) {
 		const candidateReport = reports.find((r) => r.runConfig.collectionId === corpus);
@@ -220,11 +243,12 @@ export async function materializeVariant(
 		// production variant on this corpus, sharing the SAME
 		// runConfigFingerprint. Comparability rule mirrors detector.
 		const candidateFingerprint = candidateReport.runConfigFingerprint;
+		const baselineVariantId = input.targetVariantId ?? productionVariantId;
 		const baselineRows = [...allRows]
 			.reverse()
 			.filter(
 				(r) =>
-					r.variantId === productionVariantId &&
+					r.variantId === baselineVariantId &&
 					r.runConfig.collectionId === corpus &&
 					r.stage === "nightly-cron" &&
 					r.runConfigFingerprint === candidateFingerprint &&

--- a/scripts/autoresearch/materialize-variant.ts
+++ b/scripts/autoresearch/materialize-variant.ts
@@ -176,8 +176,7 @@ export async function materializeVariant(
 	mkdirSync(proposalDir, { recursive: true });
 	const matrixPath = join(proposalDir, "matrix.ts");
 
-	const productionVariantId = input.productionMatrix.productionVariantId ?? "";
-	const baseVariantId = input.targetVariantId ?? productionVariantId;
+	const baseVariantId = input.targetVariantId ?? input.productionMatrix.productionVariantId;
 	const derived = applyAxisToMatrix(input.productionMatrix, knob, input.proposal.value, baseVariantId);
 	writeFileSync(matrixPath, renderMatrixFile(derived, proposalId));
 
@@ -220,6 +219,7 @@ export async function materializeVariant(
 	// of those baseline runs — mirroring the regression detector's
 	// majority rule. Single-baseline accept is too noisy given the
 	// documented paraphrase brittleness (~48%).
+	const productionVariantId = input.productionMatrix.productionVariantId ?? "";
 	const minBaseline = input.minBaseline ?? 3;
 	const decisions: MaterializeResult["decisions"] = [];
 	const corpora = Array.from(new Set(reports.map((r) => r.runConfig.collectionId)));


### PR DESCRIPTION
## Summary

Fixes the loop's target-variant materialization seam (#394). When a regression finding implicates variant X, the materializer now derives base axes from X (the target) instead of unconditionally from `matrix.productionVariantId`.

Caught during the autonomy-proof attempt against #327: proposer rationale cited BGE reranker, but the materialized variant had rerank off (production base) — evidence chain broke.

- `materializeVariant` accepts new optional `targetVariantId`. When set + diverges from production, base axes derive from target and the decide() baseline window is scoped to that variant.
- `autonomous-loop` threads `finding.variantId` into the call.
- Dry-run output surfaces the target→production mapping for audit.
- Legacy callers (no `targetVariantId`) keep production behavior.

## Test plan

- [x] `pnpm vitest run scripts/autoresearch/` — 334 pass, 2 new tests cover cross-variant + legacy fallback
- [x] `pnpm -r build` clean
- [x] Dry-run with `/tmp/findings-327.json` (synthetic finding for noar_div_rrBge) prints: `materialize-target: noar_div_rrBge (from finding) — production=noar_div_rrOff; base axes would be derived from target`
- [ ] Post-merge: re-run loop in #395 to confirm proposer rationale + materialized variant match