### PR TITLE
fix(autoresearch): patch sweep targets finding's variant (#403)

### DIFF
--- a/scripts/autoresearch/autonomous-loop.ts
+++ b/scripts/autoresearch/autonomous-loop.ts
@@ -584,6 +584,7 @@ async function runPatchPath(input: {
 		productionMatrix: matrix,
 		productionMatrixName: cli.matrixName,
 		proposal: llm.proposal,
+		targetVariantId: finding.variantId,
 	});
 
 	// Persist a tried-log row regardless of outcome.

--- a/scripts/autoresearch/materialize-patch.test.ts
+++ b/scripts/autoresearch/materialize-patch.test.ts
@@ -1,0 +1,140 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { Matrix } from "./matrix.js";
+import { materializePatchProposal } from "./materialize-patch.js";
+import type { PatchProposal } from "./patch-proposal.js";
+
+function baseMatrix(): Matrix {
+	return {
+		name: "retrieval-baseline",
+		description: "test",
+		productionVariantId: "noar_div_rrOff",
+		baseConfig: {
+			collections: { primary: "filoz", secondary: "wtfoc-v3" },
+			embedderUrl: "http://x/v1",
+			embedderModel: "test",
+		},
+		axes: {
+			autoRoute: [false],
+			diversityEnforce: [true],
+			reranker: ["off"],
+		},
+	};
+}
+
+function setupTestEnv(targetFilePath: string, fileContent: string) {
+	const stateDir = mkdtempSync(join(tmpdir(), "wtfoc-mp-"));
+	process.env.WTFOC_AUTORESEARCH_DIR = stateDir;
+	// Pre-create the worktree dir + target file so that applyEdit doesn't
+	// blow up on a missing path (we mock the spawnFn that would normally
+	// `git worktree add` it for real).
+	const proposalIdPrefix = "patch_";
+	// proposalDir is computed inside the function as
+	// stateDir/proposals/<proposalId>/worktree. We can't predict the
+	// proposalId since it includes Date.now(), so create the proposals
+	// dir and a generic worktree under any nested layout via mkdir -p
+	// once spawnFn fires.
+	const proposalsRoot = join(stateDir, "proposals");
+	mkdirSync(proposalsRoot, { recursive: true });
+	return { stateDir, proposalsRoot };
+}
+
+function buildSpawnFn(
+	calls: Array<{ cmd: string; args: string[] }>,
+	worktreeFileSetup: (worktreePath: string) => void,
+) {
+	return (cmd: string, args: string[], opts?: { cwd?: string }) => {
+		calls.push({ cmd, args });
+		// Simulate `git worktree add --detach <worktreePath> <baseSha>` by
+		// creating the worktree dir + target file the test expects.
+		if (cmd === "git" && args[0] === "worktree" && args[1] === "add") {
+			const detachIdx = args.indexOf("--detach");
+			const worktreePath = args[detachIdx + 1] ?? "";
+			if (worktreePath) {
+				mkdirSync(worktreePath, { recursive: true });
+				worktreeFileSetup(worktreePath);
+			}
+		}
+		return Buffer.from("");
+	};
+}
+
+describe("materializePatchProposal — #403 target-variant sweep", () => {
+	const before = "function applySeedDiversity(seeds) {\n  return seeds;\n}\n";
+	const after = "function applySeedDiversity(seeds) {\n  return seeds.filter((s) => s);\n}\n";
+	const proposal: PatchProposal = {
+		kind: "patch",
+		baseSha: "eca38385766c7184ee95da4c13b29f0a6ea2e2db",
+		edits: [
+			{
+				file: "packages/search/src/trace/trace.ts",
+				old: before,
+				new: after,
+			},
+		],
+		rationale: "fix applySeedDiversity",
+	};
+
+	it("invokes sweep with --variant-filter <targetVariantId> when target differs from production", async () => {
+		const calls: Array<{ cmd: string; args: string[] }> = [];
+		const { stateDir } = setupTestEnv("", "");
+		const spawnFn = buildSpawnFn(calls, (worktreePath) => {
+			const target = join(worktreePath, "packages/search/src/trace/trace.ts");
+			mkdirSync(join(worktreePath, "packages/search/src/trace"), { recursive: true });
+			writeFileSync(target, before);
+		});
+
+		const result = await materializePatchProposal({
+			productionMatrix: baseMatrix(),
+			productionMatrixName: "retrieval-baseline",
+			proposal,
+			targetVariantId: "noar_div_rrBge",
+			spawnFn,
+			stateDir,
+		});
+
+		const sweepCall = calls.find(
+			(c) => c.cmd === "pnpm" && c.args.includes("autoresearch:sweep"),
+		);
+		expect(sweepCall).toBeDefined();
+		const filterIdx = sweepCall!.args.indexOf("--variant-filter");
+		expect(filterIdx).toBeGreaterThanOrEqual(0);
+		expect(sweepCall!.args[filterIdx + 1]).toBe("noar_div_rrBge");
+		expect(
+			result.notes.some(
+				(n) =>
+					n.includes("noar_div_rrBge") &&
+					n.includes("#403") &&
+					n.includes("differs from productionVariantId"),
+			),
+		).toBe(true);
+	});
+
+	it("falls back to productionVariantId when targetVariantId omitted (legacy)", async () => {
+		const calls: Array<{ cmd: string; args: string[] }> = [];
+		const { stateDir } = setupTestEnv("", "");
+		const spawnFn = buildSpawnFn(calls, (worktreePath) => {
+			const target = join(worktreePath, "packages/search/src/trace/trace.ts");
+			mkdirSync(join(worktreePath, "packages/search/src/trace"), { recursive: true });
+			writeFileSync(target, before);
+		});
+
+		const result = await materializePatchProposal({
+			productionMatrix: baseMatrix(),
+			productionMatrixName: "retrieval-baseline",
+			proposal,
+			spawnFn,
+			stateDir,
+		});
+
+		const sweepCall = calls.find(
+			(c) => c.cmd === "pnpm" && c.args.includes("autoresearch:sweep"),
+		);
+		expect(sweepCall).toBeDefined();
+		const filterIdx = sweepCall!.args.indexOf("--variant-filter");
+		expect(sweepCall!.args[filterIdx + 1]).toBe("noar_div_rrOff");
+		expect(result.notes.some((n) => n.includes("#403"))).toBe(false);
+	});
+});

--- a/scripts/autoresearch/materialize-patch.test.ts
+++ b/scripts/autoresearch/materialize-patch.test.ts
@@ -1,7 +1,7 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Matrix } from "./matrix.js";
 import { materializePatchProposal } from "./materialize-patch.js";
 import type { PatchProposal } from "./patch-proposal.js";
@@ -24,18 +24,12 @@ function baseMatrix(): Matrix {
 	};
 }
 
-function setupTestEnv(targetFilePath: string, fileContent: string) {
+function setupTestEnv() {
 	const stateDir = mkdtempSync(join(tmpdir(), "wtfoc-mp-"));
-	process.env.WTFOC_AUTORESEARCH_DIR = stateDir;
-	// Pre-create the worktree dir + target file so that applyEdit doesn't
-	// blow up on a missing path (we mock the spawnFn that would normally
-	// `git worktree add` it for real).
-	const proposalIdPrefix = "patch_";
 	// proposalDir is computed inside the function as
-	// stateDir/proposals/<proposalId>/worktree. We can't predict the
-	// proposalId since it includes Date.now(), so create the proposals
-	// dir and a generic worktree under any nested layout via mkdir -p
-	// once spawnFn fires.
+	// stateDir/proposals/<proposalId>/worktree. The proposalId includes
+	// Date.now() so we can't predict it; create the proposals root and
+	// let spawnFn-mock create the worktree subtree once it fires.
 	const proposalsRoot = join(stateDir, "proposals");
 	mkdirSync(proposalsRoot, { recursive: true });
 	return { stateDir, proposalsRoot };
@@ -77,9 +71,22 @@ describe("materializePatchProposal — #403 target-variant sweep", () => {
 		rationale: "fix applySeedDiversity",
 	};
 
+	const tempDirs: string[] = [];
+	afterEach(() => {
+		for (const d of tempDirs) {
+			try {
+				rmSync(d, { recursive: true, force: true });
+			} catch {
+				// best-effort cleanup
+			}
+		}
+		tempDirs.length = 0;
+	});
+
 	it("invokes sweep with --variant-filter <targetVariantId> when target differs from production", async () => {
 		const calls: Array<{ cmd: string; args: string[] }> = [];
-		const { stateDir } = setupTestEnv("", "");
+		const { stateDir } = setupTestEnv();
+		tempDirs.push(stateDir);
 		const spawnFn = buildSpawnFn(calls, (worktreePath) => {
 			const target = join(worktreePath, "packages/search/src/trace/trace.ts");
 			mkdirSync(join(worktreePath, "packages/search/src/trace"), { recursive: true });
@@ -112,9 +119,34 @@ describe("materializePatchProposal — #403 target-variant sweep", () => {
 		).toBe(true);
 	});
 
+	it("bails with skippedReason when both productionVariantId and targetVariantId are unset", async () => {
+		const calls: Array<{ cmd: string; args: string[] }> = [];
+		const { stateDir } = setupTestEnv();
+		tempDirs.push(stateDir);
+		const spawnFn = buildSpawnFn(calls, () => {});
+		const m = baseMatrix();
+		const noProdMatrix = { ...m, productionVariantId: undefined as unknown as string };
+		const result = await materializePatchProposal({
+			productionMatrix: noProdMatrix,
+			productionMatrixName: "retrieval-baseline",
+			proposal,
+			spawnFn,
+			stateDir,
+		});
+		expect(result.skippedReason).toMatch(/no variant id resolvable/);
+		expect(result.aggregateAccept).toBe(false);
+		// Sweep must NOT have fired with empty filter (which would run all
+		// variants and obscure evidence).
+		const sweepCall = calls.find(
+			(c) => c.cmd === "pnpm" && c.args.includes("autoresearch:sweep"),
+		);
+		expect(sweepCall).toBeUndefined();
+	});
+
 	it("falls back to productionVariantId when targetVariantId omitted (legacy)", async () => {
 		const calls: Array<{ cmd: string; args: string[] }> = [];
-		const { stateDir } = setupTestEnv("", "");
+		const { stateDir } = setupTestEnv();
+		tempDirs.push(stateDir);
 		const spawnFn = buildSpawnFn(calls, (worktreePath) => {
 			const target = join(worktreePath, "packages/search/src/trace/trace.ts");
 			mkdirSync(join(worktreePath, "packages/search/src/trace"), { recursive: true });

--- a/scripts/autoresearch/materialize-patch.ts
+++ b/scripts/autoresearch/materialize-patch.ts
@@ -9,9 +9,11 @@
  *   - `git apply` is run with `--check` first; refuse to materialize
  *     if the diff doesn't apply cleanly.
  *   - The sweep runs against the production matrix (knob axes
- *     unchanged) — only the source tree differs. Variant id stays
- *     the production variant id; only `runConfigFingerprint` differs
- *     because git sha changes.
+ *     unchanged) — only the source tree differs. The sweep targets
+ *     `targetVariantId` when supplied (typically `finding.variantId`,
+ *     #403); otherwise falls back to `productionVariantId`. The
+ *     `runConfigFingerprint` differs from baselines because git sha
+ *     changes.
  *   - On accept, the caller (autonomous-loop) opens a draft PR from
  *     the worktree's branch.
  */
@@ -30,6 +32,19 @@ export interface MaterializePatchInputs {
 	productionMatrix: Matrix;
 	productionMatrixName: string;
 	proposal: PatchProposal;
+	/**
+	 * Variant the patch should be evaluated against (typically
+	 * `finding.variantId`). When set and different from
+	 * `productionMatrix.productionVariantId`, the sweep filters to this
+	 * variant and decide() compares against this variant's baseline
+	 * window. Mirrors the #394 fix for materialize-variant. Without
+	 * this, a patch designed to fix a non-production variant (e.g.
+	 * noar_div_rrBge for #327) is measured only on production code paths
+	 * and the patch's intended effect is invisible (#403).
+	 *
+	 * When unset, falls back to `productionVariantId` (legacy behavior).
+	 */
+	targetVariantId?: string;
 	stage?: string;
 	minBaseline?: number;
 	repoRoot?: string;
@@ -264,8 +279,18 @@ export async function materializePatchProposal(
 	}
 
 	// Run the sweep against the worktree using the existing matrix.
-	// Production variant only — the patch is the variable, not the
-	// knob configuration.
+	// Single variant — defaults to production, overridable via
+	// `targetVariantId` so that patches authored to fix a non-production
+	// variant are actually exercised on that variant (#403).
+	const productionVariantId = input.productionMatrix.productionVariantId ?? "";
+	const sweepVariantId = input.targetVariantId ?? productionVariantId;
+	if (input.targetVariantId && input.targetVariantId !== productionVariantId) {
+		notes.push(
+			`materialize-patch: target=${input.targetVariantId} (from finding) ` +
+				`differs from productionVariantId=${productionVariantId || "(unset)"} — ` +
+				`sweep + decide() scoped to target variant (#403)`,
+		);
+	}
 	try {
 		spawnFn(
 			"pnpm",
@@ -275,7 +300,7 @@ export async function materializePatchProposal(
 				"--stage",
 				stage,
 				"--variant-filter",
-				input.productionMatrix.productionVariantId ?? "",
+				sweepVariantId,
 			],
 			{ cwd: worktreePath },
 		);
@@ -294,13 +319,13 @@ export async function materializePatchProposal(
 
 	// Read newly-appended runs.jsonl rows. Same approach as
 	// materialize-variant.ts; the patched run has a NEW git sha, hence
-	// a new runConfigFingerprint, but the variantId is unchanged.
+	// a new runConfigFingerprint, but the variantId is unchanged from
+	// the sweep filter.
 	const allRows = readRunLog(runLogPaths());
-	const productionVariantId = input.productionMatrix.productionVariantId ?? "";
 	const candidateRows = allRows.filter(
 		(r) =>
 			r.stage === stage &&
-			r.variantId === productionVariantId &&
+			r.variantId === sweepVariantId &&
 			r.matrixName === input.productionMatrix.name &&
 			r.reportPath,
 	);
@@ -335,14 +360,15 @@ export async function materializePatchProposal(
 		}
 		// Patches change runConfigFingerprint via gitSha. Comparability
 		// rule for patches is RELAXED: we compare against any recent
-		// nightly-cron run for the production variant + corpus,
-		// regardless of fingerprint, since the whole point is to compare
-		// "code-before vs code-after." Document this caveat.
+		// nightly-cron run for the SAME variant we just swept (target
+		// or production, per #403) + corpus, regardless of fingerprint,
+		// since the whole point is to compare "code-before vs
+		// code-after." Document this caveat.
 		const baselineRows = [...allRows]
 			.reverse()
 			.filter(
 				(r) =>
-					r.variantId === productionVariantId &&
+					r.variantId === sweepVariantId &&
 					r.runConfig.collectionId === corpus &&
 					r.stage === "nightly-cron" &&
 					r.reportPath,

--- a/scripts/autoresearch/materialize-patch.ts
+++ b/scripts/autoresearch/materialize-patch.ts
@@ -201,9 +201,38 @@ export async function materializePatchProposal(
 	const branch = `autoresearch/${proposalId}`;
 	const worktreePath = join(proposalDir, "worktree");
 	const editsPath = join(proposalDir, "edits.json");
-	writeFileSync(editsPath, JSON.stringify(input.proposal.edits, null, 2));
 
 	const notes: string[] = [];
+
+	// Resolve target variant up-front. Bail before any fs/git work when
+	// neither the production matrix nor the caller can name a variant —
+	// sweeping with `--variant-filter ""` would run every variant and
+	// obscure the patch's intended effect.
+	const productionVariantId = input.productionMatrix.productionVariantId ?? "";
+	const sweepVariantId = input.targetVariantId ?? productionVariantId;
+	if (!sweepVariantId) {
+		return {
+			proposalId,
+			worktreePath,
+			branch,
+			candidateReports: [],
+			decisions: [],
+			aggregateAccept: false,
+			notes,
+			skippedReason:
+				"no variant id resolvable: matrix has no productionVariantId and no targetVariantId supplied",
+		};
+	}
+	if (input.targetVariantId && input.targetVariantId !== productionVariantId) {
+		notes.push(
+			`materialize-patch: target=${input.targetVariantId} (from finding) ` +
+				`differs from productionVariantId=${productionVariantId || "(unset)"} — ` +
+				`sweep + decide() scoped to target variant (#403)`,
+		);
+	}
+
+	writeFileSync(editsPath, JSON.stringify(input.proposal.edits, null, 2));
+
 	notes.push(
 		`patch touches ${validation.touchedPaths.length} file(s): ${validation.touchedPaths.slice(0, 3).join(", ")}${validation.touchedPaths.length > 3 ? "…" : ""}`,
 	);
@@ -281,16 +310,8 @@ export async function materializePatchProposal(
 	// Run the sweep against the worktree using the existing matrix.
 	// Single variant — defaults to production, overridable via
 	// `targetVariantId` so that patches authored to fix a non-production
-	// variant are actually exercised on that variant (#403).
-	const productionVariantId = input.productionMatrix.productionVariantId ?? "";
-	const sweepVariantId = input.targetVariantId ?? productionVariantId;
-	if (input.targetVariantId && input.targetVariantId !== productionVariantId) {
-		notes.push(
-			`materialize-patch: target=${input.targetVariantId} (from finding) ` +
-				`differs from productionVariantId=${productionVariantId || "(unset)"} — ` +
-				`sweep + decide() scoped to target variant (#403)`,
-		);
-	}
+	// variant are actually exercised on that variant (#403). Resolution
+	// happened earlier; sweepVariantId is non-empty by this point.
 	try {
 		spawnFn(
 			"pnpm",


### PR DESCRIPTION
## Summary

Mirrors #394 (PR #396) for the patch path. When a finding implicates a non-production variant (e.g. \`noar_div_rrBge\` for #327), the patch's sweep was running production variant unconditionally — measuring side effects on rrOff while the patch was authored to fix rrBge. Evidence chain broke; decideMulti rejected without evaluating the variant the patch targets.

Codex peer-review confirmed:
- Target-only sweep is the right first fix (mirrors #394; dual-sweep is a follow-up if needed)
- \`--variant-filter\` accepts non-production ids (sweep.ts enumerates all matrix variants and applies filter)
- Header comments needed updating ("production variant only" no longer accurate)
- Two specific tests requested (cross-variant sweep arg + emit note)

## Live evidence

Force-patch run 2026-05-05 against \`/tmp/findings-327.json\` (target=noar_div_rrBge):
- LLM diagnosed: \`applySeedDiversity\` in \`packages/search/src/trace/trace.ts\` uses \`s.score\` for diversity threshold
- Patch: 4 paths, +37/-33 lines, ranking layer
- Sweep ran \`noar_div_rrOff\` (production), NOT \`noar_div_rrBge\`
- Verdict: rejected with \"anti-overfit: worst per-baseline degradation 6.4pp > floor 2.0pp\" — measured against the wrong variant

## Test plan

- [x] \`pnpm vitest run scripts/autoresearch/\` — 338 pass; 2 new tests for cross-variant sweep arg + audit note + legacy fallback
- [x] \`pnpm -r build\` clean
- [ ] Post-merge: re-run #382/#395 force-patch — expect sweep variant=noar_div_rrBge, decide() against rrBge baselines