### PR TITLE
fix(autoresearch): relax baseline fingerprint match in materialize-variant

### DIFF
--- a/scripts/autoresearch/materialize-variant.test.ts
+++ b/scripts/autoresearch/materialize-variant.test.ts
@@ -172,6 +172,85 @@ describe("materializeVariant — matrix synthesis", () => {
 		expect(result.notes.some((n) => n.includes("#394"))).toBe(false);
 	});
 
+	it("falls back to fingerprint-loose baselines when strict matches insufficient", async () => {
+		// Real-world case: candidate sweep produces a fingerprint that no
+		// nightly-cron baseline shares (env/code drift). Strict match would
+		// always block knob proposals. Relaxed fallback uses recent
+		// nightly-cron rows for the same variant+corpus regardless of fp,
+		// mirrors materialize-patch's policy.
+		const stateDir = mkdtempSync(join(tmpdir(), "wtfoc-materialize-"));
+		// Pre-seed runs.jsonl with 3 nightly-cron rows + a candidate row.
+		// Use a temp run-log dir so we don't pollute real history.
+		const runLogDir = mkdtempSync(join(tmpdir(), "wtfoc-runlog-"));
+		const runsPath = join(runLogDir, "runs.jsonl");
+		const reportsDir = join(runLogDir, "reports");
+		mkdirSync(reportsDir, { recursive: true });
+		// Helper: write a minimal report file + return its path.
+		const writeReport = (variantId: string, fp: string, passRate: number) => {
+			const p = join(reportsDir, `${variantId}-${fp.slice(0, 8)}-${passRate}.json`);
+			const report = {
+				runConfig: { collectionId: "filoz" },
+				runConfigFingerprint: fp,
+				summary: { passRate, demoCriticalPassRate: 1, recallAtKMean: 0.5, latencyP95Ms: 1000 },
+				variantId,
+			};
+			writeFileSync(p, JSON.stringify(report));
+			return p;
+		};
+		const baselineFp = "fp_baseline_old";
+		const candidateFp = "fp_candidate_drift";
+		const baselineRows = [0, 1, 2].map((i) => ({
+			schemaVersion: 1,
+			loggedAt: new Date(Date.now() - (i + 1) * 86400000).toISOString(),
+			matrixName: "retrieval-baseline",
+			variantId: "noar_div_rrOff",
+			sweepId: `nightly-${i}`,
+			runConfigFingerprint: baselineFp,
+			runConfig: { collectionId: "filoz" },
+			stage: "nightly-cron",
+			reportPath: writeReport("noar_div_rrOff", baselineFp, 0.5),
+			summary: { passRate: 0.5, demoCriticalPassRate: 1, recallAtKMean: 0.5, latencyP95Ms: 1000 },
+		}));
+		const candidateRow = {
+			schemaVersion: 1,
+			loggedAt: new Date().toISOString(),
+			matrixName: "retrieval-baseline",
+			variantId: "noar_div_rrOff_tps5",
+			sweepId: "ar-proposal-1",
+			runConfigFingerprint: candidateFp,
+			runConfig: { collectionId: "filoz" },
+			stage: "autoresearch-proposal",
+			reportPath: writeReport("noar_div_rrOff_tps5", candidateFp, 0.6),
+			summary: { passRate: 0.6, demoCriticalPassRate: 1, recallAtKMean: 0.6, latencyP95Ms: 1000 },
+		};
+		writeFileSync(runsPath, [...baselineRows, candidateRow].map((r) => JSON.stringify(r)).join("\n") + "\n");
+		// Point run-log at our temp dir.
+		const prevDir = process.env.WTFOC_AUTORESEARCH_DIR;
+		process.env.WTFOC_AUTORESEARCH_DIR = runLogDir;
+		try {
+			const result = await materializeVariant({
+				productionMatrix: baseMatrix(),
+				productionMatrixName: "retrieval-baseline",
+				proposal: { axis: "traceMaxPerSource", value: 5, rationale: "x" },
+				targetVariantId: "noar_div_rrOff",
+				spawnFn: () => Buffer.from(""),
+				stateDir,
+				minBaseline: 3,
+			});
+			// Relaxed-fallback path fired (note surfaced). decide() may
+			// return null if the minimal fixture reports lack scores —
+			// that's an orthogonal concern; what matters here is that the
+			// baseline-window construction is no longer empty.
+			expect(result.notes.some((n) => n.includes("fingerprint-loose"))).toBe(true);
+			expect(
+				result.decisions[0]?.reason?.includes("only 0 comparable production baseline"),
+			).not.toBe(true);
+		} finally {
+			if (prevDir === undefined) delete process.env.WTFOC_AUTORESEARCH_DIR;
+			else process.env.WTFOC_AUTORESEARCH_DIR = prevDir;
+		}
+	});
+
 	it("encodes reranker enum values into the derived matrix", async () => {
 		const stateDir = mkdtempSync(join(tmpdir(), "wtfoc-materialize-"));
 		const result = await materializeVariant({

--- a/scripts/autoresearch/materialize-variant.test.ts
+++ b/scripts/autoresearch/materialize-variant.test.ts
@@ -197,20 +197,30 @@ describe("materializeVariant — matrix synthesis", () => {
 			writeFileSync(p, JSON.stringify(report));
 			return p;
 		};
-		const baselineFp = "fp_baseline_old";
+		// Distinct baseline rows — each gets its own report file so that
+		// every row in the baseline window can be loaded independently
+		// (overlapping report paths would silently collapse the window).
 		const candidateFp = "fp_candidate_drift";
-		const baselineRows = [0, 1, 2].map((i) => ({
-			schemaVersion: 1,
-			loggedAt: new Date(Date.now() - (i + 1) * 86400000).toISOString(),
-			matrixName: "retrieval-baseline",
-			variantId: "noar_div_rrOff",
-			sweepId: `nightly-${i}`,
-			runConfigFingerprint: baselineFp,
-			runConfig: { collectionId: "filoz" },
-			stage: "nightly-cron",
-			reportPath: writeReport("noar_div_rrOff", baselineFp, 0.5),
-			summary: { passRate: 0.5, demoCriticalPassRate: 1, recallAtKMean: 0.5, latencyP95Ms: 1000 },
-		}));
+		const baselineRows = [0, 1, 2].map((i) => {
+			const fp = `fp_baseline_${i}`;
+			return {
+				schemaVersion: 1,
+				loggedAt: new Date(Date.now() - (i + 1) * 86400000).toISOString(),
+				matrixName: "retrieval-baseline",
+				variantId: "noar_div_rrOff",
+				sweepId: `nightly-${i}`,
+				runConfigFingerprint: fp,
+				runConfig: { collectionId: "filoz" },
+				stage: "nightly-cron",
+				reportPath: writeReport("noar_div_rrOff", fp, 0.5 + i * 0.01),
+				summary: {
+					passRate: 0.5 + i * 0.01,
+					demoCriticalPassRate: 1,
+					recallAtKMean: 0.5,
+					latencyP95Ms: 1000,
+				},
+			};
+		});
 		const candidateRow = {
 			schemaVersion: 1,
 			loggedAt: new Date().toISOString(),

--- a/scripts/autoresearch/materialize-variant.ts
+++ b/scripts/autoresearch/materialize-variant.ts
@@ -240,11 +240,16 @@ export async function materializeVariant(
 			continue;
 		}
 		// Build baseline window: latest N nightly-cron rows for the
-		// production variant on this corpus, sharing the SAME
-		// runConfigFingerprint. Comparability rule mirrors detector.
+		// production variant on this corpus. Strict rule: same
+		// runConfigFingerprint (mirrors detect-regression). Relaxed
+		// fallback: when strict matches insufficient, fall back to most-
+		// recent N nightly-cron rows regardless of fingerprint — same
+		// policy as materialize-patch.ts since fingerprints drift across
+		// env/code changes and a too-strict rule makes proposals
+		// uniformly un-acceptable in practice. Surfaced in notes for audit.
 		const candidateFingerprint = candidateReport.runConfigFingerprint;
 		const baselineVariantId = input.targetVariantId ?? productionVariantId;
-		const baselineRows = [...allRows]
+		const strictMatches = [...allRows]
 			.reverse()
 			.filter(
 				(r) =>
@@ -254,12 +259,35 @@ export async function materializeVariant(
 					r.runConfigFingerprint === candidateFingerprint &&
 					r.reportPath,
 			);
+		let baselineRows = strictMatches;
+		let usedRelaxed = false;
+		if (baselineRows.length < minBaseline) {
+			const relaxedMatches = [...allRows]
+				.reverse()
+				.filter(
+					(r) =>
+						r.variantId === baselineVariantId &&
+						r.runConfig.collectionId === corpus &&
+						r.stage === "nightly-cron" &&
+						r.reportPath,
+				);
+			if (relaxedMatches.length >= minBaseline) {
+				baselineRows = relaxedMatches;
+				usedRelaxed = true;
+				notes.push(
+					`corpus=${corpus}: 0 fingerprint-strict baselines — falling back to ` +
+						`${relaxedMatches.length} fingerprint-loose nightly-cron rows ` +
+						`for variant=${baselineVariantId} (caveat: env/code drift may bias decide())`,
+				);
+			}
+		}
 		const window = baselineRows.slice(0, minBaseline);
 		if (window.length < minBaseline) {
 			decisions.push({
 				corpus,
 				verdict: null,
-				reason: `only ${window.length} comparable production baseline(s); need >= ${minBaseline}`,
+				reason: `only ${window.length} comparable production baseline(s); need >= ${minBaseline}` +
+					(usedRelaxed ? " (relaxed fingerprint match also insufficient)" : ""),
 			});
 			notes.push(
 				`corpus=${corpus}: only ${window.length} comparable baseline(s) — accept blocked`,

--- a/scripts/autoresearch/materialize-variant.ts
+++ b/scripts/autoresearch/materialize-variant.ts
@@ -246,7 +246,7 @@ export async function materializeVariant(
 		// recent N nightly-cron rows regardless of fingerprint — same
 		// policy as materialize-patch.ts since fingerprints drift across
 		// env/code changes and a too-strict rule makes proposals
-		// uniformly un-acceptable in practice. Surfaced in notes for audit.
+		// uniformly unacceptable in practice. Surfaced in notes for audit.
 		const candidateFingerprint = candidateReport.runConfigFingerprint;
 		const baselineVariantId = input.targetVariantId ?? productionVariantId;
 		const strictMatches = [...allRows]
@@ -260,7 +260,6 @@ export async function materializeVariant(
 					r.reportPath,
 			);
 		let baselineRows = strictMatches;
-		let usedRelaxed = false;
 		if (baselineRows.length < minBaseline) {
 			const relaxedMatches = [...allRows]
 				.reverse()
@@ -273,11 +272,11 @@ export async function materializeVariant(
 				);
 			if (relaxedMatches.length >= minBaseline) {
 				baselineRows = relaxedMatches;
-				usedRelaxed = true;
 				notes.push(
-					`corpus=${corpus}: 0 fingerprint-strict baselines — falling back to ` +
-						`${relaxedMatches.length} fingerprint-loose nightly-cron rows ` +
-						`for variant=${baselineVariantId} (caveat: env/code drift may bias decide())`,
+					`corpus=${corpus}: ${strictMatches.length} fingerprint-strict baseline(s) ` +
+						`(< minBaseline=${minBaseline}) — falling back to ${relaxedMatches.length} ` +
+						`fingerprint-loose nightly-cron rows for variant=${baselineVariantId} ` +
+						`(caveat: env/code drift may bias decide())`,
 				);
 			}
 		}
@@ -286,8 +285,7 @@ export async function materializeVariant(
 			decisions.push({
 				corpus,
 				verdict: null,
-				reason: `only ${window.length} comparable production baseline(s); need >= ${minBaseline}` +
-					(usedRelaxed ? " (relaxed fingerprint match also insufficient)" : ""),
+				reason: `only ${window.length} comparable production baseline(s); need >= ${minBaseline} (strict + relaxed both insufficient)`,
 			});
 			notes.push(
 				`corpus=${corpus}: only ${window.length} comparable baseline(s) — accept blocked`,


### PR DESCRIPTION
## Summary

The variant-materialization path required strict \`runConfigFingerprint\` equality between candidate sweep and baseline window. In practice every knob proposal was rejected with \"0 comparable baselines\" because env/code drift makes fingerprints differ across runs.

This mirrors the relaxed policy already in \`materialize-patch.ts\` (its line 336-340 comment): when fingerprint-strict matches are insufficient, fall back to most-recent-N nightly-cron rows for the same variant+corpus regardless of fingerprint. Caveat surfaced in \`notes\`.

Discovered during #395 autonomy-proof attempt. Loop ran end-to-end successfully (sweep → decide), but the candidate was uniformly rejected before decide() could actually run, because the baseline window was empty. With relaxed fallback the acceptance pathway can exercise.

## Test plan

- [x] \`pnpm vitest run scripts/autoresearch/materialize-variant.test.ts\` — 10 pass, 1 new test for strict-fail / loose-succeed path
- [x] \`pnpm -r build\` clean
- [ ] Post-merge: re-run #395 loop end-to-end, confirm decide() actually runs against the relaxed baseline window