### PR TITLE
fix(autoresearch): surface vllm-admin failureReason in mode-switch errors

### DIFF
--- a/scripts/lib/mode-switch.test.ts
+++ b/scripts/lib/mode-switch.test.ts
@@ -8,9 +8,18 @@ function jsonResponse(body: unknown, status = 200): Response {
 	});
 }
 
-function buildState(activeMode: string, modePhase: string): unknown {
+function buildState(
+	activeMode: string,
+	modePhase: string,
+	extra?: { failureReason?: string; targetMode?: string | null },
+): unknown {
 	return {
-		state: { activeMode, modePhase, targetMode: null },
+		state: {
+			activeMode,
+			modePhase,
+			targetMode: extra?.targetMode ?? null,
+			failureReason: extra?.failureReason ?? null,
+		},
 		observedSteadyMode: activeMode,
 	};
 }
@@ -91,6 +100,54 @@ describe("ensureMode", () => {
 				timeoutMs: 5000,
 			}),
 		).rejects.toThrow(/terminal failure/);
+	});
+
+	it("surfaces failureReason when terminal-OK lands on wrong mode (rollback)", async () => {
+		// Real-world case: target=rerank-gpu, image-pull fails, vllm-admin
+		// rolls back to chat, terminal phase becomes ChatActive. Caller
+		// needs the underlying reason without curling /admin/mode.
+		const seq: Response[] = [
+			jsonResponse(buildState("chat", "ChatActive")), // initial
+			jsonResponse({ operationId: "x" }), // POST
+			jsonResponse(
+				buildState("chat", "ChatActive", {
+					failureReason: "image_pull_back_off: target reranker-gpu ImagePullBackOff for >30s",
+					targetMode: "rerank-gpu",
+				}),
+			), // poll: rolled back
+		];
+		const fetchFn = vi.fn(async () => seq.shift() ?? jsonResponse({}));
+		await expect(
+			ensureMode("rerank-gpu", {
+				adminUrl: "http://admin",
+				fetchFn: fetchFn as unknown as typeof fetch,
+				enabled: true,
+				pollIntervalMs: 1,
+				timeoutMs: 5000,
+			}),
+		).rejects.toThrow(/image_pull_back_off/);
+	});
+
+	it("surfaces failureReason on terminal-failure phase", async () => {
+		const seq: Response[] = [
+			jsonResponse(buildState("chat", "ChatActive")),
+			jsonResponse({ operationId: "x" }),
+			jsonResponse(
+				buildState("chat", "RollbackFailed", {
+					failureReason: "kubelet_unreachable: node bt-gpu-1 NotReady",
+				}),
+			),
+		];
+		const fetchFn = vi.fn(async () => seq.shift() ?? jsonResponse({}));
+		await expect(
+			ensureMode("rerank-gpu", {
+				adminUrl: "http://admin",
+				fetchFn: fetchFn as unknown as typeof fetch,
+				enabled: true,
+				pollIntervalMs: 1,
+				timeoutMs: 5000,
+			}),
+		).rejects.toThrow(/kubelet_unreachable/);
 	});
 
 	it("throws on manual-recovery 409", async () => {

--- a/scripts/lib/mode-switch.ts
+++ b/scripts/lib/mode-switch.ts
@@ -37,6 +37,8 @@ interface ModeStateEnvelope {
 		activeMode: GpuMode;
 		modePhase: string;
 		targetMode: GpuMode | null;
+		failureReason?: string | null;
+		lastKnownGoodMode?: GpuMode | null;
 	};
 	observedSteadyMode: GpuMode | null;
 }
@@ -194,14 +196,22 @@ export async function ensureMode(
 		const phase = env.state.modePhase;
 		if (TERMINAL_OK.has(phase)) {
 			if (env.state.activeMode !== target) {
+				// vllm-admin reached a terminal-OK phase but on the wrong mode
+				// — typically rollback after the target failed (e.g. image
+				// pull error). Surface failureReason so callers don't need to
+				// curl /admin/mode for the actual cause.
+				const reason = env.state.failureReason;
+				const detail = reason ? ` reason=${reason}` : "";
 				throw new Error(
-					`mode-switch terminal-OK but activeMode=${env.state.activeMode} != target=${target}`,
+					`mode-switch terminal-OK but activeMode=${env.state.activeMode} != target=${target} (phase=${phase})${detail}`,
 				);
 			}
 			return { skipped: false, from, to: target, finalPhase: phase };
 		}
 		if (TERMINAL_FAIL.has(phase)) {
-			throw new Error(`mode-switch terminal failure: ${phase} (target=${target})`);
+			const reason = env.state.failureReason;
+			const detail = reason ? ` reason=${reason}` : "";
+			throw new Error(`mode-switch terminal failure: ${phase} (target=${target})${detail}`);
 		}
 		await sleep(pollMs);
 	}

--- a/scripts/lib/mode-switch.ts
+++ b/scripts/lib/mode-switch.ts
@@ -200,8 +200,8 @@ export async function ensureMode(
 				// — typically rollback after the target failed (e.g. image
 				// pull error). Surface failureReason so callers don't need to
 				// curl /admin/mode for the actual cause.
-				const reason = env.state.failureReason;
-				const detail = reason ? ` reason=${reason}` : "";
+				const failureReason = env.state.failureReason;
+				const detail = failureReason ? ` reason=${failureReason}` : "";
 				throw new Error(
 					`mode-switch terminal-OK but activeMode=${env.state.activeMode} != target=${target} (phase=${phase})${detail}`,
 				);


### PR DESCRIPTION
## Summary

Discovered while debugging #395 — vllm-admin was rolling back to chat after rerank-gpu image-pull failed, but the loop only reported a generic mismatch:

> mode-switch terminal-OK but activeMode=chat != target=rerank-gpu

Required curling \`/admin/mode\` manually to see the actual cause:
> failureReason: image_pull_back_off: target reranker-gpu ImagePullBackOff for >30s

Now surfaced inline on both error paths (terminal-OK-on-wrong-mode, terminal-failure-phase). Pure observability — no happy-path behavior change.

## Test plan

- [x] \`pnpm vitest run scripts/lib/mode-switch.test.ts\` — 15 pass, 2 new tests cover failureReason surfacing on rollback + terminal-failure
- [x] \`pnpm -r build\` clean
- [x] Existing \`/terminal failure/\` regex test still matches new format