### PR TITLE
feat(autoresearch): surface reject reasons + full rationale to LLM proposer

### DIFF
--- a/scripts/autoresearch/analyze-and-propose-patch.ts
+++ b/scripts/autoresearch/analyze-and-propose-patch.ts
@@ -140,7 +140,10 @@ RULES:
 5. Each edit ≤ 30 lines. Keep changes minimal and focused.
 6. Stay under 200 total added+removed lines across all edits.
 7. Do NOT include line numbers or unified-diff hunk headers — this is search/replace, not diff.
-8. Do NOT propose changes that already appear in the tried-log.
+8. **Use the tried-log as a learning signal, not just a dedup filter.** Each prior attempt entry shows verdict, your previous Rationale, and the system's Outcome (reject reasons like "anti-overfit: worst per-baseline degradation 16.5pp > floor 2.0pp"). Before proposing:
+   - If a prior attempt targeted the SAME file or mechanism and was rejected for anti-overfit / per-baseline degradation, do NOT submit a near-duplicate. Either (a) target a different file or seam, or (b) explain in Analysis why your new edit avoids the specific failure mode that rejected the prior attempt (e.g. "prior attempt clamped X to 0.3 which overshot on baseline-2; this edit keeps the existing floor and instead changes Y").
+   - If multiple prior attempts share a diagnosis but all failed, the diagnosis is likely wrong — propose a DIFFERENT root cause hypothesis rather than another variation on the rejected fix.
+   - Treat prior Rationale entries as your own past reasoning. Build on them; don't re-derive the same conclusion in isolation.
 
 EXAMPLE of a valid edit (note 4 lines of context, full replacement, preserved tabs):
 

--- a/scripts/autoresearch/analyze-and-propose.ts
+++ b/scripts/autoresearch/analyze-and-propose.ts
@@ -72,7 +72,7 @@ Rules:
        * { "axis": "<knob name>", "value": <valid value>, "rationale": "<one sentence>" }
        * { "axis": null }   (when no proposal is appropriate)
 2. The axis MUST be one of the inventory names. The value MUST satisfy the knob's type and range.
-3. Do NOT propose a knob+value combination that already appears in the tried-log within the recent window — pick a different axis or value.
+3. Do NOT propose a knob+value combination that already appears in the tried-log within the recent window — pick a different axis or value. Use the tried-log entries' Outcome lines (system reject reasons) as a learning signal: if multiple prior attempts on the SAME axis were rejected for the same metric reason, prefer a different axis rather than another value on the same axis.
 4. Keep the analysis under 300 words. The rationale string under 200 chars.
 5. Prefer cheap knobs (no re-ingest required) over expensive ones unless the cheap space is exhausted.
 6. If the finding is a breach (hard gate floor violated), your proposal should target the breached metric specifically.

--- a/scripts/autoresearch/autonomous-loop.ts
+++ b/scripts/autoresearch/autonomous-loop.ts
@@ -596,10 +596,18 @@ async function runPatchPath(input: {
 		proposal: {
 			axis: "(code-patch)",
 			value: llm.proposal.baseSha,
-			rationale: llm.proposal.rationale.slice(0, 200),
+			// Preserve full rationale (LLM's diagnosis chain) so subsequent
+			// proposer calls can see why prior attempts targeted what they
+			// targeted. Pre-fix the rationale was clamped to 200 chars,
+			// truncating the analysis section that explains the LLM's
+			// reasoning to itself.
+			rationale: llm.proposal.rationale,
 		},
 		verdict: materialize.aggregateAccept ? "accepted" : "rejected",
-		reasons: materialize.decisions.flatMap((d) => d.verdict?.reasons ?? [d.reason ?? ""]).concat(materialize.notes),
+		reasons: materialize.decisions
+			.flatMap((d) => d.verdict?.reasons ?? [d.reason ?? ""])
+			.concat(materialize.notes)
+			.filter(Boolean),
 	});
 
 	if (!materialize.aggregateAccept) {
@@ -875,7 +883,7 @@ async function runLoop(cli: CliArgs): Promise<LoopOutcome> {
 		reasons: [
 			...materialize.notes,
 			...materialize.decisions.flatMap((d) => d.verdict?.reasons ?? [d.reason ?? ""]),
-		],
+		].filter(Boolean),
 		metrics: candidateRow?.summary
 			? {
 					passRate: candidateRow.summary.passRate,

--- a/scripts/autoresearch/tried-log.test.ts
+++ b/scripts/autoresearch/tried-log.test.ts
@@ -93,7 +93,7 @@ describe("triedLogPromptLines", () => {
 		expect(lines[0]).toMatch(/no prior attempts/);
 	});
 
-	it("renders a one-line entry per row, newest last", () => {
+	it("renders a structured entry per row with verdict header + rationale (newest last)", () => {
 		const lines = triedLogPromptLines(
 			[
 				row({ proposal: { axis: "topK", value: 15, rationale: "first" } }),
@@ -101,9 +101,36 @@ describe("triedLogPromptLines", () => {
 			],
 			"retrieval-baseline",
 		);
-		expect(lines).toHaveLength(2);
-		expect(lines[0]).toContain("rejected");
-		expect(lines[1]).toContain("accepted");
+		// Each row produces a header line + a Rationale line (no Outcome
+		// when reasons are empty); newest row comes last.
+		const joined = lines.join("\n");
+		expect(joined).toMatch(/\[rejected\] topK=15/);
+		expect(joined).toMatch(/Rationale: first/);
+		expect(joined).toMatch(/\[accepted\] topK=20/);
+		expect(joined).toMatch(/Rationale: second/);
+		// "rejected" header for first entry must appear BEFORE "accepted"
+		// header in the rendered string.
+		expect(joined.indexOf("[rejected]")).toBeLessThan(joined.indexOf("[accepted]"));
+	});
+
+	it("surfaces reject reasons as an Outcome line — closes the goldfish-memory gap (#382)", () => {
+		const lines = triedLogPromptLines(
+			[
+				row({
+					verdict: "rejected",
+					proposal: { axis: "(code-patch)", value: "abc1234", rationale: "fix applySeedDiversity" },
+					reasons: [
+						"anti-overfit: worst per-baseline degradation 16.5pp > floor 2.0pp",
+						"patch window: only 0/3 clear decide() (need 2)",
+					],
+				}),
+			],
+			"retrieval-baseline",
+		);
+		const joined = lines.join("\n");
+		expect(joined).toMatch(/Outcome: anti-overfit/);
+		expect(joined).toMatch(/16\.5pp/);
+		expect(joined).toMatch(/0\/3 clear decide/);
 	});
 
 	it("filters by matrix", () => {
@@ -114,7 +141,8 @@ describe("triedLogPromptLines", () => {
 			],
 			"retrieval-baseline",
 		);
-		expect(lines).toHaveLength(1);
-		expect(lines[0]).toContain("topK=15");
+		const joined = lines.join("\n");
+		expect(joined).toContain("topK=15");
+		expect(joined).not.toContain("topK=20");
 	});
 });

--- a/scripts/autoresearch/tried-log.ts
+++ b/scripts/autoresearch/tried-log.ts
@@ -115,8 +115,20 @@ export function alreadyTried(
 }
 
 /**
- * Render a compact prompt section listing prior attempts. Used as
- * input to the LLM proposer so it doesn't repeat itself.
+ * Render a prompt section listing prior attempts with full cause-and-
+ * effect context. The proposer needs to see not just THAT something was
+ * rejected but WHY (anti-overfit, baseline-window failure, validation
+ * error, etc.) so it can avoid repeating the same shape of mistake.
+ *
+ * Format per row (multi-line, structured):
+ *   - [verdict] axis=value pass=X%
+ *     Rationale: <full LLM rationale, untruncated>
+ *     Outcome: <reasons joined; system's response to the proposal>
+ *
+ * Pre-fix the LLM saw `[rejected]` markers + 120-char truncated
+ * rationale snippets and no reasons at all — "goldfish memory regarding
+ * consequences" (gemini peer-review 2026-05-05). One-shot reasoning
+ * across iterations because it never saw why prior tries failed.
  */
 export function triedLogPromptLines(
 	rows: readonly TriedLogRow[],
@@ -125,11 +137,22 @@ export function triedLogPromptLines(
 ): string[] {
 	const filtered = rows.filter((r) => r.matrixName === matrixName).slice(-limit);
 	if (filtered.length === 0) return ["(no prior attempts on this matrix)"];
-	return filtered.map((r) => {
+	const lines: string[] = [];
+	for (const r of filtered) {
 		const m = r.metrics;
 		const metricStr = m
-			? `pass=${m.passRate !== undefined ? (m.passRate * 100).toFixed(1) + "%" : "?"}`
+			? `pass=${m.passRate !== undefined ? `${(m.passRate * 100).toFixed(1)}%` : "?"}`
 			: "";
-		return `- [${r.verdict}] ${r.proposal.axis}=${JSON.stringify(r.proposal.value)} ${metricStr} — ${r.proposal.rationale.slice(0, 120)}`;
-	});
+		lines.push(
+			`- [${r.verdict}] ${r.proposal.axis}=${JSON.stringify(r.proposal.value)} ${metricStr}`,
+		);
+		if (r.proposal.rationale) {
+			lines.push(`  Rationale: ${r.proposal.rationale}`);
+		}
+		const reasons = r.reasons?.filter(Boolean) ?? [];
+		if (reasons.length > 0) {
+			lines.push(`  Outcome: ${reasons.join("; ")}`);
+		}
+	}
+	return lines;
 }


### PR DESCRIPTION
## Summary

Closes the \"goldfish memory\" gap in the autonomous loop's LLM proposer.

Pre-fix the proposer saw prior attempts as \`[rejected]\` markers + 120-char truncated rationale, with NO reject reasons surfaced. The \`reasons\` array (containing things like \`anti-overfit: worst per-baseline degradation 16.5pp > floor 2pp\`) was being persisted to \`tried.jsonl\` but never reached the proposer prompt.

Live evidence (#382 force-patch attempts, 2026-05-05): three consecutive runs all targeted \`applySeedDiversity\` in \`packages/search/src/trace/trace.ts\`, all rejected for similar anti-overfit floor breaches. The LLM had no way to know its prior attempts had failed for specific measurable reasons — it kept proposing variations of the same fix in the same file because it was effectively one-shotting on every iteration.

Per gemini peer-review (2026-05-05):

> The LLM is trapped in a \"local minimum.\" It correctly identifies the root cause but repeatedly proposes slightly different versions of the same failing mutation because it never sees the \`anti-overfit\` rejection signal. It essentially has \"goldfish memory\" regarding the *consequences* of its actions.

## Changes

1. \`triedLogPromptLines\` now emits structured multi-line context per prior attempt:
   \`\`\`
   - [rejected] (code-patch)=770d9396 pass=37.9%
     Rationale: <full untruncated LLM rationale>
     Outcome: anti-overfit: worst per-baseline degradation 16.5pp > floor 2.0pp; patch window: only 0/3 clear decide() (need 2); ...
   \`\`\`

2. \`autonomous-loop.ts\` no longer truncates rationale to 200 chars when storing patch tried-log entries.

3. Empty strings filtered from reasons array assembly.

## Token budget

With 30 prior attempts × full rationale + reasons, prompt grows ~10-20K tokens. Comfortable for qwen3-32b's 32K context. Trade is worth it — the alternative is one-shot looping forever.

## Test plan

- [x] \`pnpm vitest run scripts/autoresearch/\` — 340 pass; new test \`surfaces reject reasons as an Outcome line\` locks the gap closed
- [x] \`pnpm -r build\` clean
- [x] \`pnpm lint:fix\` clean
- [ ] Post-merge: re-run #382 force-patch — expect LLM to either propose a different file/seam OR explicitly explain why its choice differs from prior failed attempts

## Anti-goal check (per docs/autoresearch/roadmap.md)

- Anti-goal #3 (no self-modification of loop infra): unaffected, this is maintainer-authored prompt-construction change
- Anti-goal #4 (no leaderboard-shape gaming): unaffected, doesn't move any threshold