### PR TITLE
feat(autoresearch): 3-phase sweep architecture for single-GPU mode-switch deployments

### DIFF
--- a/scripts/autoresearch/sweep-phase-planner.test.ts
+++ b/scripts/autoresearch/sweep-phase-planner.test.ts
@@ -47,9 +47,26 @@ describe("resolveRequiredMode", () => {
 		).toBe("chat");
 	});
 
-	it("treats every URL as cloud when adminHost is null", () => {
+	it("honors GPU markers even when adminHost is null", () => {
+		// URL substring is the authoritative signal — admin host is only
+		// used to disambiguate generic chat endpoints from cloud.
 		expect(
 			resolveRequiredMode(`https://embedder-gpu.${ADMIN}/v1`, null),
+		).toBe("embed-gpu");
+		expect(resolveRequiredMode(`https://chat.${ADMIN}/v1`, null)).toBe(
+			"cloud",
+		);
+	});
+
+	it("classifies chat endpoint by parent-domain match (subdomain need not match)", () => {
+		expect(
+			resolveRequiredMode("https://chat.example.com/v1", "https://admin.example.com"),
+		).toBe("chat");
+		expect(
+			resolveRequiredMode(
+				"https://chat.openrouter.ai/api/v1",
+				"https://admin.example.com",
+			),
 		).toBe("cloud");
 	});
 });

--- a/scripts/autoresearch/sweep-phase-planner.test.ts
+++ b/scripts/autoresearch/sweep-phase-planner.test.ts
@@ -98,7 +98,8 @@ describe("planSweepPhases", () => {
 		expect(plan.find((p) => p.phase === "embed")?.mode).toBe("embed-gpu");
 		expect(plan.find((p) => p.phase === "search")?.mode).toBe("rerank-gpu");
 		expect(plan.find((p) => p.phase === "score")?.mode).toBe(null);
-		expect(plan.find((p) => p.phase === "score")?.skip).toBe(true);
+		// Score phase still runs (metrics attachment) — just no swap.
+		expect(plan.find((p) => p.phase === "score")?.skip).toBe(false);
 	});
 
 	it("full-local + grounding: 3 GPU modes total (embed-gpu / rerank-gpu / chat)", () => {

--- a/scripts/autoresearch/sweep-phase-planner.test.ts
+++ b/scripts/autoresearch/sweep-phase-planner.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import type { Variant } from "./matrix.js";
+import {
+	PhaseCompositionError,
+	planSweepPhases,
+	resolveRequiredMode,
+} from "./sweep-phase-planner.js";
+
+function variant(
+	id: string,
+	reranker: Variant["axes"]["reranker"],
+): Variant {
+	return {
+		variantId: id,
+		axes: { autoRoute: false, diversityEnforce: false, reranker },
+	};
+}
+
+const ADMIN = "vllm-admin.example";
+
+describe("resolveRequiredMode", () => {
+	it("returns null for missing url", () => {
+		expect(resolveRequiredMode(undefined, ADMIN)).toBe(null);
+	});
+
+	it("returns 'cloud' when host is not on admin", () => {
+		expect(
+			resolveRequiredMode("https://openrouter.ai/api/v1", ADMIN),
+		).toBe("cloud");
+	});
+
+	it("returns 'embed-gpu' for embedder-gpu host on admin", () => {
+		expect(
+			resolveRequiredMode(`https://embedder-gpu.${ADMIN}/v1`, ADMIN),
+		).toBe("embed-gpu");
+	});
+
+	it("returns 'rerank-gpu' for reranker-gpu host on admin", () => {
+		expect(
+			resolveRequiredMode(`https://reranker-gpu.${ADMIN}/v1`, ADMIN),
+		).toBe("rerank-gpu");
+	});
+
+	it("returns 'chat' for chat host on admin", () => {
+		expect(
+			resolveRequiredMode(`https://chat.${ADMIN}/v1`, ADMIN),
+		).toBe("chat");
+	});
+
+	it("treats every URL as cloud when adminHost is null", () => {
+		expect(
+			resolveRequiredMode(`https://embedder-gpu.${ADMIN}/v1`, null),
+		).toBe("cloud");
+	});
+});
+
+describe("planSweepPhases", () => {
+	it("full-cloud matrix: 0 swaps, no skip on search", () => {
+		const plan = planSweepPhases({
+			embedderUrl: "https://openrouter.ai/api/v1",
+			extractorUrl: "https://nim.example.com/v1",
+			variants: [
+				variant("v1", { type: "bge", url: "https://reranker.cloud.example/v1" }),
+			],
+			adminHost: ADMIN,
+			groundingEnabled: false,
+		});
+		expect(plan.map((p) => p.mode)).toEqual([null, null, null]);
+	});
+
+	it("full-local 3-mode matrix: embed-gpu / rerank-gpu / null (no grounding)", () => {
+		const plan = planSweepPhases({
+			embedderUrl: `https://embedder-gpu.${ADMIN}/v1`,
+			extractorUrl: `https://chat.${ADMIN}/v1`,
+			variants: [
+				variant("v1", { type: "bge", url: `https://reranker-gpu.${ADMIN}/v1` }),
+			],
+			adminHost: ADMIN,
+			groundingEnabled: false,
+		});
+		expect(plan.find((p) => p.phase === "embed")?.mode).toBe("embed-gpu");
+		expect(plan.find((p) => p.phase === "search")?.mode).toBe("rerank-gpu");
+		expect(plan.find((p) => p.phase === "score")?.mode).toBe(null);
+		expect(plan.find((p) => p.phase === "score")?.skip).toBe(true);
+	});
+
+	it("full-local + grounding: 3 GPU modes total (embed-gpu / rerank-gpu / chat)", () => {
+		const plan = planSweepPhases({
+			embedderUrl: `https://embedder-gpu.${ADMIN}/v1`,
+			extractorUrl: `https://chat.${ADMIN}/v1`,
+			variants: [
+				variant("v1", { type: "bge", url: `https://reranker-gpu.${ADMIN}/v1` }),
+			],
+			adminHost: ADMIN,
+			groundingEnabled: true,
+		});
+		expect(plan.find((p) => p.phase === "embed")?.mode).toBe("embed-gpu");
+		expect(plan.find((p) => p.phase === "search")?.mode).toBe("rerank-gpu");
+		expect(plan.find((p) => p.phase === "score")?.mode).toBe("chat");
+	});
+
+	it("mixed: cloud embedder + cloud extractor + local BGE → 1 swap on search", () => {
+		const plan = planSweepPhases({
+			embedderUrl: "https://openrouter.ai/api/v1",
+			extractorUrl: "https://nim.example.com/v1",
+			variants: [
+				variant("v1", { type: "bge", url: `https://reranker-gpu.${ADMIN}/v1` }),
+			],
+			adminHost: ADMIN,
+			groundingEnabled: false,
+		});
+		expect(plan.find((p) => p.phase === "embed")?.mode).toBe(null);
+		expect(plan.find((p) => p.phase === "search")?.mode).toBe("rerank-gpu");
+		expect(plan.find((p) => p.phase === "score")?.mode).toBe(null);
+	});
+
+	it("reranker=off across every variant: search phase needs no mode swap", () => {
+		const plan = planSweepPhases({
+			embedderUrl: `https://embedder-gpu.${ADMIN}/v1`,
+			extractorUrl: undefined,
+			variants: [variant("v1", "off"), variant("v2", "off")],
+			adminHost: ADMIN,
+			groundingEnabled: false,
+		});
+		expect(plan.find((p) => p.phase === "search")?.mode).toBe(null);
+	});
+
+	it("refuses when two variants disagree on reranker GPU mode in the same phase", () => {
+		expect(() =>
+			planSweepPhases({
+				embedderUrl: "https://openrouter.ai/api/v1",
+				variants: [
+					variant("v1", { type: "bge", url: `https://reranker-gpu.${ADMIN}/v1` }),
+					// Pretend a second BGE is mounted under a hypothetical
+					// embedder-gpu host — both are local but on different
+					// modes; the planner must refuse rather than try to
+					// pre-stage one mode.
+					variant("v2", {
+						type: "bge",
+						url: `https://embedder-gpu.${ADMIN}/v1`,
+					}),
+				],
+				adminHost: ADMIN,
+				groundingEnabled: false,
+			}),
+		).toThrow(PhaseCompositionError);
+	});
+});

--- a/scripts/autoresearch/sweep-phase-planner.ts
+++ b/scripts/autoresearch/sweep-phase-planner.ts
@@ -86,12 +86,22 @@ export class PhaseCompositionError extends Error {
 
 /**
  * Classify a single URL into "cloud" or a concrete GPU mode. Pure.
+ *
+ * GPU-mode markers (`embedder-gpu`, `reranker-gpu`) are honored
+ * regardless of host: a vllm-admin cluster typically exposes those
+ * workloads on dedicated subdomains that share only a parent domain
+ * with the admin URL, so a strict prefix/substring check on the admin
+ * host would miss them. The admin host is still used to classify
+ * generic chat endpoints — a URL with no GPU marker on the admin host
+ * is the chat workload; off-admin URLs with no marker are cloud.
  */
 export function resolveRequiredMode(
 	url: string | undefined,
 	adminHost: string | null,
 ): ComponentMode | null {
 	if (!url) return null;
+	if (url.includes("embedder-gpu")) return "embed-gpu";
+	if (url.includes("reranker-gpu")) return "rerank-gpu";
 	if (!adminHost) return "cloud";
 	let host: string;
 	try {
@@ -106,9 +116,15 @@ export function resolveRequiredMode(
 			return adminHost;
 		}
 	})();
-	if (!host.includes(adminHostNormalized)) return "cloud";
-	if (url.includes("embedder-gpu")) return "embed-gpu";
-	if (url.includes("reranker-gpu")) return "rerank-gpu";
+	// Compare on the parent-domain level (last two labels) so an admin
+	// URL like `admin.example.com` matches a chat endpoint at
+	// `chat.example.com` even though their leftmost labels differ.
+	const parentOf = (h: string): string => {
+		const parts = h.split(".");
+		if (parts.length < 2) return h;
+		return parts.slice(-2).join(".");
+	};
+	if (parentOf(host) !== parentOf(adminHostNormalized)) return "cloud";
 	return "chat";
 }
 

--- a/scripts/autoresearch/sweep-phase-planner.ts
+++ b/scripts/autoresearch/sweep-phase-planner.ts
@@ -105,15 +105,17 @@ export function resolveRequiredMode(
 	if (!adminHost) return "cloud";
 	let host: string;
 	try {
-		host = new URL(url).host;
+		host = new URL(url).hostname;
 	} catch {
 		return "cloud";
 	}
 	const adminHostNormalized = (() => {
 		try {
-			return new URL(adminHost).host;
+			return new URL(adminHost).hostname;
 		} catch {
-			return adminHost;
+			// Strip any port suffix from a bare host string so the
+			// parent-domain comparison stays apples-to-apples.
+			return adminHost.replace(/:\d+$/, "");
 		}
 	})();
 	// Compare on the parent-domain level (last two labels) so an admin
@@ -141,12 +143,13 @@ function reduceModes(
 		(m): m is { owner: string; mode: GpuMode } =>
 			m.mode !== null && m.mode !== "cloud",
 	);
-	if (local.length === 0) return null;
+	const [first] = local;
+	if (!first) return null;
 	const distinct = new Set(local.map((m) => m.mode));
 	if (distinct.size > 1) {
 		throw new PhaseCompositionError(phase, local);
 	}
-	return local[0]!.mode;
+	return first.mode;
 }
 
 /**
@@ -198,9 +201,12 @@ export function planSweepPhases(input: PlanSweepPhasesInput): PhasePlan[] {
 			// Score phase needs an LLM only when grounding is wired up.
 			// Without grounding, the deterministic-scoring output is
 			// already in the search-phase cache and the score phase is a
-			// no-op replay → no GPU mode needed.
+			// no-op replay → no GPU mode needed. The phase itself still
+			// runs (without a swap) so it can re-attach timing / cost
+			// telemetry onto the cached EvalStageResult; otherwise the
+			// downstream Pareto leaderboard would lose cost+latency.
 			mode: groundingEnabled ? extractorMode : null,
-			skip: !groundingEnabled,
+			skip: false,
 		},
 	];
 }

--- a/scripts/autoresearch/sweep-phase-planner.ts
+++ b/scripts/autoresearch/sweep-phase-planner.ts
@@ -1,0 +1,190 @@
+/**
+ * Sweep phase planner. Given a matrix's per-component endpoint set,
+ * produce an ordered embed → search → score plan with the GPU mode each
+ * phase needs (null when the phase is fully cloud or unused).
+ *
+ * Step 5 of the 3-phase sweep refactor. The planner is pure: it does
+ * not call vllm-admin, does not touch disk, and emits a deterministic
+ * plan from the matrix shape alone. Step 6 wires it into sweep.ts and
+ * inserts an `ensureMode` call between phases.
+ *
+ * Component mode resolution (per gemini peer-review suggestion):
+ *
+ *   - URL not on the admin host → "cloud" (no GPU mode required)
+ *   - URL on admin host, substring `embedder-gpu` → "embed-gpu"
+ *   - URL on admin host, substring `reranker-gpu` → "rerank-gpu"
+ *   - URL on admin host, no `-gpu` suffix         → "chat"
+ *
+ * Composition guard: within a single phase, if two variants demand
+ * different non-null GPU modes (e.g. one variant wants `rerank-gpu`,
+ * another wants `chat` for the reranker phase) the planner refuses.
+ * The 3-phase split prevents the embedder/reranker/extractor mode
+ * collision naturally because each component lives in its own phase;
+ * the guard catches future misconfigurations that violate that.
+ */
+
+import type { GpuMode } from "../lib/mode-switch.js";
+import type { RerankerSpec, Variant } from "./matrix.js";
+
+export type ComponentMode = GpuMode | "cloud";
+export type PhaseName = "embed" | "search" | "score";
+
+export interface PhasePlan {
+	phase: PhaseName;
+	/**
+	 * GPU mode required to run this phase. null when no variant in the
+	 * matrix exercises a local workload for this phase (all cloud, or
+	 * the component is absent — e.g. reranker=off across every variant).
+	 * `ensureMode` is only called when this is non-null.
+	 */
+	mode: GpuMode | null;
+	/**
+	 * True when no variant participates in this phase at all (e.g. every
+	 * variant has reranker=off → the search phase still runs vector
+	 * retrieval, so this stays false; but the score phase is `skip` when
+	 * grounding is off and the deterministic-scoring evaluator is the
+	 * only consumer of the cached search output).
+	 */
+	skip: boolean;
+}
+
+export interface PlanSweepPhasesInput {
+	embedderUrl: string;
+	extractorUrl?: string | undefined;
+	variants: Variant[];
+	/**
+	 * Hostname (or full origin) of the vllm-admin cluster. URLs whose
+	 * host matches this prefix are subject to GPU-mode classification;
+	 * URLs whose host does not match are treated as "cloud" and require
+	 * no mode swap. When null or empty, every URL is "cloud" — useful
+	 * for full-cloud sweeps that should produce a 0-swap plan.
+	 */
+	adminHost: string | null;
+	/**
+	 * When grounding is enabled the score phase will run an LLM
+	 * extractor against the cached search results, so it inherits the
+	 * extractor's mode. When false the score phase has no GPU
+	 * dependency and is marked `skip: true`.
+	 */
+	groundingEnabled?: boolean;
+}
+
+export class PhaseCompositionError extends Error {
+	constructor(
+		public readonly phase: PhaseName,
+		public readonly conflicts: Array<{ owner: string; mode: GpuMode }>,
+	) {
+		const detail = conflicts
+			.map((c) => `${c.owner}=${c.mode}`)
+			.join(", ");
+		super(
+			`phase=${phase}: incompatible local GPU modes across variants — ${detail}. The 3-phase planner cannot pre-stage two non-null modes for the same phase; split the matrix or move the conflicting component to a different phase.`,
+		);
+		this.name = "PhaseCompositionError";
+	}
+}
+
+/**
+ * Classify a single URL into "cloud" or a concrete GPU mode. Pure.
+ */
+export function resolveRequiredMode(
+	url: string | undefined,
+	adminHost: string | null,
+): ComponentMode | null {
+	if (!url) return null;
+	if (!adminHost) return "cloud";
+	let host: string;
+	try {
+		host = new URL(url).host;
+	} catch {
+		return "cloud";
+	}
+	const adminHostNormalized = (() => {
+		try {
+			return new URL(adminHost).host;
+		} catch {
+			return adminHost;
+		}
+	})();
+	if (!host.includes(adminHostNormalized)) return "cloud";
+	if (url.includes("embedder-gpu")) return "embed-gpu";
+	if (url.includes("reranker-gpu")) return "rerank-gpu";
+	return "chat";
+}
+
+function rerankerUrl(spec: RerankerSpec): string | undefined {
+	if (spec === "off") return undefined;
+	return spec.url;
+}
+
+function reduceModes(
+	modes: Array<{ owner: string; mode: ComponentMode | null }>,
+	phase: PhaseName,
+): GpuMode | null {
+	const local = modes.filter(
+		(m): m is { owner: string; mode: GpuMode } =>
+			m.mode !== null && m.mode !== "cloud",
+	);
+	if (local.length === 0) return null;
+	const distinct = new Set(local.map((m) => m.mode));
+	if (distinct.size > 1) {
+		throw new PhaseCompositionError(phase, local);
+	}
+	return local[0]!.mode;
+}
+
+/**
+ * Produce an embed → search → score phase plan. Throws
+ * PhaseCompositionError when two variants disagree on the GPU mode
+ * required by the same phase.
+ */
+export function planSweepPhases(input: PlanSweepPhasesInput): PhasePlan[] {
+	const adminHost = input.adminHost ?? null;
+	const embedMode = reduceModes(
+		[
+			{
+				owner: `embedder(${input.embedderUrl})`,
+				mode: resolveRequiredMode(input.embedderUrl, adminHost),
+			},
+		],
+		"embed",
+	);
+
+	const rerankerEntries = input.variants.map((v) => ({
+		owner: `variant(${v.variantId}).reranker`,
+		mode: resolveRequiredMode(rerankerUrl(v.axes.reranker), adminHost),
+	}));
+	const searchMode = reduceModes(rerankerEntries, "search");
+
+	const extractorMode = reduceModes(
+		[
+			{
+				owner: `extractor(${input.extractorUrl ?? "none"})`,
+				mode: resolveRequiredMode(input.extractorUrl, adminHost),
+			},
+		],
+		"score",
+	);
+	const groundingEnabled = input.groundingEnabled ?? false;
+
+	return [
+		{ phase: "embed", mode: embedMode, skip: false },
+		{
+			phase: "search",
+			mode: searchMode,
+			// Search phase always runs vector retrieval; reranker is just
+			// optional. Skip is never true here — the deterministic-
+			// scoring evaluator is the actual workload.
+			skip: false,
+		},
+		{
+			phase: "score",
+			// Score phase needs an LLM only when grounding is wired up.
+			// Without grounding, the deterministic-scoring output is
+			// already in the search-phase cache and the score phase is a
+			// no-op replay → no GPU mode needed.
+			mode: groundingEnabled ? extractorMode : null,
+			skip: !groundingEnabled,
+		},
+	];
+}

--- a/scripts/autoresearch/sweep.ts
+++ b/scripts/autoresearch/sweep.ts
@@ -30,7 +30,12 @@
  * defaults. That gate stays manual until methodology is hardened.
  */
 
-import { ensureMode, type GpuMode, resolveModeFromMatrix } from "../lib/mode-switch.js";
+import { ensureMode, resolveModeFromMatrix } from "../lib/mode-switch.js";
+import {
+	type PhaseName,
+	type PhasePlan,
+	planSweepPhases,
+} from "./sweep-phase-planner.js";
 import { safeExecFileSync as execFileSync } from "../lib/safe-exec.js";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -178,11 +183,17 @@ async function loadMatrix(matrixName: string): Promise<Matrix> {
 	}
 }
 
+interface PhaseInvocation {
+	phase: PhaseName;
+	cacheBase: string;
+}
+
 function runVariantOnCorpus(
 	matrix: Matrix,
 	variant: Variant,
 	collection: string,
 	sweepId: string,
+	phaseInvocation?: PhaseInvocation,
 ): { report: ExtendedDogfoodReport; durationMs: number; reportPath: string } {
 	const archiveDir = resolve(
 		`${process.env.WTFOC_AUTORESEARCH_DIR ?? `${process.env.HOME}/.wtfoc/autoresearch`}/reports/${sweepId}`,
@@ -246,8 +257,22 @@ function runVariantOnCorpus(
 		args.push("--trace-max-total", String(variant.axes.traceMaxTotal));
 	if (variant.axes.traceMinScore !== undefined)
 		args.push("--trace-min-score", String(variant.axes.traceMinScore));
+	if (phaseInvocation) {
+		args.push(
+			"--phase",
+			phaseInvocation.phase,
+			"--cache-base",
+			phaseInvocation.cacheBase,
+			"--sweep-id",
+			sweepId,
+			"--variant-id",
+			variant.variantId,
+		);
+	}
 
-	logErr(`[sweep] running variant ${variant.variantId} on ${collection}`);
+	logErr(
+		`[sweep] running variant ${variant.variantId} on ${collection}${phaseInvocation ? ` (phase=${phaseInvocation.phase})` : ""}`,
+	);
 	const t0 = performance.now();
 	execFileSync("pnpm", args, { stdio: ["ignore", "pipe", "inherit"], env: childEnv });
 	const durationMs = performance.now() - t0;
@@ -368,117 +393,283 @@ async function main(): Promise<void> {
 		} sweepId=${sweepId} stage=${stage ?? "(none)"}`,
 	);
 
-	// #360 — auto-switch GPU mode for sweeps targeting a GPU-only
-	// workload (rerank-gpu / embed-gpu). Mirrors the autonomous-loop's
-	// `swapMode` wrapper. Gated by `WTFOC_VLLM_AUTOSWAP=1`; when unset
-	// every call is a noop and the sweep runs in whatever mode is
-	// already active. After the sweep finishes (success OR failure),
-	// the GPU is returned to `chat` so the autonomous-loop's analyze
-	// phase has a chat-ready model.
-	const sweepMode: GpuMode | null = resolveModeFromMatrix(matrix);
-	if (sweepMode) {
-		logErr(`[sweep] resolved gpu mode requirement: ${sweepMode}`);
+	// 3-phase sweep architecture (single-GPU mode-switch deployments).
+	// Compute the embed → search → score plan once, then either run a
+	// single-shot fast path (every phase mode is null — fully cloud or
+	// no GPU dependency) or batch each phase across all variant×corpus
+	// combinations with one ensureMode call per phase. Gated by
+	// `WTFOC_VLLM_AUTOSWAP=1`; when unset every ensureMode is a noop
+	// and the sweep runs in whatever mode is already active.
+	const adminHostFromEnv = (() => {
+		const url = process.env.WTFOC_VLLM_ADMIN_URL;
+		if (!url) return null;
 		try {
-			const r = await ensureMode(sweepMode, { reason: `sweep ${matrix.name}` });
-			if (r.skipped) {
-				logErr(`[sweep] mode-switch skipped (${sweepMode}): ${r.skippedReason}`);
-			} else {
-				logErr(`[sweep] mode-switch ok: ${r.from ?? "?"}→${r.to ?? sweepMode}`);
-			}
-		} catch (err) {
-			const msg = err instanceof Error ? err.message : String(err);
-			logErr(`[sweep] mode-switch FAILED (${sweepMode}): ${msg}`);
-			logErr(
-				`[sweep] aborting — variants targeting a ${sweepMode} workload would 503 against the inactive deployment`,
-			);
-			process.exit(3);
+			return new URL(url).host;
+		} catch {
+			return null;
 		}
-	}
+	})();
+	const phasePlan: PhasePlan[] = planSweepPhases({
+		embedderUrl: matrix.baseConfig.embedderUrl,
+		extractorUrl: matrix.baseConfig.extractorUrl,
+		variants,
+		adminHost: adminHostFromEnv,
+		groundingEnabled: process.env.WTFOC_GROUND_CHECK === "1",
+	});
+	const phasesNeedingMode = phasePlan.filter((p) => p.mode !== null);
+	const usePhaseSplit = phasesNeedingMode.length > 0;
+	logErr(
+		`[sweep] phase plan: ${phasePlan
+			.map((p) => `${p.phase}=${p.mode ?? "cloud"}${p.skip ? ":skip" : ""}`)
+			.join(" → ")}`,
+	);
 
 	const results: SweepRunResult[] = [];
-	let primaryBaselineReport: ExtendedDogfoodReport | null = null;
-	let secondaryBaselineReport: ExtendedDogfoodReport | null = null;
 
-	for (const v of variants) {
-		// Primary corpus run.
-		const primaryRun = runVariantOnCorpus(matrix, v, corpora.primary, sweepId);
-		const primary: PerCorpusRun = {
-			corpus: corpora.primary,
-			report: primaryRun.report,
-			durationMs: primaryRun.durationMs,
-			reportPath: primaryRun.reportPath,
-		};
-		if (primaryBaselineReport) {
-			primary.decisionVsBaseline = decide({
-				baseline: primaryBaselineReport,
-				candidate: primary.report,
-			});
-		} else {
-			primaryBaselineReport = primary.report;
-		}
-		appendRunLogRow(
-			buildRunLogRow({
-				sweepId,
-				matrixName: matrix.name,
-				variantId: v.variantId,
-				report: primary.report,
-				durationMs: primary.durationMs,
-				reportPath: primary.reportPath,
-				...(stage ? { stage } : {}),
-			}),
-		);
-
-		// Secondary corpus run (when configured).
-		let secondary: PerCorpusRun | undefined;
-		if (corpora.secondary) {
-			const secondaryRun = runVariantOnCorpus(matrix, v, corpora.secondary, sweepId);
-			secondary = {
-				corpus: corpora.secondary,
-				report: secondaryRun.report,
-				durationMs: secondaryRun.durationMs,
-				reportPath: secondaryRun.reportPath,
+	if (!usePhaseSplit) {
+		// Single-shot fast path: no GPU mode swaps required for any
+		// phase, so the existing per-variant×corpus invocation runs
+		// the full pipeline in one shot — no cache hand-off, no phase
+		// flag.
+		let primaryBaselineReport: ExtendedDogfoodReport | null = null;
+		let secondaryBaselineReport: ExtendedDogfoodReport | null = null;
+		for (const v of variants) {
+			const primaryRun = runVariantOnCorpus(matrix, v, corpora.primary, sweepId);
+			const primary: PerCorpusRun = {
+				corpus: corpora.primary,
+				report: primaryRun.report,
+				durationMs: primaryRun.durationMs,
+				reportPath: primaryRun.reportPath,
 			};
-			if (secondaryBaselineReport) {
-				secondary.decisionVsBaseline = decide({
-					baseline: secondaryBaselineReport,
-					candidate: secondary.report,
+			if (primaryBaselineReport) {
+				primary.decisionVsBaseline = decide({
+					baseline: primaryBaselineReport,
+					candidate: primary.report,
 				});
 			} else {
-				secondaryBaselineReport = secondary.report;
+				primaryBaselineReport = primary.report;
 			}
 			appendRunLogRow(
 				buildRunLogRow({
 					sweepId,
 					matrixName: matrix.name,
 					variantId: v.variantId,
-					report: secondary.report,
-					durationMs: secondary.durationMs,
-					reportPath: secondary.reportPath,
+					report: primary.report,
+					durationMs: primary.durationMs,
+					reportPath: primary.reportPath,
 					...(stage ? { stage } : {}),
 				}),
 			);
+
+			let secondary: PerCorpusRun | undefined;
+			if (corpora.secondary) {
+				const secondaryRun = runVariantOnCorpus(
+					matrix,
+					v,
+					corpora.secondary,
+					sweepId,
+				);
+				secondary = {
+					corpus: corpora.secondary,
+					report: secondaryRun.report,
+					durationMs: secondaryRun.durationMs,
+					reportPath: secondaryRun.reportPath,
+				};
+				if (secondaryBaselineReport) {
+					secondary.decisionVsBaseline = decide({
+						baseline: secondaryBaselineReport,
+						candidate: secondary.report,
+					});
+				} else {
+					secondaryBaselineReport = secondary.report;
+				}
+				appendRunLogRow(
+					buildRunLogRow({
+						sweepId,
+						matrixName: matrix.name,
+						variantId: v.variantId,
+						report: secondary.report,
+						durationMs: secondary.durationMs,
+						reportPath: secondary.reportPath,
+						...(stage ? { stage } : {}),
+					}),
+				);
+			}
+
+			const headline = computeHeadline({
+				v12: primary.report,
+				...(secondary ? { v3: secondary.report } : {}),
+			});
+			const aggregateAccept =
+				(primary.decisionVsBaseline ? primary.decisionVsBaseline.accept : true) &&
+				(secondary?.decisionVsBaseline
+					? secondary.decisionVsBaseline.accept
+					: true);
+			results.push({
+				variantId: v.variantId,
+				variant: v,
+				primary,
+				...(secondary ? { secondary } : {}),
+				headline,
+				aggregateAccept,
+			});
+		}
+	} else {
+		// Phase-split orchestration. One ensureMode call per phase, then
+		// every variant×corpus runs that phase against a shared cache
+		// dir. Total swaps = number of phases with non-null mode (at
+		// most 3). The score phase reads the cache the search phase
+		// wrote, so retrieval never re-runs under the wrong GPU mode.
+		const phaseCacheBase = mkdtempSync(join(tmpdir(), "wtfoc-sweep-phase-"));
+		logErr(`[sweep] phase cache base: ${phaseCacheBase}`);
+
+		// (variant, corpus) → most recent useful run. Embed-phase output
+		// is a sentinel (`pass: embeddings warmed`) and would mask the
+		// search/score reports if it landed in this map, so we skip it.
+		type RunOutput = {
+			report: ExtendedDogfoodReport;
+			durationMs: number;
+			reportPath: string;
+		};
+		const lastReportPerKey = new Map<string, RunOutput>();
+		const corpusList = corpora.secondary
+			? [corpora.primary, corpora.secondary]
+			: [corpora.primary];
+
+		for (const phase of phasePlan) {
+			if (phase.skip) {
+				logErr(`[sweep] phase=${phase.phase} skip (no GPU dependency)`);
+				continue;
+			}
+			if (phase.mode) {
+				logErr(`[sweep] ensureMode → ${phase.mode} (phase=${phase.phase})`);
+				try {
+					const r = await ensureMode(phase.mode, {
+						reason: `sweep ${matrix.name} phase=${phase.phase}`,
+					});
+					if (r.skipped) {
+						logErr(
+							`[sweep] mode-switch skipped (${phase.mode}): ${r.skippedReason}`,
+						);
+					} else {
+						logErr(
+							`[sweep] mode-switch ok: ${r.from ?? "?"}→${r.to ?? phase.mode}`,
+						);
+					}
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					logErr(
+						`[sweep] mode-switch FAILED (${phase.mode}, phase=${phase.phase}): ${msg}`,
+					);
+					process.exit(3);
+				}
+			}
+
+			for (const v of variants) {
+				for (const corpus of corpusList) {
+					const out = runVariantOnCorpus(matrix, v, corpus, sweepId, {
+						phase: phase.phase,
+						cacheBase: phaseCacheBase,
+					});
+					if (phase.phase !== "embed") {
+						lastReportPerKey.set(`${v.variantId}|${corpus}`, out);
+					}
+				}
+			}
 		}
 
-		const headline = computeHeadline({
-			v12: primary.report,
-			...(secondary ? { v3: secondary.report } : {}),
-		});
+		let primaryBaselineReport: ExtendedDogfoodReport | null = null;
+		let secondaryBaselineReport: ExtendedDogfoodReport | null = null;
+		for (const v of variants) {
+			const primaryOut = lastReportPerKey.get(
+				`${v.variantId}|${corpora.primary}`,
+			);
+			if (!primaryOut) {
+				throw new Error(
+					`phase-split: no final report captured for variant=${v.variantId} corpus=${corpora.primary}`,
+				);
+			}
+			const primary: PerCorpusRun = {
+				corpus: corpora.primary,
+				report: primaryOut.report,
+				durationMs: primaryOut.durationMs,
+				reportPath: primaryOut.reportPath,
+			};
+			if (primaryBaselineReport) {
+				primary.decisionVsBaseline = decide({
+					baseline: primaryBaselineReport,
+					candidate: primary.report,
+				});
+			} else {
+				primaryBaselineReport = primary.report;
+			}
+			appendRunLogRow(
+				buildRunLogRow({
+					sweepId,
+					matrixName: matrix.name,
+					variantId: v.variantId,
+					report: primary.report,
+					durationMs: primary.durationMs,
+					reportPath: primary.reportPath,
+					...(stage ? { stage } : {}),
+				}),
+			);
 
-		// Aggregate accept = all per-corpus decisions accept (or, in
-		// single-corpus mode, just the primary). The very first variant
-		// has no decision (it IS the baseline) and counts as accepting.
-		const aggregateAccept =
-			(primary.decisionVsBaseline ? primary.decisionVsBaseline.accept : true) &&
-			(secondary?.decisionVsBaseline ? secondary.decisionVsBaseline.accept : true);
+			let secondary: PerCorpusRun | undefined;
+			if (corpora.secondary) {
+				const secondaryOut = lastReportPerKey.get(
+					`${v.variantId}|${corpora.secondary}`,
+				);
+				if (!secondaryOut) {
+					throw new Error(
+						`phase-split: no final report captured for variant=${v.variantId} corpus=${corpora.secondary}`,
+					);
+				}
+				secondary = {
+					corpus: corpora.secondary,
+					report: secondaryOut.report,
+					durationMs: secondaryOut.durationMs,
+					reportPath: secondaryOut.reportPath,
+				};
+				if (secondaryBaselineReport) {
+					secondary.decisionVsBaseline = decide({
+						baseline: secondaryBaselineReport,
+						candidate: secondary.report,
+					});
+				} else {
+					secondaryBaselineReport = secondary.report;
+				}
+				appendRunLogRow(
+					buildRunLogRow({
+						sweepId,
+						matrixName: matrix.name,
+						variantId: v.variantId,
+						report: secondary.report,
+						durationMs: secondary.durationMs,
+						reportPath: secondary.reportPath,
+						...(stage ? { stage } : {}),
+					}),
+				);
+			}
 
-		results.push({
-			variantId: v.variantId,
-			variant: v,
-			primary,
-			...(secondary ? { secondary } : {}),
-			headline,
-			aggregateAccept,
-		});
+			const headline = computeHeadline({
+				v12: primary.report,
+				...(secondary ? { v3: secondary.report } : {}),
+			});
+			const aggregateAccept =
+				(primary.decisionVsBaseline ? primary.decisionVsBaseline.accept : true) &&
+				(secondary?.decisionVsBaseline
+					? secondary.decisionVsBaseline.accept
+					: true);
+			results.push({
+				variantId: v.variantId,
+				variant: v,
+				primary,
+				...(secondary ? { secondary } : {}),
+				headline,
+				aggregateAccept,
+			});
+		}
 	}
 
 	summarize(results);

--- a/scripts/autoresearch/sweep.ts
+++ b/scripts/autoresearch/sweep.ts
@@ -37,7 +37,7 @@ import {
 	planSweepPhases,
 } from "./sweep-phase-planner.js";
 import { safeExecFileSync as execFileSync } from "../lib/safe-exec.js";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -404,7 +404,7 @@ async function main(): Promise<void> {
 		const url = process.env.WTFOC_VLLM_ADMIN_URL;
 		if (!url) return null;
 		try {
-			return new URL(url).host;
+			return new URL(url).hostname;
 		} catch {
 			return null;
 		}
@@ -522,6 +522,27 @@ async function main(): Promise<void> {
 		// wrote, so retrieval never re-runs under the wrong GPU mode.
 		const phaseCacheBase = mkdtempSync(join(tmpdir(), "wtfoc-sweep-phase-"));
 		logErr(`[sweep] phase cache base: ${phaseCacheBase}`);
+		// Phase caches are per-sweep ephemera. The summary report is the
+		// durable artifact; the cache only exists so the score phase can
+		// replay search-phase results under a different GPU mode. Clean
+		// up unconditionally — even on failure — so successive sweeps
+		// don't accumulate gigabytes under /tmp.
+		const cleanupPhaseCache = (): void => {
+			try {
+				rmSync(phaseCacheBase, { recursive: true, force: true });
+			} catch (err) {
+				logErr(
+					`[sweep] phase cache cleanup failed (${phaseCacheBase}): ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
+		};
+		// Belt-and-suspenders: ensure the cache dir is removed even if the
+		// sweep throws before reaching the explicit cleanup at the end of
+		// this block. The handler is per-sweep so successive sweeps don't
+		// stack listeners.
+		const exitHandler = (): void => cleanupPhaseCache();
+		process.once("exit", exitHandler);
+		try {
 
 		// (variant, corpus) → most recent useful run. Embed-phase output
 		// is a sentinel (`pass: embeddings warmed`) and would mask the
@@ -669,6 +690,10 @@ async function main(): Promise<void> {
 				headline,
 				aggregateAccept,
 			});
+		}
+		} finally {
+			process.removeListener("exit", exitHandler);
+			cleanupPhaseCache();
 		}
 	}
 

--- a/scripts/dogfood.ts
+++ b/scripts/dogfood.ts
@@ -35,7 +35,11 @@ import { CostAggregator } from "./lib/cost-aggregator.js";
 import {
 	buildRetrievalContext,
 	groundingPromptHashes,
+	loadSearchPhaseCache,
+	runEmbedPhase,
 	runQualityQueriesPipeline,
+	runScorePhase,
+	runSearchPhase,
 } from "./lib/dogfood-pipeline.js";
 import type { LlmUsage } from "./lib/llm-usage.js";
 import {
@@ -94,6 +98,14 @@ const { values } = parseArgs({
 		"trace-max-per-source": { type: "string" },
 		"trace-max-total": { type: "string" },
 		"trace-min-score": { type: "string" },
+		// 3-phase sweep (single-GPU mode-switch) — split the
+		// quality-queries pipeline into embed → search → score so the sweep
+		// driver can swap GPU modes between phases without forcing the full
+		// matrix to share one mode.
+		phase: { type: "string", default: "all" },
+		"cache-base": { type: "string" },
+		"sweep-id": { type: "string" },
+		"variant-id": { type: "string" },
 		help: { type: "boolean", short: "h", default: false },
 	},
 	strict: true,
@@ -114,6 +126,10 @@ Options:
   --embedder-url <url>       Embedder endpoint
   --embedder-model <model>   Embedder model name
   --embedder-key <key>       Embedder API key
+  --phase <name>             quality-queries phase: all|embed|search|score (default: all)
+  --cache-base <path>        Phase cache root (or env WTFOC_DOGFOOD_CACHE_DIR)
+  --sweep-id <id>            Sweep id for phase cache path
+  --variant-id <id>          Variant id for phase cache path
   -h, --help                 Show this help
 `);
 	process.exit(0);
@@ -130,6 +146,29 @@ if (values.stage && !VALID_STAGES.includes(values.stage as StageName)) {
 		`Error: --stage must be one of: ${VALID_STAGES.join(", ")}`,
 	);
 	process.exit(1);
+}
+
+const VALID_PHASES = ["all", "embed", "search", "score"] as const;
+type PhaseName = (typeof VALID_PHASES)[number];
+const phase = (values.phase ?? "all") as string;
+if (!VALID_PHASES.includes(phase as PhaseName)) {
+	console.error(`Error: --phase must be one of: ${VALID_PHASES.join(", ")}`);
+	process.exit(1);
+}
+if (phase !== "all") {
+	const cacheBase = values["cache-base"] ?? process.env.WTFOC_DOGFOOD_CACHE_DIR;
+	if (!cacheBase) {
+		console.error(
+			"Error: --phase != all requires --cache-base or WTFOC_DOGFOOD_CACHE_DIR",
+		);
+		process.exit(1);
+	}
+	if (!values["sweep-id"] || !values["variant-id"]) {
+		console.error(
+			"Error: --phase != all requires --sweep-id and --variant-id",
+		);
+		process.exit(1);
+	}
 }
 
 // Validate edge stage requires extractor options
@@ -474,18 +513,100 @@ async function main() {
 							embedderUsageSink,
 						});
 
-						result = await runQualityQueriesPipeline(ctx, {
-							reranker,
-							autoRoute: values["auto-route"] ?? false,
-							diversityEnforce: values["diversity-enforce"] ?? false,
-							checkParaphrases: process.env.WTFOC_CHECK_PARAPHRASES === "1",
-							timer,
-							costs,
-							groundingEnabled,
-							graderConfig,
-							synthesizerConfig,
-							collectionId,
-						});
+						const cacheBaseDir =
+							values["cache-base"] ?? process.env.WTFOC_DOGFOOD_CACHE_DIR;
+						const cachePath = cacheBaseDir
+							? {
+									cacheBase: cacheBaseDir,
+									sweepId: values["sweep-id"] ?? "default",
+									variantId: values["variant-id"] ?? "default",
+								}
+							: null;
+						const rerankerIdentity = values["reranker-type"] && values["reranker-url"]
+							? {
+									type: values["reranker-type"],
+									url: values["reranker-url"],
+									...(values["reranker-model"]
+										? { model: values["reranker-model"] }
+										: {}),
+								}
+							: null;
+						const manifestId = head.manifest.currentRevisionId ?? collectionId;
+						const segmentIds = head.manifest.segments.map((s) => s.id);
+
+						if (phase === "all") {
+							result = await runQualityQueriesPipeline(ctx, {
+								reranker,
+								autoRoute: values["auto-route"] ?? false,
+								diversityEnforce: values["diversity-enforce"] ?? false,
+								checkParaphrases: process.env.WTFOC_CHECK_PARAPHRASES === "1",
+								timer,
+								costs,
+								groundingEnabled,
+								graderConfig,
+								synthesizerConfig,
+								collectionId,
+							});
+						} else if (phase === "embed") {
+							if (!cachePath) throw new Error("phase=embed requires cache path");
+							await runEmbedPhase(ctx, cachePath, {
+								runConfigFingerprint,
+								embedderUrl: values["embedder-url"]!,
+								embedderModel: values["embedder-model"]!,
+								embedderCacheDir:
+									values["embedder-cache-dir"] ??
+									process.env.WTFOC_EMBEDDER_CACHE_DIR ??
+									null,
+							});
+							result = {
+								stage: STAGE_ID[stage],
+								startedAt: new Date().toISOString(),
+								durationMs: 0,
+								verdict: "pass",
+								summary: "phase=embed: query embeddings warmed",
+								metrics: {},
+								checks: [],
+							};
+						} else if (phase === "search") {
+							if (!cachePath) throw new Error("phase=search requires cache path");
+							const { stageResult } = await runSearchPhase(ctx, cachePath, {
+								reranker,
+								autoRoute: values["auto-route"] ?? false,
+								diversityEnforce: values["diversity-enforce"] ?? false,
+								checkParaphrases: process.env.WTFOC_CHECK_PARAPHRASES === "1",
+								timer,
+								costs,
+								collectionId,
+								manifestId,
+								segmentIds,
+								rerankerIdentity,
+								documentCatalogId: ctx.documentCatalog ? "present" : null,
+								runConfigFingerprint,
+							});
+							result = stageResult;
+						} else {
+							// phase === "score"
+							if (!cachePath) throw new Error("phase=score requires cache path");
+							const searchCache = loadSearchPhaseCache(
+								cachePath,
+								collectionId,
+								runConfigFingerprint,
+							);
+							if (!searchCache) {
+								throw new Error(
+									`phase=score: no search-phase cache at ${cachePath.cacheBase} for sweep=${cachePath.sweepId} variant=${cachePath.variantId} corpus=${collectionId} fingerprint=${runConfigFingerprint.slice(0, 12)}`,
+								);
+							}
+							result = await runScorePhase(ctx, searchCache, {
+								reranker,
+								timer,
+								costs,
+								groundingEnabled,
+								graderConfig,
+								synthesizerConfig,
+								collectionId,
+							});
+						}
 					}
 					break;
 				}

--- a/scripts/dogfood.ts
+++ b/scripts/dogfood.ts
@@ -19,39 +19,31 @@ import {
 	BgeReranker,
 	CachingEmbedder,
 	evaluateEdgeResolution,
-	evaluateQualityQueries,
 	evaluateSearch,
 	evaluateThemes,
-	GOLD_STANDARD_QUERIES,
 	GOLD_STANDARD_QUERIES_VERSION,
+	GOLD_STANDARD_QUERIES,
 	InMemoryVectorIndex,
 	LlmReranker,
 	OpenAIEmbedder,
-	type PreflightStatus,
 	type Reranker,
-	runPreflight,
 } from "@wtfoc/search";
 import { evaluateStorage, createStore } from "@wtfoc/store";
 import { formatDogfoodReport } from "./dogfood-formatter.js";
 import { buildRunConfig, defaultQualityQueriesRetrieval } from "./lib/build-run-config.js";
-import { namespacedCacheDir } from "./lib/cache-namespace.js";
 import { CostAggregator } from "./lib/cost-aggregator.js";
 import {
-	GRADER_PROMPT_VERSION,
-	GRADER_SYSTEM_PROMPT,
-	SYNTHESIS_PROMPT_VERSION,
-	SYNTHESIS_SYSTEM_PROMPT,
-} from "./lib/grounding-prompts.js";
-import { runGrounding } from "./lib/grounding-runner.js";
+	buildRetrievalContext,
+	groundingPromptHashes,
+	runQualityQueriesPipeline,
+} from "./lib/dogfood-pipeline.js";
 import type { LlmUsage } from "./lib/llm-usage.js";
 import {
 	computeRunConfigFingerprint,
 	type ExtendedDogfoodReport,
 	FINGERPRINT_VERSION,
 } from "./lib/run-config.js";
-import { sha256Hex } from "./lib/run-config.js";
 import { SubstageTimer } from "./lib/substage-timer.js";
-import { TimingVectorIndex } from "./lib/timing-vector-index.js";
 
 const VALID_STAGES = [
 	"ingest",
@@ -204,12 +196,7 @@ async function main() {
 					apiKey: values["extractor-key"],
 				}
 			: null;
-	const promptHashes: Record<string, string> = groundingEnabled
-		? {
-				synthesis: `${SYNTHESIS_PROMPT_VERSION}:${sha256Hex(SYNTHESIS_SYSTEM_PROMPT)}`,
-				grader: `${GRADER_PROMPT_VERSION}:${sha256Hex(GRADER_SYSTEM_PROMPT)}`,
-			}
-		: {};
+	const promptHashes = groundingPromptHashes(groundingEnabled);
 
 	// Build the run identity record + fingerprint up front so cache
 	// namespacing can use it before any stage runs. Variants with
@@ -447,55 +434,13 @@ async function main() {
 							checks: [],
 						};
 					} else {
-						const rawEmbedder = new OpenAIEmbedder({
-							apiKey: values["embedder-key"] || process.env.WTFOC_EMBEDDER_KEY || values["extractor-key"] || "no-key",
-							baseUrl: values["embedder-url"],
-							model: values["embedder-model"],
-							usageSink: embedderUsageSink,
-						});
-						const embedCacheBaseDir =
-							values["embedder-cache-dir"] ?? process.env.WTFOC_EMBEDDER_CACHE_DIR;
-						const embedder = embedCacheBaseDir
-							? new CachingEmbedder(rawEmbedder, {
-									cacheDir: namespacedCacheDir(embedCacheBaseDir, runConfigFingerprint),
-									provider: "openai-compatible",
-									modelVersion: "unknown",
-								})
-							: rawEmbedder;
-						const baseVectorIndex = new InMemoryVectorIndex();
-						for (const seg of segments) {
-							const entries = seg.chunks
-								.filter((c: { embedding?: number[] }) => c.embedding && c.embedding.length > 0)
-								.map((c: { id: string; storageId: string; content: string; sourceType: string; source: string; sourceUrl?: string; embedding: number[]; metadata?: Record<string, string>; signalScores?: Record<string, number> }) => ({
-									id: c.id,
-									vector: new Float32Array(c.embedding),
-									storageId: c.storageId || c.id,
-									metadata: {
-										sourceType: c.sourceType,
-										source: c.source,
-										sourceUrl: c.sourceUrl ?? "",
-										content: c.content,
-										...(c.metadata ?? {}),
-										...(c.signalScores && Object.keys(c.signalScores).length > 0
-											? { signalScores: JSON.stringify(c.signalScores) }
-											: {}),
-									},
-								}));
-							if (entries.length > 0) {
-								await baseVectorIndex.add(entries);
-							}
+						const collectionId = values.collection;
+						if (!collectionId) {
+							throw new Error("--collection is required for the quality-queries stage");
 						}
-						const vectorIndex = new TimingVectorIndex(baseVectorIndex, (ms) =>
-							timer.record("vector-retrieve", ms),
-						);
 						const qqManifestDir =
 							(store.manifests as { dir?: string }).dir ??
 							`${process.env.HOME ?? "."}.wtfoc/projects`;
-						const qqOverlayEdges = await loadAllOverlayEdges(qqManifestDir, values.collection!);
-						const corpusSourceTypes = new Set<string>();
-						for (const segSummary of head.manifest.segments) {
-							for (const st of segSummary.sourceTypes ?? []) corpusSourceTypes.add(st);
-						}
 						const retrievalOverrides: {
 							topK?: number;
 							traceMaxPerSource?: number;
@@ -510,131 +455,37 @@ async function main() {
 						if (values["trace-min-score"] !== undefined)
 							retrievalOverrides.traceMinScore = Number.parseFloat(values["trace-min-score"]);
 
-						// #344 step 3 — pre-flight catalog applicability so the
-						// failure-diagnosis layer's rule-1 short-circuit can fire
-						// (gold artifacts absent from this corpus = `fixture-invalid`,
-						// no retrieval-layer triage). Loads the catalog for the
-						// active collection only and runs preflight against the
-						// subset of queries that target this corpus, so
-						// `runPreflight`'s cross-corpus schema check (which would
-						// hard-error on every multi-corpus query) does not fire.
-						const collectionId = values.collection;
-						if (!collectionId) {
-							throw new Error("--collection is required for the quality-queries stage");
-						}
-						const qqCatPath = catalogFilePath(qqManifestDir, collectionId);
-						const qqCatalog = await readCatalog(qqCatPath);
-						const preflightStatusByQueryId = new Map<string, PreflightStatus>();
-						if (qqCatalog) {
-							// Project each query down to "this corpus" before preflight so
-							// `runPreflight`'s matrix-validation pass (which expects a
-							// catalog for every applicableCorpora id it sees) gets a
-							// single-corpus view it can satisfy.
-							const localQueries = GOLD_STANDARD_QUERIES.filter((q) =>
-								q.applicableCorpora.includes(collectionId),
-							).map((q) => ({ ...q, applicableCorpora: [collectionId] }));
-							const preflight = runPreflight({
-								queries: localQueries,
-								catalogs: [{ corpusId: collectionId, catalog: qqCatalog }],
-							});
-							if (preflight.hardErrors.length > 0) {
-								console.warn(
-									`[dogfood] preflight hard-errors (${preflight.hardErrors.length}); skipping fixture-invalid wiring`,
-								);
-								for (const e of preflight.hardErrors) console.warn(`  - ${e}`);
-							} else {
-								for (const r of preflight.results) {
-									if (r.corpusId === collectionId) {
-										preflightStatusByQueryId.set(r.queryId, r.status);
-									}
-								}
-							}
-						}
-
-						result = await evaluateQualityQueries(
-						embedder,
-						vectorIndex,
-						segments,
-						undefined,
-						qqOverlayEdges,
-						reranker,
-						values["auto-route"] ?? false,
-						{
-							collectionId: values.collection!,
-							corpusSourceTypes,
-							perQueryHook: (id, ms) => timer.record("per-query-total", ms),
-							checkParaphrases: process.env.WTFOC_CHECK_PARAPHRASES === "1",
-							...(preflightStatusByQueryId.size > 0
-								? { preflightStatusByQueryId }
-								: {}),
-							...(Object.keys(retrievalOverrides).length > 0
-								? { retrievalOverrides }
-								: {}),
-							// #360 — feed the per-corpus document catalog so the
-							// evaluator emits coverageReport + fixtureHealthSignal
-							// alongside diagnosisAggregate. Knobs land via env so
-							// the autoresearch sweep can override per-cycle.
-							...(qqCatalog ? { documentCatalog: qqCatalog } : {}),
-							...(process.env.WTFOC_RECIPE_GINI_FLOOR
-								? { coverageGiniFloor: Number(process.env.WTFOC_RECIPE_GINI_FLOOR) }
-								: {}),
-							...(process.env.WTFOC_RECIPE_MIN_UNCOVERED_STRATA
-								? {
-										coverageMinUncoveredStrata: Number(
-											process.env.WTFOC_RECIPE_MIN_UNCOVERED_STRATA,
-										),
-									}
-								: {}),
-						},
-						values["diversity-enforce"] ?? false,
-					);
-
-					// Phase 0f — citation/grounding on the synthesis tier. Off
-					// by default; opt-in via WTFOC_GROUND_CHECK=1 (single
-					// pinned grader, no escalation, no rate-limit risk on
-					// local vLLM). Synthesis prompts the extractor to emit
-					// claims; grader (stronger model than extractor) verdicts
-					// each claim against the same retrieved evidence.
-					let grounding: Awaited<ReturnType<typeof runGrounding>> | null = null;
-					if (groundingEnabled && graderConfig && synthesizerConfig) {
-						const synthSink = (u: LlmUsage): void => {
-							if (typeof u.durationMs === "number") timer.record("synthesize", u.durationMs);
-							costs.record("synthesize", u);
-						};
-						const graderSink = (u: LlmUsage): void => {
-							if (typeof u.durationMs === "number") timer.record("grade", u.durationMs);
-							costs.record("grade", u);
-						};
-						const synthQueries = GOLD_STANDARD_QUERIES.filter(
-							(q) =>
-								q.queryType === "howto" && q.applicableCorpora.includes(values.collection!),
-						).map((q) => ({ id: q.id, queryText: q.query }));
-						console.error(
-							`[dogfood] grounding: ${synthQueries.length} synthesis-tier queries (grader=${graderConfig.model})`,
-						);
-						grounding = await runGrounding({
-							queries: synthQueries,
-							synthesizer: synthesizerConfig,
-							grader: graderConfig,
-							embedder,
-							vectorIndex,
-							reranker,
-							topK: 10,
-							synthesizerUsageSink: synthSink,
-							graderUsageSink: graderSink,
+						const ctx = await buildRetrievalContext({
+							collectionId,
+							manifestDir: qqManifestDir,
+							manifest: head.manifest,
+							segments,
+							runConfigFingerprint,
+							embedderUrl: values["embedder-url"],
+							embedderModel: values["embedder-model"],
+							embedderApiKey:
+								values["embedder-key"] ||
+								process.env.WTFOC_EMBEDDER_KEY ||
+								values["extractor-key"],
+							embedderCacheDir:
+								values["embedder-cache-dir"] ?? process.env.WTFOC_EMBEDDER_CACHE_DIR,
+							retrievalOverrides,
+							timer,
+							embedderUsageSink,
 						});
-					}
 
-					// Attach timing + cost telemetry (and grounding when run)
-					// to the stage's metrics payload — published
-					// `EvalStageResult.metrics` is `Record<string, unknown>`
-					// so this is additive.
-					result.metrics = {
-						...result.metrics,
-						timing: timer.allStats(),
-						cost: costs.allStats(),
-						...(grounding ? { grounding } : {}),
-					};
+						result = await runQualityQueriesPipeline(ctx, {
+							reranker,
+							autoRoute: values["auto-route"] ?? false,
+							diversityEnforce: values["diversity-enforce"] ?? false,
+							checkParaphrases: process.env.WTFOC_CHECK_PARAPHRASES === "1",
+							timer,
+							costs,
+							groundingEnabled,
+							graderConfig,
+							synthesizerConfig,
+							collectionId,
+						});
 					}
 					break;
 				}

--- a/scripts/dogfood.ts
+++ b/scripts/dogfood.ts
@@ -545,14 +545,20 @@ async function main() {
 								groundingEnabled,
 								graderConfig,
 								synthesizerConfig,
-								collectionId,
 							});
 						} else if (phase === "embed") {
 							if (!cachePath) throw new Error("phase=embed requires cache path");
+							const embedderUrl = values["embedder-url"];
+							const embedderModel = values["embedder-model"];
+							if (!embedderUrl || !embedderModel) {
+								throw new Error(
+									"phase=embed requires --embedder-url and --embedder-model",
+								);
+							}
 							await runEmbedPhase(ctx, cachePath, {
 								runConfigFingerprint,
-								embedderUrl: values["embedder-url"]!,
-								embedderModel: values["embedder-model"]!,
+								embedderUrl,
+								embedderModel,
 								embedderCacheDir:
 									values["embedder-cache-dir"] ??
 									process.env.WTFOC_EMBEDDER_CACHE_DIR ??
@@ -576,7 +582,6 @@ async function main() {
 								checkParaphrases: process.env.WTFOC_CHECK_PARAPHRASES === "1",
 								timer,
 								costs,
-								collectionId,
 								manifestId,
 								segmentIds,
 								rerankerIdentity,
@@ -604,7 +609,6 @@ async function main() {
 								groundingEnabled,
 								graderConfig,
 								synthesizerConfig,
-								collectionId,
 							});
 						}
 					}

--- a/scripts/lib/dogfood-cache.test.ts
+++ b/scripts/lib/dogfood-cache.test.ts
@@ -1,0 +1,187 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	CACHE_SCHEMA_VERSION,
+	CacheFingerprintMismatchError,
+	CacheSchemaMismatchError,
+	type EmbedPhaseCacheV1,
+	type SearchPhaseCacheV1,
+	phaseCachePath,
+	readPhaseCache,
+	writePhaseCache,
+} from "./dogfood-cache.js";
+
+describe("phaseCachePath", () => {
+	it("composes <base>/<sweep>/<variant>/<corpus>/<fingerprint>/<phase>.json", () => {
+		const p = phaseCachePath({
+			base: "/tmp/cache",
+			sweepId: "sw_1",
+			variantId: "v_a",
+			corpus: "demo",
+			runConfigFingerprint: "abc123",
+			phase: "search",
+		});
+		expect(p).toBe("/tmp/cache/sw_1/v_a/demo/abc123/search.json");
+	});
+
+	it("keeps phases isolated per variant", () => {
+		const a = phaseCachePath({
+			base: "/c",
+			sweepId: "s",
+			variantId: "v_a",
+			corpus: "demo",
+			runConfigFingerprint: "fp",
+			phase: "search",
+		});
+		const b = phaseCachePath({
+			base: "/c",
+			sweepId: "s",
+			variantId: "v_b",
+			corpus: "demo",
+			runConfigFingerprint: "fp",
+			phase: "search",
+		});
+		expect(a).not.toBe(b);
+	});
+});
+
+describe("write/read phase cache", () => {
+	let base: string;
+	beforeEach(() => {
+		base = mkdtempSync(join(tmpdir(), "wtfoc-cache-test-"));
+	});
+	afterEach(() => {
+		rmSync(base, { recursive: true, force: true });
+	});
+
+	const baseInput = {
+		sweepId: "sw_1",
+		variantId: "v_a",
+		corpus: "demo",
+		runConfigFingerprint: "fp_abc",
+	};
+
+	it("round-trips a SearchPhaseCacheV1 payload", () => {
+		const payload: SearchPhaseCacheV1 = {
+			schemaVersion: CACHE_SCHEMA_VERSION,
+			phase: "search",
+			capturedAt: "2026-05-05T00:00:00Z",
+			runConfigFingerprint: baseInput.runConfigFingerprint,
+			collectionId: "demo",
+			manifestId: "m1",
+			segmentIds: ["s1", "s2"],
+			activeQueryIds: ["q1"],
+			preflight: { q1: "applicable" as never },
+			corpusSourceTypes: ["github"],
+			documentCatalogId: "cat1",
+			retrievalOverrides: { topK: 12 },
+			reranker: { type: "bge", url: "http://reranker-gpu.x" },
+			diversityEnforce: false,
+			autoRoute: false,
+			queries: [
+				{
+					id: "q1",
+					queryText: "hello",
+					queryResults: [
+						{
+							chunkId: "c1",
+							score: 0.9,
+							retrievalScore: 0.7,
+							documentId: "d1",
+							source: "src1",
+							sourceType: "github",
+							sourceUrl: "",
+							content: "snippet",
+						},
+					],
+					timingMs: 42,
+				},
+			],
+			searchTiming: {},
+			searchCost: {},
+		};
+		const path = writePhaseCache(
+			{ base, ...baseInput, phase: "search" },
+			payload,
+		);
+		expect(path).toContain("/sw_1/v_a/demo/fp_abc/search.json");
+		const back = readPhaseCache({ base, ...baseInput, phase: "search" });
+		expect(back).toEqual(payload);
+	});
+
+	it("returns null when file is missing", () => {
+		expect(
+			readPhaseCache({ base, ...baseInput, phase: "search" }),
+		).toBeNull();
+	});
+
+	it("throws CacheSchemaMismatchError on schemaVersion drift", () => {
+		const path = writePhaseCache(
+			{ base, ...baseInput, phase: "embed" },
+			{
+				schemaVersion: CACHE_SCHEMA_VERSION,
+				phase: "embed",
+				capturedAt: "2026-05-05T00:00:00Z",
+				runConfigFingerprint: baseInput.runConfigFingerprint,
+				collectionId: "demo",
+				embedderModel: "m",
+				embedderUrl: "u",
+				embedderCacheDir: null,
+				warmedQueryIds: ["q1"],
+			} satisfies EmbedPhaseCacheV1,
+		);
+		// Mutate stored version to simulate an older build's payload.
+		const raw = JSON.parse(readFileSync(path, "utf-8"));
+		raw.schemaVersion = 0;
+		writeFileSync(path, JSON.stringify(raw));
+		expect(() =>
+			readPhaseCache({ base, ...baseInput, phase: "embed" }),
+		).toThrow(CacheSchemaMismatchError);
+	});
+
+	it("throws CacheFingerprintMismatchError when stored fingerprint drifts from path", () => {
+		const path = writePhaseCache(
+			{ base, ...baseInput, phase: "embed" },
+			{
+				schemaVersion: CACHE_SCHEMA_VERSION,
+				phase: "embed",
+				capturedAt: "2026-05-05T00:00:00Z",
+				runConfigFingerprint: baseInput.runConfigFingerprint,
+				collectionId: "demo",
+				embedderModel: "m",
+				embedderUrl: "u",
+				embedderCacheDir: null,
+				warmedQueryIds: ["q1"],
+			} satisfies EmbedPhaseCacheV1,
+		);
+		// Tamper with stored fingerprint to simulate a corrupt or relocated
+		// cache file; reader must reject rather than serve stale state.
+		const raw = JSON.parse(readFileSync(path, "utf-8"));
+		raw.runConfigFingerprint = "tampered";
+		writeFileSync(path, JSON.stringify(raw));
+		expect(() =>
+			readPhaseCache({ base, ...baseInput, phase: "embed" }),
+		).toThrow(CacheFingerprintMismatchError);
+	});
+
+	it("refuses to write when payload.phase mismatches path phase", () => {
+		expect(() =>
+			writePhaseCache(
+				{ base, ...baseInput, phase: "search" },
+				{
+					schemaVersion: CACHE_SCHEMA_VERSION,
+					phase: "embed",
+					capturedAt: "2026-05-05T00:00:00Z",
+					runConfigFingerprint: baseInput.runConfigFingerprint,
+					collectionId: "demo",
+					embedderModel: "m",
+					embedderUrl: "u",
+					embedderCacheDir: null,
+					warmedQueryIds: [],
+				} satisfies EmbedPhaseCacheV1,
+			),
+		).toThrow(/phase mismatch/);
+	});
+});

--- a/scripts/lib/dogfood-cache.test.ts
+++ b/scripts/lib/dogfood-cache.test.ts
@@ -99,6 +99,15 @@ describe("write/read phase cache", () => {
 					timingMs: 42,
 				},
 			],
+			stageResult: {
+				stage: "quality-queries",
+				startedAt: "2026-05-05T00:00:00Z",
+				durationMs: 1234,
+				verdict: "pass",
+				summary: "stub",
+				metrics: { passRate: 1.0 },
+				checks: [],
+			},
 			searchTiming: {},
 			searchCost: {},
 		};

--- a/scripts/lib/dogfood-cache.ts
+++ b/scripts/lib/dogfood-cache.ts
@@ -167,7 +167,19 @@ export interface SearchPhaseCacheV1 {
 	reranker: { type: string; model?: string; url?: string } | null;
 	diversityEnforce: boolean;
 	autoRoute: boolean;
-	queries: CachedQueryEntry[];
+	/**
+	 * Granular per-query rows for forensics. Optional in v1 — populated
+	 * when the evaluator surfaces its internal QueryScore[] (a follow-up).
+	 * The score phase prefers `stageResult` when present.
+	 */
+	queries?: CachedQueryEntry[];
+	/**
+	 * The deterministic-scoring `EvalStageResult` produced by the search
+	 * phase. The score phase replays this verbatim and layers grounding /
+	 * additional metrics on top, so the cached search can drive the final
+	 * report under a different GPU mode without re-running retrieval.
+	 */
+	stageResult: unknown;
 	searchTiming: Record<string, unknown>;
 	searchCost: Record<string, unknown>;
 }

--- a/scripts/lib/dogfood-cache.ts
+++ b/scripts/lib/dogfood-cache.ts
@@ -1,0 +1,299 @@
+/**
+ * Dogfood-private phase cache. Captures the artifacts produced by one
+ * sweep phase (embed, search, score) so the next phase can resume
+ * without re-running anything that's already on disk.
+ *
+ * Step 2 of the 3-phase sweep refactor — schema + IO only. Wiring into
+ * the dogfood pipeline lands when `--phase` is added.
+ *
+ * Path layout (per codex peer-review):
+ *
+ *   <base>/<sweepId>/<variantId>/<corpus>/<runConfigFingerprint>/<phase>.json
+ *
+ * `base` defaults to `$WTFOC_DOGFOOD_CACHE_DIR` when set, otherwise a
+ * fresh temp dir under the OS tmp prefix. Caches are NOT a public
+ * artifact: they are written next to the active sweep report, deleted
+ * on sweep cleanup, and never bundled with the published packages.
+ *
+ * The schema is versioned. Bump `CACHE_SCHEMA_VERSION` whenever the
+ * stored shape changes — readers MUST reject any payload whose stored
+ * `schemaVersion` does not match the current build, because a stale
+ * cache silently consumed across schema generations is worse than a
+ * miss. The fingerprint already prevents cross-config reuse, so a
+ * schema bump only ever invalidates caches written by an older build.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { PreflightStatus } from "@wtfoc/search";
+
+export const CACHE_SCHEMA_VERSION = 1;
+
+export type CachePhase = "embed" | "search" | "score";
+
+export interface CachePathInput {
+	base: string;
+	sweepId: string;
+	variantId: string;
+	corpus: string;
+	runConfigFingerprint: string;
+	phase: CachePhase;
+}
+
+/**
+ * Resolve the on-disk path for a single phase cache file. Pure — does
+ * not create the parent directory. Callers that intend to write should
+ * either call `writePhaseCache` (which mkdirs) or `mkdirSync(dirname,
+ * { recursive: true })` themselves.
+ */
+export function phaseCachePath(input: CachePathInput): string {
+	return join(
+		input.base,
+		input.sweepId,
+		input.variantId,
+		input.corpus,
+		input.runConfigFingerprint,
+		`${input.phase}.json`,
+	);
+}
+
+/**
+ * Compact view of a retrieved chunk — just the fields the score phase
+ * needs to reconstruct evidence checks without re-running the embedder
+ * or vector index. Mirrors the metadata shape that `query()` /
+ * `trace()` emit, but normalized so the cache stays stable across
+ * minor evaluator refactors.
+ */
+export interface CachedQueryResult {
+	chunkId: string;
+	score: number;
+	/**
+	 * Raw embedder cosine before reranking / boosts. Stored separately
+	 * so the hard-negative gate's calibrated thresholds keep working
+	 * when score-phase replays a cached search produced under a
+	 * different reranker.
+	 */
+	retrievalScore: number;
+	documentId: string;
+	source: string;
+	sourceType: string;
+	sourceUrl: string;
+	content: string;
+	metadata?: Record<string, string>;
+	signalScores?: Record<string, number>;
+}
+
+export interface CachedTraceHop {
+	chunkId: string;
+	viaEdge: string | null;
+	source: string;
+	sourceType: string;
+	score: number;
+}
+
+export interface CachedTraceStats {
+	hopCount: number;
+	maxHops: number;
+	maxPerSource: number;
+	maxTotal: number;
+	minScore: number;
+	terminationReason: string;
+}
+
+export interface CachedQueryEntry {
+	id: string;
+	queryText: string;
+	/**
+	 * When the evaluator skipped the query (corpus coverage gap,
+	 * preflight invalidation, etc.) the cache stores only the skip
+	 * reason — there are no search results to replay.
+	 */
+	skipped?: { reason: string };
+	queryResults: CachedQueryResult[];
+	trace?: {
+		hops: CachedTraceHop[];
+		stats: CachedTraceStats;
+		/**
+		 * Inputs needed by `aggregateLineageMetrics` so the score phase
+		 * can re-derive lineage metrics without re-walking the graph.
+		 */
+		lineageInputs: Record<string, unknown>;
+	};
+	timingMs: number;
+	goldProximity?: {
+		widerK: number;
+		topKCutoff: number;
+		goldRank: number | null;
+		goldScore: number | null;
+		topKLastScore: number | null;
+	} | null;
+	/** Top-K retrieval recall when the fixture has goldSupportingSources. */
+	recallAtK?: number | null;
+	recallK?: number | null;
+	/**
+	 * Retrieval-side hard-negative signal. Raw embedder scores only;
+	 * calibrated against the hard-negative noise floor / score ceiling
+	 * by the score phase.
+	 */
+	hardNegatives?: Array<{
+		chunkId: string;
+		retrievalScore: number;
+		calibratedScore: number;
+	}>;
+}
+
+/**
+ * Search-phase output. The score phase reads this and runs deterministic
+ * evidence checks (and optional grounding) against the cached results.
+ */
+export interface SearchPhaseCacheV1 {
+	schemaVersion: typeof CACHE_SCHEMA_VERSION;
+	phase: "search";
+	capturedAt: string;
+	runConfigFingerprint: string;
+	collectionId: string;
+	manifestId: string;
+	segmentIds: string[];
+	activeQueryIds: string[];
+	preflight: Record<string, PreflightStatus>;
+	corpusSourceTypes: string[];
+	documentCatalogId: string | null;
+	retrievalOverrides: {
+		topK?: number;
+		traceMaxPerSource?: number;
+		traceMaxTotal?: number;
+		traceMinScore?: number;
+	};
+	reranker: { type: string; model?: string; url?: string } | null;
+	diversityEnforce: boolean;
+	autoRoute: boolean;
+	queries: CachedQueryEntry[];
+	searchTiming: Record<string, unknown>;
+	searchCost: Record<string, unknown>;
+}
+
+/**
+ * Embed-phase output. Today the on-disk caching embedder already
+ * persists query embeddings under the run-config fingerprint, so the
+ * embed-phase cache is a thin manifest used to assert the warm-pass
+ * actually covered every active query before search starts.
+ */
+export interface EmbedPhaseCacheV1 {
+	schemaVersion: typeof CACHE_SCHEMA_VERSION;
+	phase: "embed";
+	capturedAt: string;
+	runConfigFingerprint: string;
+	collectionId: string;
+	embedderModel: string;
+	embedderUrl: string;
+	embedderCacheDir: string | null;
+	warmedQueryIds: string[];
+}
+
+/**
+ * Score-phase output. This is the EvalStageResult of the quality-queries
+ * stage plus any grounding payload — the same payload that
+ * `runQualityQueriesPipeline` produces today. Stored so a re-run with
+ * `--phase=score` can be skipped when the fingerprint is unchanged.
+ */
+export interface ScorePhaseCacheV1 {
+	schemaVersion: typeof CACHE_SCHEMA_VERSION;
+	phase: "score";
+	capturedAt: string;
+	runConfigFingerprint: string;
+	collectionId: string;
+	stageResult: unknown;
+}
+
+export type PhaseCache =
+	| EmbedPhaseCacheV1
+	| SearchPhaseCacheV1
+	| ScorePhaseCacheV1;
+
+export class CacheSchemaMismatchError extends Error {
+	constructor(
+		public readonly path: string,
+		public readonly stored: number,
+		public readonly expected: number,
+	) {
+		super(
+			`phase cache schema mismatch at ${path}: stored=${stored}, expected=${expected}`,
+		);
+		this.name = "CacheSchemaMismatchError";
+	}
+}
+
+export class CacheFingerprintMismatchError extends Error {
+	constructor(
+		public readonly path: string,
+		public readonly stored: string,
+		public readonly expected: string,
+	) {
+		super(
+			`phase cache fingerprint mismatch at ${path}: stored=${stored.slice(0, 12)}, expected=${expected.slice(0, 12)}`,
+		);
+		this.name = "CacheFingerprintMismatchError";
+	}
+}
+
+/**
+ * Persist a phase cache. Creates the parent directory tree as needed.
+ * Writes pretty-printed JSON so a maintainer can diff successive caches
+ * without re-formatting.
+ */
+export function writePhaseCache(
+	pathInput: CachePathInput,
+	payload: PhaseCache,
+): string {
+	if (payload.schemaVersion !== CACHE_SCHEMA_VERSION) {
+		throw new Error(
+			`writePhaseCache refuses to write payload with schemaVersion=${payload.schemaVersion}; expected ${CACHE_SCHEMA_VERSION}`,
+		);
+	}
+	if (payload.phase !== pathInput.phase) {
+		throw new Error(
+			`writePhaseCache phase mismatch: payload.phase=${payload.phase} but pathInput.phase=${pathInput.phase}`,
+		);
+	}
+	const path = phaseCachePath(pathInput);
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, JSON.stringify(payload, null, 2));
+	return path;
+}
+
+/**
+ * Read a phase cache, asserting schema and fingerprint identity. Returns
+ * null when the file does not exist; throws on mismatch so a stale
+ * cache cannot silently feed downstream phases.
+ */
+export function readPhaseCache(pathInput: CachePathInput): PhaseCache | null {
+	const path = phaseCachePath(pathInput);
+	let raw: string;
+	try {
+		raw = readFileSync(path, "utf-8");
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+		throw err;
+	}
+	const parsed = JSON.parse(raw) as PhaseCache;
+	if (parsed.schemaVersion !== CACHE_SCHEMA_VERSION) {
+		throw new CacheSchemaMismatchError(
+			path,
+			parsed.schemaVersion as number,
+			CACHE_SCHEMA_VERSION,
+		);
+	}
+	if (parsed.phase !== pathInput.phase) {
+		throw new Error(
+			`phase cache phase mismatch at ${path}: stored=${parsed.phase}, expected=${pathInput.phase}`,
+		);
+	}
+	if (parsed.runConfigFingerprint !== pathInput.runConfigFingerprint) {
+		throw new CacheFingerprintMismatchError(
+			path,
+			parsed.runConfigFingerprint,
+			pathInput.runConfigFingerprint,
+		);
+	}
+	return parsed;
+}

--- a/scripts/lib/dogfood-pipeline.parity.test.ts
+++ b/scripts/lib/dogfood-pipeline.parity.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Parity test: a single-shot quality-queries run must produce the same
+ * stageResult as a phase-split run (embed → search → score) routed
+ * through the on-disk cache. This is the gate the 3-phase sweep
+ * refactor needs before mode-switch sequencing — if the phase split
+ * silently changes scoring, the sweep would be optimizing against a
+ * different signal than the published baseline.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EvalStageResult, Segment } from "@wtfoc/common";
+
+const evaluateQualityQueriesMock = vi.hoisted(() =>
+	vi.fn<() => Promise<EvalStageResult>>(),
+);
+
+vi.mock("@wtfoc/search", async () => {
+	const actual = await vi.importActual<typeof import("@wtfoc/search")>(
+		"@wtfoc/search",
+	);
+	return {
+		...actual,
+		evaluateQualityQueries: evaluateQualityQueriesMock,
+	};
+});
+
+const {
+	runEmbedPhase,
+	runQualityQueriesPipeline,
+	runScorePhase,
+	runSearchPhase,
+	loadSearchPhaseCache,
+} = await import("./dogfood-pipeline.js");
+
+import { CostAggregator } from "./cost-aggregator.js";
+import type { RetrievalContext } from "./dogfood-pipeline.js";
+import { SubstageTimer } from "./substage-timer.js";
+
+function buildStub(): EvalStageResult {
+	return {
+		stage: "quality-queries",
+		startedAt: "2026-05-05T00:00:00Z",
+		durationMs: 100,
+		verdict: "pass",
+		summary: "stub: 3/3 passed",
+		metrics: { passRate: 1.0, total: 3, passed: 3 },
+		checks: [],
+	};
+}
+
+function fakeContext(): RetrievalContext {
+	const fakeEmbed = vi
+		.fn<(text: string) => Promise<{ vector: Float32Array }>>()
+		.mockResolvedValue({ vector: new Float32Array([0.1, 0.2]) });
+	return {
+		embedder: { embed: fakeEmbed } as unknown as RetrievalContext["embedder"],
+		vectorIndex: {} as RetrievalContext["vectorIndex"],
+		segments: [] as Segment[],
+		overlayEdges: [],
+		documentCatalog: null,
+		preflightStatusByQueryId: new Map(),
+		retrievalOverrides: { topK: 10 },
+		corpusSourceTypes: new Set(["github"]),
+		collectionId: "demo",
+	};
+}
+
+function stripVolatile(r: EvalStageResult): EvalStageResult {
+	const { startedAt: _s, durationMs: _d, ...rest } = r;
+	const m = { ...(rest.metrics as Record<string, unknown>) };
+	delete m.timing;
+	delete m.cost;
+	return {
+		...rest,
+		startedAt: "FROZEN",
+		durationMs: 0,
+		metrics: m,
+	} as EvalStageResult;
+}
+
+describe("phase-split parity", () => {
+	let cacheBase: string;
+	beforeEach(() => {
+		cacheBase = mkdtempSync(join(tmpdir(), "wtfoc-parity-"));
+		evaluateQualityQueriesMock.mockReset();
+		evaluateQualityQueriesMock.mockResolvedValue(buildStub());
+	});
+	afterEach(() => {
+		rmSync(cacheBase, { recursive: true, force: true });
+	});
+
+	it("single-shot stageResult ≡ phase-split (embed → search → score)", async () => {
+		const ctx = fakeContext();
+		const fingerprint = "fp_parity_1";
+
+		const singleShot = await runQualityQueriesPipeline(ctx, {
+			autoRoute: false,
+			diversityEnforce: false,
+			checkParaphrases: false,
+			timer: new SubstageTimer(),
+			costs: new CostAggregator(),
+			groundingEnabled: false,
+			graderConfig: null,
+			synthesizerConfig: null,
+			collectionId: "demo",
+		});
+
+		const cachePath = {
+			cacheBase,
+			sweepId: "sw_1",
+			variantId: "v_a",
+		};
+
+		await runEmbedPhase(ctx, cachePath, {
+			runConfigFingerprint: fingerprint,
+			embedderUrl: "http://embedder",
+			embedderModel: "stub",
+			embedderCacheDir: null,
+		});
+
+		await runSearchPhase(ctx, cachePath, {
+			autoRoute: false,
+			diversityEnforce: false,
+			checkParaphrases: false,
+			timer: new SubstageTimer(),
+			costs: new CostAggregator(),
+			collectionId: "demo",
+			manifestId: "m1",
+			segmentIds: [],
+			rerankerIdentity: null,
+			documentCatalogId: null,
+			runConfigFingerprint: fingerprint,
+		});
+
+		const cached = loadSearchPhaseCache(cachePath, "demo", fingerprint);
+		expect(cached).not.toBeNull();
+		const phaseSplit = await runScorePhase(ctx, cached!, {
+			timer: new SubstageTimer(),
+			costs: new CostAggregator(),
+			groundingEnabled: false,
+			graderConfig: null,
+			synthesizerConfig: null,
+			collectionId: "demo",
+		});
+
+		expect(stripVolatile(phaseSplit)).toEqual(stripVolatile(singleShot));
+		// evaluateQualityQueries must have been called the same number of
+		// times in both paths (once for single-shot, once for the search
+		// phase) — score phase replays from cache rather than re-running.
+		expect(evaluateQualityQueriesMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("phase-split: score phase does NOT re-invoke evaluateQualityQueries", async () => {
+		const ctx = fakeContext();
+		const fingerprint = "fp_parity_2";
+		const cachePath = { cacheBase, sweepId: "sw_2", variantId: "v_b" };
+
+		await runSearchPhase(ctx, cachePath, {
+			autoRoute: false,
+			diversityEnforce: false,
+			checkParaphrases: false,
+			timer: new SubstageTimer(),
+			costs: new CostAggregator(),
+			collectionId: "demo",
+			manifestId: "m1",
+			segmentIds: [],
+			rerankerIdentity: null,
+			documentCatalogId: null,
+			runConfigFingerprint: fingerprint,
+		});
+		expect(evaluateQualityQueriesMock).toHaveBeenCalledTimes(1);
+
+		const cached = loadSearchPhaseCache(cachePath, "demo", fingerprint);
+		await runScorePhase(ctx, cached!, {
+			timer: new SubstageTimer(),
+			costs: new CostAggregator(),
+			groundingEnabled: false,
+			graderConfig: null,
+			synthesizerConfig: null,
+			collectionId: "demo",
+		});
+		expect(evaluateQualityQueriesMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/scripts/lib/dogfood-pipeline.parity.test.ts
+++ b/scripts/lib/dogfood-pipeline.parity.test.ts
@@ -52,12 +52,18 @@ function buildStub(): EvalStageResult {
 }
 
 function fakeContext(): RetrievalContext {
-	const fakeEmbed = vi
-		.fn<(text: string) => Promise<{ vector: Float32Array }>>()
-		.mockResolvedValue({ vector: new Float32Array([0.1, 0.2]) });
+	const fakeEmbedder: RetrievalContext["embedder"] = {
+		embed: vi
+			.fn<(text: string) => Promise<{ vector: Float32Array }>>()
+			.mockResolvedValue({ vector: new Float32Array([0.1, 0.2]) }),
+	};
+	const fakeVectorIndex: RetrievalContext["vectorIndex"] = {
+		add: vi.fn().mockResolvedValue(undefined),
+		search: vi.fn().mockResolvedValue([]),
+	};
 	return {
-		embedder: { embed: fakeEmbed } as unknown as RetrievalContext["embedder"],
-		vectorIndex: {} as RetrievalContext["vectorIndex"],
+		embedder: fakeEmbedder,
+		vectorIndex: fakeVectorIndex,
 		segments: [] as Segment[],
 		overlayEdges: [],
 		documentCatalog: null,
@@ -105,7 +111,6 @@ describe("phase-split parity", () => {
 			groundingEnabled: false,
 			graderConfig: null,
 			synthesizerConfig: null,
-			collectionId: "demo",
 		});
 
 		const cachePath = {
@@ -127,7 +132,6 @@ describe("phase-split parity", () => {
 			checkParaphrases: false,
 			timer: new SubstageTimer(),
 			costs: new CostAggregator(),
-			collectionId: "demo",
 			manifestId: "m1",
 			segmentIds: [],
 			rerankerIdentity: null,
@@ -137,13 +141,13 @@ describe("phase-split parity", () => {
 
 		const cached = loadSearchPhaseCache(cachePath, "demo", fingerprint);
 		expect(cached).not.toBeNull();
-		const phaseSplit = await runScorePhase(ctx, cached!, {
+		if (!cached) throw new Error("loadSearchPhaseCache returned null");
+		const phaseSplit = await runScorePhase(ctx, cached, {
 			timer: new SubstageTimer(),
 			costs: new CostAggregator(),
 			groundingEnabled: false,
 			graderConfig: null,
 			synthesizerConfig: null,
-			collectionId: "demo",
 		});
 
 		expect(stripVolatile(phaseSplit)).toEqual(stripVolatile(singleShot));
@@ -164,7 +168,6 @@ describe("phase-split parity", () => {
 			checkParaphrases: false,
 			timer: new SubstageTimer(),
 			costs: new CostAggregator(),
-			collectionId: "demo",
 			manifestId: "m1",
 			segmentIds: [],
 			rerankerIdentity: null,
@@ -174,13 +177,13 @@ describe("phase-split parity", () => {
 		expect(evaluateQualityQueriesMock).toHaveBeenCalledTimes(1);
 
 		const cached = loadSearchPhaseCache(cachePath, "demo", fingerprint);
-		await runScorePhase(ctx, cached!, {
+		if (!cached) throw new Error("loadSearchPhaseCache returned null");
+		await runScorePhase(ctx, cached, {
 			timer: new SubstageTimer(),
 			costs: new CostAggregator(),
 			groundingEnabled: false,
 			graderConfig: null,
 			synthesizerConfig: null,
-			collectionId: "demo",
 		});
 		expect(evaluateQualityQueriesMock).toHaveBeenCalledTimes(1);
 	});

--- a/scripts/lib/dogfood-pipeline.ts
+++ b/scripts/lib/dogfood-pipeline.ts
@@ -1,0 +1,306 @@
+/**
+ * Pure helpers for the dogfood quality-queries pipeline. Extracted from
+ * `scripts/dogfood.ts` so the autoresearch sweep can phase-split the
+ * pipeline into embed → search → score for single-GPU mode-switch
+ * deployments.
+ *
+ * Step 1 of the 3-phase sweep refactor — no behavior change. Today the
+ * pipeline still runs as a single shot; later steps add cache-backed
+ * `runSearch` / `scoreFromCachedSearch` boundaries.
+ */
+
+import {
+	type DocumentCatalog,
+	type Edge,
+	type Embedder,
+	type EvalStageResult,
+	type HeadManifest,
+	type Reranker,
+	type Segment,
+	type VectorIndex,
+} from "@wtfoc/common";
+import { catalogFilePath, loadAllOverlayEdges, readCatalog } from "@wtfoc/ingest";
+import {
+	CachingEmbedder,
+	evaluateQualityQueries,
+	GOLD_STANDARD_QUERIES,
+	InMemoryVectorIndex,
+	OpenAIEmbedder,
+	type PreflightStatus,
+	runPreflight,
+} from "@wtfoc/search";
+import { namespacedCacheDir } from "./cache-namespace.js";
+import { CostAggregator } from "./cost-aggregator.js";
+import {
+	GRADER_PROMPT_VERSION,
+	GRADER_SYSTEM_PROMPT,
+	SYNTHESIS_PROMPT_VERSION,
+	SYNTHESIS_SYSTEM_PROMPT,
+} from "./grounding-prompts.js";
+import { runGrounding } from "./grounding-runner.js";
+import type { LlmUsage } from "./llm-usage.js";
+import { sha256Hex } from "./run-config.js";
+import { SubstageTimer } from "./substage-timer.js";
+import { TimingVectorIndex } from "./timing-vector-index.js";
+
+export interface BuildRetrievalContextInput {
+	collectionId: string;
+	manifestDir: string;
+	manifest: HeadManifest;
+	segments: Segment[];
+	runConfigFingerprint: string;
+	embedderUrl: string;
+	embedderModel: string;
+	embedderApiKey?: string;
+	embedderCacheDir?: string;
+	retrievalOverrides: {
+		topK?: number;
+		traceMaxPerSource?: number;
+		traceMaxTotal?: number;
+		traceMinScore?: number;
+	};
+	timer: SubstageTimer;
+	embedderUsageSink: (u: LlmUsage) => void;
+}
+
+export interface RetrievalContext {
+	embedder: Embedder;
+	vectorIndex: VectorIndex;
+	segments: Segment[];
+	overlayEdges: Edge[];
+	documentCatalog: DocumentCatalog | null;
+	preflightStatusByQueryId: Map<string, PreflightStatus>;
+	retrievalOverrides: BuildRetrievalContextInput["retrievalOverrides"];
+	corpusSourceTypes: Set<string>;
+	collectionId: string;
+}
+
+/**
+ * Build the retrieval context the quality-queries stage needs. Pure
+ * setup: constructs the embedder (caching when configured), populates
+ * an in-memory vector index from segment chunks, loads overlay edges
+ * and document catalog, and runs the catalog-applicability preflight
+ * for the active corpus.
+ */
+export async function buildRetrievalContext(
+	input: BuildRetrievalContextInput,
+): Promise<RetrievalContext> {
+	const rawEmbedder = new OpenAIEmbedder({
+		apiKey: input.embedderApiKey || "no-key",
+		baseUrl: input.embedderUrl,
+		model: input.embedderModel,
+		usageSink: input.embedderUsageSink,
+	});
+	const embedder = input.embedderCacheDir
+		? new CachingEmbedder(rawEmbedder, {
+				cacheDir: namespacedCacheDir(
+					input.embedderCacheDir,
+					input.runConfigFingerprint,
+				),
+				provider: "openai-compatible",
+				modelVersion: "unknown",
+			})
+		: rawEmbedder;
+
+	const baseVectorIndex = new InMemoryVectorIndex();
+	for (const seg of input.segments) {
+		const entries = seg.chunks
+			.filter(
+				(c: { embedding?: number[] }) =>
+					c.embedding && c.embedding.length > 0,
+			)
+			.map(
+				(c: {
+					id: string;
+					storageId: string;
+					content: string;
+					sourceType: string;
+					source: string;
+					sourceUrl?: string;
+					embedding: number[];
+					metadata?: Record<string, string>;
+					signalScores?: Record<string, number>;
+				}) => ({
+					id: c.id,
+					vector: new Float32Array(c.embedding),
+					storageId: c.storageId || c.id,
+					metadata: {
+						sourceType: c.sourceType,
+						source: c.source,
+						sourceUrl: c.sourceUrl ?? "",
+						content: c.content,
+						...(c.metadata ?? {}),
+						...(c.signalScores && Object.keys(c.signalScores).length > 0
+							? { signalScores: JSON.stringify(c.signalScores) }
+							: {}),
+					},
+				}),
+			);
+		if (entries.length > 0) {
+			await baseVectorIndex.add(entries);
+		}
+	}
+	const vectorIndex = new TimingVectorIndex(baseVectorIndex, (ms) =>
+		input.timer.record("vector-retrieve", ms),
+	);
+
+	const overlayEdges = await loadAllOverlayEdges(
+		input.manifestDir,
+		input.collectionId,
+	);
+
+	const corpusSourceTypes = new Set<string>();
+	for (const segSummary of input.manifest.segments) {
+		for (const st of segSummary.sourceTypes ?? []) corpusSourceTypes.add(st);
+	}
+
+	const catPath = catalogFilePath(input.manifestDir, input.collectionId);
+	const documentCatalog = await readCatalog(catPath);
+	const preflightStatusByQueryId = new Map<string, PreflightStatus>();
+	if (documentCatalog) {
+		const localQueries = GOLD_STANDARD_QUERIES.filter((q) =>
+			q.applicableCorpora.includes(input.collectionId),
+		).map((q) => ({ ...q, applicableCorpora: [input.collectionId] }));
+		const preflight = runPreflight({
+			queries: localQueries,
+			catalogs: [{ corpusId: input.collectionId, catalog: documentCatalog }],
+		});
+		if (preflight.hardErrors.length > 0) {
+			console.warn(
+				`[dogfood] preflight hard-errors (${preflight.hardErrors.length}); skipping fixture-invalid wiring`,
+			);
+			for (const e of preflight.hardErrors) console.warn(`  - ${e}`);
+		} else {
+			for (const r of preflight.results) {
+				if (r.corpusId === input.collectionId) {
+					preflightStatusByQueryId.set(r.queryId, r.status);
+				}
+			}
+		}
+	}
+
+	return {
+		embedder,
+		vectorIndex,
+		segments: input.segments,
+		overlayEdges,
+		documentCatalog,
+		preflightStatusByQueryId,
+		retrievalOverrides: input.retrievalOverrides,
+		corpusSourceTypes,
+		collectionId: input.collectionId,
+	};
+}
+
+export interface QualityQueriesPipelineOptions {
+	reranker?: Reranker;
+	autoRoute: boolean;
+	diversityEnforce: boolean;
+	checkParaphrases: boolean;
+	timer: SubstageTimer;
+	costs: CostAggregator;
+	groundingEnabled: boolean;
+	graderConfig: { url: string; model: string; apiKey?: string } | null;
+	synthesizerConfig: { url: string; model: string; apiKey?: string } | null;
+	collectionId: string;
+}
+
+/**
+ * Run the quality-queries pipeline over a prebuilt retrieval context.
+ * Today this is a thin wrapper around `evaluateQualityQueries` plus the
+ * optional citation/grounding pass; later steps split this into
+ * `runSearch` (embed + retrieve + rerank) and `scoreFromCachedSearch`
+ * (extract + rubric scoring) so a phase planner can call them
+ * separately around a `ensureMode` swap.
+ */
+export async function runQualityQueriesPipeline(
+	ctx: RetrievalContext,
+	opts: QualityQueriesPipelineOptions,
+): Promise<EvalStageResult> {
+	const result = await evaluateQualityQueries(
+		ctx.embedder,
+		ctx.vectorIndex,
+		ctx.segments,
+		undefined,
+		ctx.overlayEdges,
+		opts.reranker,
+		opts.autoRoute,
+		{
+			collectionId: ctx.collectionId,
+			corpusSourceTypes: ctx.corpusSourceTypes,
+			perQueryHook: (id, ms) => opts.timer.record("per-query-total", ms),
+			checkParaphrases: opts.checkParaphrases,
+			...(ctx.preflightStatusByQueryId.size > 0
+				? { preflightStatusByQueryId: ctx.preflightStatusByQueryId }
+				: {}),
+			...(Object.keys(ctx.retrievalOverrides).length > 0
+				? { retrievalOverrides: ctx.retrievalOverrides }
+				: {}),
+			...(ctx.documentCatalog ? { documentCatalog: ctx.documentCatalog } : {}),
+			...(process.env.WTFOC_RECIPE_GINI_FLOOR
+				? { coverageGiniFloor: Number(process.env.WTFOC_RECIPE_GINI_FLOOR) }
+				: {}),
+			...(process.env.WTFOC_RECIPE_MIN_UNCOVERED_STRATA
+				? {
+						coverageMinUncoveredStrata: Number(
+							process.env.WTFOC_RECIPE_MIN_UNCOVERED_STRATA,
+						),
+					}
+				: {}),
+		},
+		opts.diversityEnforce,
+	);
+
+	let grounding: Awaited<ReturnType<typeof runGrounding>> | null = null;
+	if (opts.groundingEnabled && opts.graderConfig && opts.synthesizerConfig) {
+		const synthSink = (u: LlmUsage): void => {
+			if (typeof u.durationMs === "number") opts.timer.record("synthesize", u.durationMs);
+			opts.costs.record("synthesize", u);
+		};
+		const graderSink = (u: LlmUsage): void => {
+			if (typeof u.durationMs === "number") opts.timer.record("grade", u.durationMs);
+			opts.costs.record("grade", u);
+		};
+		const synthQueries = GOLD_STANDARD_QUERIES.filter(
+			(q) =>
+				q.queryType === "howto" &&
+				q.applicableCorpora.includes(opts.collectionId),
+		).map((q) => ({ id: q.id, queryText: q.query }));
+		console.error(
+			`[dogfood] grounding: ${synthQueries.length} synthesis-tier queries (grader=${opts.graderConfig.model})`,
+		);
+		grounding = await runGrounding({
+			queries: synthQueries,
+			synthesizer: opts.synthesizerConfig,
+			grader: opts.graderConfig,
+			embedder: ctx.embedder,
+			vectorIndex: ctx.vectorIndex,
+			reranker: opts.reranker,
+			topK: 10,
+			synthesizerUsageSink: synthSink,
+			graderUsageSink: graderSink,
+		});
+	}
+
+	result.metrics = {
+		...result.metrics,
+		timing: opts.timer.allStats(),
+		cost: opts.costs.allStats(),
+		...(grounding ? { grounding } : {}),
+	};
+
+	return result;
+}
+
+/**
+ * Compute prompt hashes used to namespace grounding caches. Returns an
+ * empty record when grounding is disabled so the run-config fingerprint
+ * stays stable across runs without grounding.
+ */
+export function groundingPromptHashes(enabled: boolean): Record<string, string> {
+	if (!enabled) return {};
+	return {
+		synthesis: `${SYNTHESIS_PROMPT_VERSION}:${sha256Hex(SYNTHESIS_SYSTEM_PROMPT)}`,
+		grader: `${GRADER_PROMPT_VERSION}:${sha256Hex(GRADER_SYSTEM_PROMPT)}`,
+	};
+}

--- a/scripts/lib/dogfood-pipeline.ts
+++ b/scripts/lib/dogfood-pipeline.ts
@@ -211,7 +211,6 @@ export interface QualityQueriesPipelineOptions {
 	groundingEnabled: boolean;
 	graderConfig: { url: string; model: string; apiKey?: string } | null;
 	synthesizerConfig: { url: string; model: string; apiKey?: string } | null;
-	collectionId: string;
 }
 
 /**
@@ -270,11 +269,9 @@ export async function runQualityQueriesPipeline(
 			if (typeof u.durationMs === "number") opts.timer.record("grade", u.durationMs);
 			opts.costs.record("grade", u);
 		};
-		const synthQueries = GOLD_STANDARD_QUERIES.filter(
-			(q) =>
-				q.queryType === "howto" &&
-				q.applicableCorpora.includes(opts.collectionId),
-		).map((q) => ({ id: q.id, queryText: q.query }));
+		const synthQueries = activeGoldQueries(ctx.collectionId)
+			.filter((q) => q.queryType === "howto")
+			.map((q) => ({ id: q.id, queryText: q.query }));
 		console.error(
 			`[dogfood] grounding: ${synthQueries.length} synthesis-tier queries (grader=${opts.graderConfig.model})`,
 		);
@@ -386,7 +383,6 @@ export interface SearchPhaseOptions {
 	checkParaphrases: boolean;
 	timer: SubstageTimer;
 	costs: CostAggregator;
-	collectionId: string;
 	manifestId: string;
 	segmentIds: string[];
 	rerankerIdentity: { type: string; model?: string; url?: string } | null;
@@ -478,7 +474,6 @@ export interface ScorePhaseOptions {
 	groundingEnabled: boolean;
 	graderConfig: { url: string; model: string; apiKey?: string } | null;
 	synthesizerConfig: { url: string; model: string; apiKey?: string } | null;
-	collectionId: string;
 }
 
 /**
@@ -504,7 +499,7 @@ export async function runScorePhase(
 			if (typeof u.durationMs === "number") opts.timer.record("grade", u.durationMs);
 			opts.costs.record("grade", u);
 		};
-		const synthQueries = activeGoldQueries(opts.collectionId)
+		const synthQueries = activeGoldQueries(ctx.collectionId)
 			.filter((q) => q.queryType === "howto")
 			.map((q) => ({ id: q.id, queryText: q.query }));
 		console.error(

--- a/scripts/lib/dogfood-pipeline.ts
+++ b/scripts/lib/dogfood-pipeline.ts
@@ -23,6 +23,7 @@ import { catalogFilePath, loadAllOverlayEdges, readCatalog } from "@wtfoc/ingest
 import {
 	CachingEmbedder,
 	evaluateQualityQueries,
+	type GoldQuery,
 	GOLD_STANDARD_QUERIES,
 	InMemoryVectorIndex,
 	OpenAIEmbedder,
@@ -31,6 +32,14 @@ import {
 } from "@wtfoc/search";
 import { namespacedCacheDir } from "./cache-namespace.js";
 import { CostAggregator } from "./cost-aggregator.js";
+import {
+	type CachePathInput,
+	type EmbedPhaseCacheV1,
+	type SearchPhaseCacheV1,
+	CACHE_SCHEMA_VERSION,
+	readPhaseCache,
+	writePhaseCache,
+} from "./dogfood-cache.js";
 import {
 	GRADER_PROMPT_VERSION,
 	GRADER_SYSTEM_PROMPT,
@@ -303,4 +312,242 @@ export function groundingPromptHashes(enabled: boolean): Record<string, string> 
 		synthesis: `${SYNTHESIS_PROMPT_VERSION}:${sha256Hex(SYNTHESIS_SYSTEM_PROMPT)}`,
 		grader: `${GRADER_PROMPT_VERSION}:${sha256Hex(GRADER_SYSTEM_PROMPT)}`,
 	};
+}
+
+/**
+ * Resolve the gold-standard queries that apply to a given corpus.
+ * Pure — used by every phase to enumerate the active query set.
+ */
+export function activeGoldQueries(collectionId: string): GoldQuery[] {
+	return GOLD_STANDARD_QUERIES.filter((q) =>
+		q.applicableCorpora.includes(collectionId),
+	);
+}
+
+export interface PhaseCachePathBase {
+	cacheBase: string;
+	sweepId: string;
+	variantId: string;
+}
+
+function pathFor(
+	base: PhaseCachePathBase,
+	ctx: { collectionId: string },
+	fingerprint: string,
+	phase: "embed" | "search" | "score",
+): CachePathInput {
+	return {
+		base: base.cacheBase,
+		sweepId: base.sweepId,
+		variantId: base.variantId,
+		corpus: ctx.collectionId,
+		runConfigFingerprint: fingerprint,
+		phase,
+	};
+}
+
+/**
+ * Embed phase: warm the embedder cache for every active query so the
+ * search phase can run without an embed-mode GPU. Idempotent — calling
+ * the embedder for an already-cached query is a free hash lookup. Emits
+ * an `EmbedPhaseCacheV1` manifest the next phase asserts against.
+ */
+export async function runEmbedPhase(
+	ctx: RetrievalContext,
+	cachePath: PhaseCachePathBase,
+	opts: { runConfigFingerprint: string; embedderUrl: string; embedderModel: string; embedderCacheDir: string | null },
+): Promise<EmbedPhaseCacheV1> {
+	const queries = activeGoldQueries(ctx.collectionId);
+	for (const q of queries) {
+		await ctx.embedder.embed(q.query);
+	}
+	const payload: EmbedPhaseCacheV1 = {
+		schemaVersion: CACHE_SCHEMA_VERSION,
+		phase: "embed",
+		capturedAt: new Date().toISOString(),
+		runConfigFingerprint: opts.runConfigFingerprint,
+		collectionId: ctx.collectionId,
+		embedderModel: opts.embedderModel,
+		embedderUrl: opts.embedderUrl,
+		embedderCacheDir: opts.embedderCacheDir,
+		warmedQueryIds: queries.map((q) => q.id),
+	};
+	writePhaseCache(
+		pathFor(cachePath, ctx, opts.runConfigFingerprint, "embed"),
+		payload,
+	);
+	return payload;
+}
+
+export interface SearchPhaseOptions {
+	reranker?: Reranker;
+	autoRoute: boolean;
+	diversityEnforce: boolean;
+	checkParaphrases: boolean;
+	timer: SubstageTimer;
+	costs: CostAggregator;
+	collectionId: string;
+	manifestId: string;
+	segmentIds: string[];
+	rerankerIdentity: { type: string; model?: string; url?: string } | null;
+	documentCatalogId: string | null;
+	runConfigFingerprint: string;
+}
+
+/**
+ * Search phase: run the deterministic-scoring quality-queries evaluator
+ * (no grounding) and persist the result so the score phase can replay
+ * it under a different GPU mode.
+ */
+export async function runSearchPhase(
+	ctx: RetrievalContext,
+	cachePath: PhaseCachePathBase,
+	opts: SearchPhaseOptions,
+): Promise<{ stageResult: EvalStageResult; cache: SearchPhaseCacheV1 }> {
+	const stageResult = await evaluateQualityQueries(
+		ctx.embedder,
+		ctx.vectorIndex,
+		ctx.segments,
+		undefined,
+		ctx.overlayEdges,
+		opts.reranker,
+		opts.autoRoute,
+		{
+			collectionId: ctx.collectionId,
+			corpusSourceTypes: ctx.corpusSourceTypes,
+			perQueryHook: (id, ms) => opts.timer.record("per-query-total", ms),
+			checkParaphrases: opts.checkParaphrases,
+			...(ctx.preflightStatusByQueryId.size > 0
+				? { preflightStatusByQueryId: ctx.preflightStatusByQueryId }
+				: {}),
+			...(Object.keys(ctx.retrievalOverrides).length > 0
+				? { retrievalOverrides: ctx.retrievalOverrides }
+				: {}),
+			...(ctx.documentCatalog ? { documentCatalog: ctx.documentCatalog } : {}),
+			...(process.env.WTFOC_RECIPE_GINI_FLOOR
+				? { coverageGiniFloor: Number(process.env.WTFOC_RECIPE_GINI_FLOOR) }
+				: {}),
+			...(process.env.WTFOC_RECIPE_MIN_UNCOVERED_STRATA
+				? {
+						coverageMinUncoveredStrata: Number(
+							process.env.WTFOC_RECIPE_MIN_UNCOVERED_STRATA,
+						),
+					}
+				: {}),
+		},
+		opts.diversityEnforce,
+	);
+
+	const queries = activeGoldQueries(ctx.collectionId);
+	const preflight: Record<string, PreflightStatus> = {};
+	for (const [id, status] of ctx.preflightStatusByQueryId.entries()) {
+		preflight[id] = status;
+	}
+
+	const cache: SearchPhaseCacheV1 = {
+		schemaVersion: CACHE_SCHEMA_VERSION,
+		phase: "search",
+		capturedAt: new Date().toISOString(),
+		runConfigFingerprint: opts.runConfigFingerprint,
+		collectionId: ctx.collectionId,
+		manifestId: opts.manifestId,
+		segmentIds: opts.segmentIds,
+		activeQueryIds: queries.map((q) => q.id),
+		preflight,
+		corpusSourceTypes: [...ctx.corpusSourceTypes],
+		documentCatalogId: opts.documentCatalogId,
+		retrievalOverrides: ctx.retrievalOverrides,
+		reranker: opts.rerankerIdentity,
+		diversityEnforce: opts.diversityEnforce,
+		autoRoute: opts.autoRoute,
+		stageResult,
+		searchTiming: opts.timer.allStats(),
+		searchCost: opts.costs.allStats(),
+	};
+	writePhaseCache(
+		pathFor(cachePath, ctx, opts.runConfigFingerprint, "search"),
+		cache,
+	);
+	return { stageResult, cache };
+}
+
+export interface ScorePhaseOptions {
+	reranker?: Reranker;
+	timer: SubstageTimer;
+	costs: CostAggregator;
+	groundingEnabled: boolean;
+	graderConfig: { url: string; model: string; apiKey?: string } | null;
+	synthesizerConfig: { url: string; model: string; apiKey?: string } | null;
+	collectionId: string;
+}
+
+/**
+ * Score phase: replay the cached search-phase EvalStageResult and layer
+ * the optional grounding pass on top. When grounding is disabled this
+ * phase is a deterministic projection of the search-phase output —
+ * still safe to call so the dogfood report shape stays uniform across
+ * configurations.
+ */
+export async function runScorePhase(
+	ctx: RetrievalContext,
+	searchCache: SearchPhaseCacheV1,
+	opts: ScorePhaseOptions,
+): Promise<EvalStageResult> {
+	const result = searchCache.stageResult as EvalStageResult;
+	let grounding: Awaited<ReturnType<typeof runGrounding>> | null = null;
+	if (opts.groundingEnabled && opts.graderConfig && opts.synthesizerConfig) {
+		const synthSink = (u: LlmUsage): void => {
+			if (typeof u.durationMs === "number") opts.timer.record("synthesize", u.durationMs);
+			opts.costs.record("synthesize", u);
+		};
+		const graderSink = (u: LlmUsage): void => {
+			if (typeof u.durationMs === "number") opts.timer.record("grade", u.durationMs);
+			opts.costs.record("grade", u);
+		};
+		const synthQueries = activeGoldQueries(opts.collectionId)
+			.filter((q) => q.queryType === "howto")
+			.map((q) => ({ id: q.id, queryText: q.query }));
+		console.error(
+			`[dogfood] grounding: ${synthQueries.length} synthesis-tier queries (grader=${opts.graderConfig.model})`,
+		);
+		grounding = await runGrounding({
+			queries: synthQueries,
+			synthesizer: opts.synthesizerConfig,
+			grader: opts.graderConfig,
+			embedder: ctx.embedder,
+			vectorIndex: ctx.vectorIndex,
+			reranker: opts.reranker,
+			topK: 10,
+			synthesizerUsageSink: synthSink,
+			graderUsageSink: graderSink,
+		});
+	}
+	result.metrics = {
+		...result.metrics,
+		timing: opts.timer.allStats(),
+		cost: opts.costs.allStats(),
+		...(grounding ? { grounding } : {}),
+	};
+	return result;
+}
+
+/**
+ * Read the search-phase cache for a (sweep, variant, corpus, fingerprint)
+ * tuple. Returns null when missing — callers (typically `--phase=score`
+ * standalone runs) decide whether absence is fatal.
+ */
+export function loadSearchPhaseCache(
+	cacheBase: PhaseCachePathBase,
+	collectionId: string,
+	runConfigFingerprint: string,
+): SearchPhaseCacheV1 | null {
+	const cache = readPhaseCache({
+		base: cacheBase.cacheBase,
+		sweepId: cacheBase.sweepId,
+		variantId: cacheBase.variantId,
+		corpus: collectionId,
+		runConfigFingerprint,
+		phase: "search",
+	});
+	return cache as SearchPhaseCacheV1 | null;
 }


### PR DESCRIPTION
## Summary

Refactor the autoresearch sweep into an embed → search → score plan with one GPU mode swap per phase, so a single-GPU vllm-admin deployment can serve embedder, reranker, and extractor workloads from one cluster without the deadlock the prior single-mode-swap design produced.

Prior bug: sweep flipped to `rerank-gpu` once at startup; a chat-extractor call mid-sweep then hung indefinitely against the scaled-to-zero pod (observed 13+ min 0% CPU stalls). Refusing-upfront on conflict was the wrong shape — the right shape is to switch the model used and **wait** between phases.

## What ships

- **dogfood pipeline split** (`scripts/lib/dogfood-pipeline.ts`): pure helpers (`buildRetrievalContext`, `runEmbedPhase`, `runSearchPhase`, `runScorePhase`) plus `--phase=embed|search|score|all` on `scripts/dogfood.ts`.
- **versioned phase cache** (`scripts/lib/dogfood-cache.ts`): per-`<sweep>/<variant>/<corpus>/<fingerprint>/<phase>.json` layout with schema + fingerprint guards. The score phase replays the search phase's `EvalStageResult` from cache so retrieval never re-runs under the wrong GPU mode.
- **phase planner** (`scripts/autoresearch/sweep-phase-planner.ts`): per-component URL classifier + composition guard, emits the embed → search → score plan.
- **sweep orchestration** (`scripts/autoresearch/sweep.ts`): one `ensureMode` call per phase across all variant×corpus combos, single-shot fast path retained when every phase is cloud.
- **parity test** (`scripts/lib/dogfood-pipeline.parity.test.ts`): single-shot stageResult ≡ phase-split stageResult, score phase does NOT re-invoke `evaluateQualityQueries`.

Cases handled:
- All cloud → 0 swaps (single-shot fast path)
- Mixed cloud + local → 1 swap (verified live)
- Full-local 3-mode → up to 3 swaps total (architecture in place)

## Live verification

Mixed config (cloud OpenRouter embedder + local BGE reranker), one variant × two corpora:

```
[sweep] phase plan: embed=cloud → search=rerank-gpu → score=cloud:skip
[sweep] running variant <id> on <primary> (phase=embed)
[sweep] running variant <id> on <secondary> (phase=embed)
[sweep] ensureMode → rerank-gpu (phase=search)
[sweep] mode-switch ok: chat→rerank-gpu
[sweep] running variant <id> on <primary> (phase=search)
[sweep] running variant <id> on <secondary> (phase=search)
[sweep] phase=score skip (no GPU dependency)
[sweep] post-sweep revert ok: rerank-gpu→chat
```

Search phase ran cleanly under `rerank-gpu`; no deadlock. Sweep summary written, run-log appended, post-sweep revert succeeded.

Smoke matrix (full-cloud) classified as 0-swap single-shot path — behavior unchanged from prior.

## Test plan

- [x] `pnpm vitest run` — 1905 passed, 2 skipped
- [x] `pnpm -r build` — clean
- [x] `pnpm lint:fix` — no fixes applied
- [x] Live mixed-config sweep — 1 swap, no deadlock, summary written
- [x] Live full-cloud (smoke) sweep — 0 swaps, single-shot fast path
- [ ] Live full-local 3-mode sweep (embed-gpu + rerank-gpu + chat) — pending; depends on operator running with that endpoint shape

## Implementation order (per peer review)

1. Extract pure helpers (no behavior change) — parity test substrate
2. Versioned phase cache schema
3. `--phase` CLI + parity test
4. Phase planner
5. Wire orchestration into sweep
6. Live verify

Each commit on this branch corresponds to one step.